### PR TITLE
Add Stream generate image functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from flux_1.flux import Flux1
 from flux_1.post_processing.image_util import ImageUtil
 
 
-def main():
+def setup_arg_parser():
     parser = argparse.ArgumentParser(description='Generate an image based on a prompt.')
     parser.add_argument('--prompt', type=str, required=True, help='The textual description of the image to generate.')
     parser.add_argument('--output', type=str, default="image.png", help='The filename for the output image. Default is "image.png".')
@@ -23,7 +23,10 @@ def main():
     parser.add_argument('--guidance', type=float, default=3.5, help='Guidance Scale (Default is 3.5)')
     parser.add_argument('--quantize',  "-q", type=int, choices=[4, 8], default=None, help='Quantize the model (4 or 8, Default is None)')
     parser.add_argument('--path', type=str, default=None, help='Local path for loading a model from disk')
+    return parser
 
+def main():
+    parser = setup_arg_parser()
     args = parser.parse_args()
 
     if args.path and args.model is None:


### PR DESCRIPTION
Add the `stream_generate_image` function to expose the results of each step of the inference for follow-up GUI interaction. 

The usage would look something like this:

```python
def stream_demo(args):
    seed = int(time.time()) if args.seed is None else args.seed

    flux = Flux1.from_alias(args.model)

    stream = flux.stream_generate_image(
        seed=seed,
        prompt=args.prompt,
        report_step=5,
        config=Config(
            num_inference_steps=args.steps,
            height=args.height,
            width=args.width,
            guidance=args.guidance,
        ),
    )

    step_count = 0

    for image in stream:
        step_count += 1

        intermediate_output_path = f"{args.output}_report_step_{step_count}.png"
        ImageUtil.save_image(image, "build/stream/" + intermediate_output_path)

    print(f"Generation complete. Total steps: {step_count}")

stream_demo()
```