### PR TITLE
ruff patch for one-time linter/formatter catchup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Run the powerful [FLUX](https://blackforestlabs.ai/#get-flux) models from [Black
 
 ### Philosophy
 
-MFLUX is a line-by-line port of the FLUX implementation in the [Huggingface Diffusers](https://github.com/huggingface/diffusers) library to [Apple MLX](https://github.com/ml-explore/mlx). 
+MFLUX is a line-by-line port of the FLUX implementation in the [Huggingface Diffusers](https://github.com/huggingface/diffusers) library to [Apple MLX](https://github.com/ml-explore/mlx).
 MFLUX is purposefully kept minimal and explicit - Network architectures are hardcoded and no config files are used
-except for the tokenizers. The aim is to have a tiny codebase with the single purpose of expressing these models 
+except for the tokenizers. The aim is to have a tiny codebase with the single purpose of expressing these models
 (thereby avoiding too many abstractions). While MFLUX priorities readability over generality and performance, [it can still be quite fast](#image-generation-speed-updated), [and even faster quantized](#quantization).
 
-All models are implemented from scratch in MLX and only the tokenizers are used via the 
-[Huggingface Transformers](https://github.com/huggingface/transformers) library. Other than that, there are only minimal dependencies 
+All models are implemented from scratch in MLX and only the tokenizers are used via the
+[Huggingface Transformers](https://github.com/huggingface/transformers) library. Other than that, there are only minimal dependencies
 like [Numpy](https://numpy.org) and [Pillow](https://pypi.org/project/pillow/) for simple image post-processing.
 
 ### Models
@@ -40,12 +40,18 @@ This creates and activates a virtual environment in the `mflux` folder. After th
  ```
 2. Navigate to the project and set up a virtual environment:
  ```
- cd mflux && python3 -m venv .venv && source .venv/bin/activate
+ cd mflux
+ python3 -m venv .venv  # alternative: `uv venv`
+ source .venv/bin/activate
  ```
-3. Install the required dependencies:
+3. Install the required dependencies in [development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) as defined in `pyproject.toml`:
  ```
- pip install -r requirements.txt
+ pip install -e .
  ```
+4. Follow format and lint checks prior to submitting Pull Requests. Install the `ruff` tool as a common resource somewhere else in your system external to this project.
+  - [`uv tool install ruff`](https://github.com/astral-sh/uv) OR [`pipx install ruff`](https://github.com/pypa/pipx).
+  - [`ruff check` and `ruff check --fix`](https://github.com/astral-sh/ruff?tab=readme-ov-file#usage) any linter warnings generated from your PR diff.
+  - [`ruff format`](https://github.com/astral-sh/ruff?tab=readme-ov-file#usage)) any added or modified files in your PR diff.
 </details>
 
 ### Generating an image
@@ -64,7 +70,7 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 
 ⚠️ *If the specific model is not already downloaded on your machine, it will start the download process and fetch the model weights (~34GB in size for the Schnell or Dev model respectively). See the [quantization](#quantization) section for running compressed versions of the model.* ⚠️
 
-*By default, model files are downloaded to the `.cache` folder within your home directory. For example, in my setup, the path looks like this:* 
+*By default, model files are downloaded to the `.cache` folder within your home directory. For example, in my setup, the path looks like this:*
 
 ```
 /Users/filipstrand/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev
@@ -72,9 +78,9 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 
 *To change this default behavior, you can do so by modifying the `HF_HOME` environment variable. For more details on how to adjust this setting, please refer to the [Hugging Face documentation](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables)*.
 
-🔒 [FLUX.1-dev currently requires granted access to its Huggingface repo. For troubleshooting, see the issue tracker](https://github.com/filipstrand/mflux/issues/14) 🔒 
+🔒 [FLUX.1-dev currently requires granted access to its Huggingface repo. For troubleshooting, see the issue tracker](https://github.com/filipstrand/mflux/issues/14) 🔒
 
-#### Full list of Command-Line Arguments 
+#### Full list of Command-Line Arguments
 
 - **`--prompt`** (required, `str`): Text description of the image to generate.
 
@@ -99,7 +105,7 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 - **`--lora-paths`** (optional, `[str]`, default: `None`): The paths to the [LoRA](#LoRA) weights.
 
 - **`--lora-scales`** (optional, `[float]`, default: `None`): The scale for each respective [LoRA](#LoRA) (will default to `1.0` if not specified and only one LoRA weight is loaded.)
- 
+
 - **`--metadata`** (optional): Exports a `.json` file containing the metadata for the image with the same name. (Even without this flag, the image metadata is saved and can be viewed using `exiftool image.png`)
 
 Or, with the correct python environment active, create and run a separate script like the following:
@@ -112,7 +118,7 @@ from mflux.config.config import Config
 flux = Flux1.from_alias(
    alias="schnell",  # "schnell" or "dev"
    quantize=8,       # 4 or 8
-)  
+)
 
 # Generate an image
 image = flux.generate_image(
@@ -132,7 +138,7 @@ For more options on how to configure MFLUX, please see [generate.py](src/mflux/g
 
 ### Image generation speed (updated)
 
-These numbers are based on the non-quantized `schnell` model, with the configuration provided in the code snippet below. 
+These numbers are based on the non-quantized `schnell` model, with the configuration provided in the code snippet below.
 To time your machine, run the following:
 ```
 time mflux-generate \
@@ -156,20 +162,20 @@ time mflux-generate \
 | 2021 M1 Pro (32GB) | @filipstrand                                                                                                                | ~160s         |                           |
 | 2023 M2 Max (32GB) | @filipstrand                                                                                                                | ~70s          |                           |
 
-*Note that these numbers includes starting the application from scratch, which means doing model i/o, setting/quantizing weights etc. 
+*Note that these numbers includes starting the application from scratch, which means doing model i/o, setting/quantizing weights etc.
 If we assume that the model is already loaded, you can inspect the image metadata using `exiftool image.png` and see the total duration of the denoising loop (excluding text embedding).*
 
-### Equivalent to Diffusers implementation 
+### Equivalent to Diffusers implementation
 
-There is only a single source of randomness when generating an image: The initial latent array. 
-In this implementation, this initial latent is fully deterministically controlled by the input `seed` parameter. 
+There is only a single source of randomness when generating an image: The initial latent array.
+In this implementation, this initial latent is fully deterministically controlled by the input `seed` parameter.
 However, if we were to import a fixed instance of this latent array saved from the Diffusers implementation, then MFLUX will produce an identical image to the Diffusers implementation (assuming a fixed prompt and using the default parameter settings in the Diffusers setup).
 
 
-The images below illustrate this equivalence. 
-In all cases the Schnell model was run for 2 time steps. 
-The Diffusers implementation ran in CPU mode. 
-The precision for MFLUX can be set in the [Config](src/mflux/config/config.py) class. 
+The images below illustrate this equivalence.
+In all cases the Schnell model was run for 2 time steps.
+The Diffusers implementation ran in CPU mode.
+The precision for MFLUX can be set in the [Config](src/mflux/config/config.py) class.
 There is typically a noticeable but very small difference in the final image when switching between 16bit and 32bit precision.
 
 ---
@@ -208,10 +214,10 @@ Luxury food photograph of an italian Linguine pasta alle vongole dish with lots 
 
 ---
 
-### Quantization 
+### Quantization
 
 MFLUX supports running FLUX in 4-bit or 8-bit quantized mode. Running a quantized version can greatly speed up the
-generation process and reduce the memory consumption by several gigabytes. [Quantized models also take up less disk space](#size-comparisons-for-quantized-models). 
+generation process and reduce the memory consumption by several gigabytes. [Quantized models also take up less disk space](#size-comparisons-for-quantized-models).
 
 ```
 mflux-generate \
@@ -221,7 +227,7 @@ mflux-generate \
     --quantize 8 \
     --height 1920 \
     --width 1024 \
-    --prompt "Tranquil pond in a bamboo forest at dawn, the sun is barely starting to peak over the horizon, panda practices Tai Chi near the edge of the pond, atmospheric perspective through the mist of morning dew, sunbeams, its movements are graceful and fluid — creating a sense of harmony and balance, the pond’s calm waters reflecting the scene, inviting a sense of meditation and connection with nature, style of Howard Terpning and Jessica Rossier" 
+    --prompt "Tranquil pond in a bamboo forest at dawn, the sun is barely starting to peak over the horizon, panda practices Tai Chi near the edge of the pond, atmospheric perspective through the mist of morning dew, sunbeams, its movements are graceful and fluid — creating a sense of harmony and balance, the pond’s calm waters reflecting the scene, inviting a sense of meditation and connection with nature, style of Howard Terpning and Jessica Rossier"
 ```
 ![image](src/mflux/assets/comparison6.jpg)
 
@@ -232,7 +238,7 @@ By selecting the `--quantize` or `-q` flag to be `4`, `8`, or removing it entire
 Image generation times in this example are based on a 2021 M1 Pro (32GB) machine. Even though the images are almost identical, there is a ~2x speedup by
 running the 8-bit quantized version on this particular machine. Unlike the non-quantized version, for the 8-bit version the swap memory usage is drastically reduced and GPU utilization is close to 100% during the whole generation. Results here can vary across different machines.
 
-#### Size comparisons for quantized models 
+#### Size comparisons for quantized models
 
 The model sizes for both `schnell` and `dev` at various quantization levels are as follows:
 
@@ -257,7 +263,7 @@ mflux-save \
 
 #### Loading and running a quantized version from disk
 
-To generate a new image from the quantized model, simply provide a `--path` to where it was saved: 
+To generate a new image from the quantized model, simply provide a `--path` to where it was saved:
 
 ```
 mflux-generate \
@@ -267,21 +273,21 @@ mflux-generate \
     --seed 2 \
     --height 1920 \
     --width 1024 \
-    --prompt "Tranquil pond in a bamboo forest at dawn, the sun is barely starting to peak over the horizon, panda practices Tai Chi near the edge of the pond, atmospheric perspective through the mist of morning dew, sunbeams, its movements are graceful and fluid — creating a sense of harmony and balance, the pond’s calm waters reflecting the scene, inviting a sense of meditation and connection with nature, style of Howard Terpning and Jessica Rossier" 
+    --prompt "Tranquil pond in a bamboo forest at dawn, the sun is barely starting to peak over the horizon, panda practices Tai Chi near the edge of the pond, atmospheric perspective through the mist of morning dew, sunbeams, its movements are graceful and fluid — creating a sense of harmony and balance, the pond’s calm waters reflecting the scene, inviting a sense of meditation and connection with nature, style of Howard Terpning and Jessica Rossier"
 ```
 
 *Note: When loading a quantized model from disk, there is no need to pass in `-q` flag, since we can infer this from the weight metadata.*
 
-*Also Note: Once we have a local model (quantized [or not](#running-a-non-quantized-model-directly-from-disk)) specified via the `--path` argument, the huggingface cache models are not required to launch the model. 
-In other words, you can reclaim the 34GB diskspace (per model) by deleting the full 16-bit model from the [Huggingface cache](#generating-an-image) if you choose.* 
+*Also Note: Once we have a local model (quantized [or not](#running-a-non-quantized-model-directly-from-disk)) specified via the `--path` argument, the huggingface cache models are not required to launch the model.
+In other words, you can reclaim the 34GB diskspace (per model) by deleting the full 16-bit model from the [Huggingface cache](#generating-an-image) if you choose.*
 
-*If you don't want to download the full models and quantize them yourself, the 4-bit weights are available here for a direct download:* 
+*If you don't want to download the full models and quantize them yourself, the 4-bit weights are available here for a direct download:*
 - [madroid/flux.1-schnell-mflux-4bit](https://huggingface.co/madroid/flux.1-schnell-mflux-4bit)
 - [madroid/flux.1-dev-mflux-4bit](https://huggingface.co/madroid/flux.1-dev-mflux-4bit)
 
 ### Running a non-quantized model directly from disk
 
-MFLUX also supports running a non-quantized model directly from a custom location.  
+MFLUX also supports running a non-quantized model directly from a custom location.
 In the example below, the model is placed in `/Users/filipstrand/Desktop/schnell`:
 
 ```
@@ -290,10 +296,10 @@ mflux-generate \
     --model schnell \
     --steps 2 \
     --seed 2 \
-    --prompt "Luxury food photograph" 
+    --prompt "Luxury food photograph"
 ```
 
-Note that the `--model` flag must be set when loading a model from disk. 
+Note that the `--model` flag must be set when loading a model from disk.
 
 Also note that unlike when using the typical `alias` way of initializing the model (which internally handles that the required resources are downloaded),
 when loading a model directly from disk, we require the downloaded models to look like the following:
@@ -324,14 +330,14 @@ when loading a model directly from disk, we require the downloaded models to loo
 ```
 This mirrors how the resources are placed in the [HuggingFace Repo](https://huggingface.co/black-forest-labs/FLUX.1-schnell/tree/main) for FLUX.1.
 *Huggingface weights, unlike quantized ones exported directly from this project, have to be
-processed a bit differently, which is why we require this structure above.* 
+processed a bit differently, which is why we require this structure above.*
 
 
 ### LoRA
 
 MFLUX support loading trained [LoRA](https://huggingface.co/docs/diffusers/en/training/lora) adapters (actual training support is coming).
 
-The following example [The_Hound](https://huggingface.co/TheLastBen/The_Hound) LoRA from [@TheLastBen](https://github.com/TheLastBen): 
+The following example [The_Hound](https://huggingface.co/TheLastBen/The_Hound) LoRA from [@TheLastBen](https://github.com/TheLastBen):
 
 ```
 mflux-generate --prompt "sandor clegane" --model dev --steps 20 --seed 43 -q 8 --lora-paths "sandor_clegane_single_layer.safetensors"
@@ -367,12 +373,12 @@ mflux-generate \
 ```
 ![image](src/mflux/assets/lora3.jpg)
 
-Just to see the difference, this image displays the four cases: One of having both adapters fully active, partially active and no LoRA at all. 
-The example above also show the usage of `--lora-scales` flag. 
+Just to see the difference, this image displays the four cases: One of having both adapters fully active, partially active and no LoRA at all.
+The example above also show the usage of `--lora-scales` flag.
 
 #### Supported LoRA formats (updated)
 
-Since different fine-tuning services can use different implementations of FLUX, the corresponding 
+Since different fine-tuning services can use different implementations of FLUX, the corresponding
 LoRA weights trained on these services can be different from one another. The aim of MFLUX is to support the most common ones.
 The following table show the current supported formats:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
     "Operating System :: MacOS",
 ]
 dependencies = [
+    "huggingface-hub>=0.24.5",
     "mlx>=0.16.0",
-    "numpy>=2.0.0",
+    "numpy>=2.0.1",
+    "piexif>=1.1.3",
     "pillow>=10.4.0",
-    "transformers>=4.44.0",
+    "safetensors>=0.4.4",
     "sentencepiece>=0.2.0",
     "torch>=2.3.1",
     "tqdm>=4.66.5",
-    "huggingface-hub>=0.24.5",
-    "safetensors>=0.4.4",
-    "piexif>=1.1.3",
+    "transformers>=4.44.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-mlx>=0.16.0
-numpy>=2.0.1
-pillow>=10.4.0
-transformers>=4.44.0
-sentencepiece>=0.2.0
-torch>=2.3.1
-tqdm>=4.66.5
-huggingface-hub>=0.24.5
-safetensors>=0.4.4
-piexif>=1.1.3
+# direct habitual `pip install -r requirements.txt`
+# users to `pyproject.toml` defined req list
+-e .

--- a/src/mflux/config/config.py
+++ b/src/mflux/config/config.py
@@ -9,11 +9,11 @@ class Config:
     precision: mx.Dtype = mx.bfloat16
 
     def __init__(
-            self,
-            num_inference_steps: int = 4,
-            width: int = 1024,
-            height: int = 1024,
-            guidance: float = 4.0,
+        self,
+        num_inference_steps: int = 4,
+        width: int = 1024,
+        height: int = 1024,
+        guidance: float = 4.0,
     ):
         if width % 16 != 0 or height % 16 != 0:
             log.warning("Width and height should be multiples of 16. Rounding down.")

--- a/src/mflux/config/model_config.py
+++ b/src/mflux/config/model_config.py
@@ -6,11 +6,11 @@ class ModelConfig(Enum):
     FLUX1_SCHNELL = ("black-forest-labs/FLUX.1-schnell", "schnell", 1000, 256)
 
     def __init__(
-            self,
-            model_name: str,
-            alias: str,
-            num_train_steps: int,
-            max_sequence_length: int,
+        self,
+        model_name: str,
+        alias: str,
+        num_train_steps: int,
+        max_sequence_length: int,
     ):
         self.alias = alias
         self.model_name = model_name

--- a/src/mflux/config/runtime_config.py
+++ b/src/mflux/config/runtime_config.py
@@ -6,7 +6,6 @@ from mflux.config.model_config import ModelConfig
 
 
 class RuntimeConfig:
-
     def __init__(self, config: Config, model_config: ModelConfig):
         self.config = config
         self.model_config = model_config

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mflux.config.model_config import ModelConfig
 from mflux.config.config import Config
@@ -11,20 +11,74 @@ from mflux.flux.flux import Flux1
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate an image based on a prompt.')
-    parser.add_argument('--prompt', type=str, required=True, help='The textual description of the image to generate.')
-    parser.add_argument('--output', type=str, default="image.png", help='The filename for the output image. Default is "image.png".')
-    parser.add_argument('--model', "-m", type=str, required=True, choices=["dev", "schnell"], help='The model to use ("schnell" or "dev").')
-    parser.add_argument('--seed', type=int, default=None, help='Entropy Seed (Default is time-based random-seed)')
-    parser.add_argument('--height', type=int, default=1024, help='Image height (Default is 1024)')
-    parser.add_argument('--width', type=int, default=1024, help='Image width (Default is 1024)')
-    parser.add_argument('--steps', type=int, default=4, help='Inference Steps')
-    parser.add_argument('--guidance', type=float, default=3.5, help='Guidance Scale (Default is 3.5)')
-    parser.add_argument('--quantize',  "-q", type=int, choices=[4, 8], default=None, help='Quantize the model (4 or 8, Default is None)')
-    parser.add_argument('--path', type=str, default=None, help='Local path for loading a model from disk')
-    parser.add_argument('--lora-paths', type=str, nargs='*', default=None, help='Local safetensors for applying LORA from disk')
-    parser.add_argument('--lora-scales', type=float, nargs='*', default=None, help='Scaling factor to adjust the impact of LoRA weights on the model. A value of 1.0 applies the LoRA weights as they are.')
-    parser.add_argument('--metadata', action='store_true', help='Export image metadata as a JSON file.')
+    parser = argparse.ArgumentParser(description="Generate an image based on a prompt.")
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        required=True,
+        help="The textual description of the image to generate.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="image.png",
+        help='The filename for the output image. Default is "image.png".',
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        type=str,
+        required=True,
+        choices=["dev", "schnell"],
+        help='The model to use ("schnell" or "dev").',
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Entropy Seed (Default is time-based random-seed)",
+    )
+    parser.add_argument(
+        "--height", type=int, default=1024, help="Image height (Default is 1024)"
+    )
+    parser.add_argument(
+        "--width", type=int, default=1024, help="Image width (Default is 1024)"
+    )
+    parser.add_argument("--steps", type=int, default=4, help="Inference Steps")
+    parser.add_argument(
+        "--guidance", type=float, default=3.5, help="Guidance Scale (Default is 3.5)"
+    )
+    parser.add_argument(
+        "--quantize",
+        "-q",
+        type=int,
+        choices=[4, 8],
+        default=None,
+        help="Quantize the model (4 or 8, Default is None)",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        default=None,
+        help="Local path for loading a model from disk",
+    )
+    parser.add_argument(
+        "--lora-paths",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Local safetensors for applying LORA from disk",
+    )
+    parser.add_argument(
+        "--lora-scales",
+        type=float,
+        nargs="*",
+        default=None,
+        help="Scaling factor to adjust the impact of LoRA weights on the model. A value of 1.0 applies the LoRA weights as they are.",
+    )
+    parser.add_argument(
+        "--metadata", action="store_true", help="Export image metadata as a JSON file."
+    )
 
     args = parser.parse_args()
 
@@ -37,7 +91,7 @@ def main():
         quantize=args.quantize,
         local_path=args.path,
         lora_paths=args.lora_paths,
-        lora_scales=args.lora_scales
+        lora_scales=args.lora_scales,
     )
 
     # Generate an image
@@ -49,12 +103,12 @@ def main():
             height=args.height,
             width=args.width,
             guidance=args.guidance,
-        )
+        ),
     )
 
     # Save the image
     image.save(path=args.output, export_json_metadata=args.metadata)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/mflux/models/text_encoder/clip_encoder/clip_embeddings.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_embeddings.py
@@ -5,10 +5,11 @@ from mflux.tokenizer.clip_tokenizer import TokenizerCLIP
 
 
 class CLIPEmbeddings(nn.Module):
-
     def __init__(self, dims: int):
         super().__init__()
-        self.position_embedding = nn.Embedding(num_embeddings=TokenizerCLIP.MAX_TOKEN_LENGTH, dims=dims)
+        self.position_embedding = nn.Embedding(
+            num_embeddings=TokenizerCLIP.MAX_TOKEN_LENGTH, dims=dims
+        )
         self.token_embedding = nn.Embedding(num_embeddings=49408, dims=dims)
 
     def forward(self, tokens: mx.array) -> mx.array:

--- a/src/mflux/models/text_encoder/clip_encoder/clip_encoder.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_encoder.py
@@ -5,7 +5,6 @@ from mflux.models.text_encoder.clip_encoder.clip_text_model import CLIPTextModel
 
 
 class CLIPEncoder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.text_model = CLIPTextModel(dims=768, num_encoder_layers=12)

--- a/src/mflux/models/text_encoder/clip_encoder/clip_encoder_layer.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_encoder_layer.py
@@ -6,7 +6,6 @@ from mflux.models.text_encoder.clip_encoder.clip_sdpa_attention import CLIPSdpaA
 
 
 class CLIPEncoderLayer(nn.Module):
-
     def __init__(self, layer: int):
         super().__init__()
         self.self_attn = CLIPSdpaAttention()
@@ -14,7 +13,9 @@ class CLIPEncoderLayer(nn.Module):
         self.mlp = CLIPMLP()
         self.layer_norm2 = nn.LayerNorm(dims=768)
 
-    def forward(self, hidden_states: mx.array, causal_attention_mask: mx.array) -> mx.array:
+    def forward(
+        self, hidden_states: mx.array, causal_attention_mask: mx.array
+    ) -> mx.array:
         residual = hidden_states
         hidden_states = self.layer_norm1(hidden_states)
         hidden_states = self.self_attn.forward(hidden_states, causal_attention_mask)

--- a/src/mflux/models/text_encoder/clip_encoder/clip_mlp.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_mlp.py
@@ -3,7 +3,6 @@ from mlx import nn
 
 
 class CLIPMLP(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.fc1 = nn.Linear(input_dims=768, output_dims=3072)

--- a/src/mflux/models/text_encoder/clip_encoder/clip_sdpa_attention.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_sdpa_attention.py
@@ -14,18 +14,30 @@ class CLIPSdpaAttention(nn.Module):
         self.v_proj = nn.Linear(input_dims=768, output_dims=768)
         self.out_proj = nn.Linear(input_dims=768, output_dims=768)
 
-    def forward(self, hidden_states: mx.array, causal_attention_mask: mx.array) -> mx.array:
+    def forward(
+        self, hidden_states: mx.array, causal_attention_mask: mx.array
+    ) -> mx.array:
         query = self.q_proj(hidden_states)
         key = self.k_proj(hidden_states)
         value = self.v_proj(hidden_states)
 
-        query = CLIPSdpaAttention.reshape_and_transpose(query, self.batch_size, self.num_heads, self.head_dimension)
-        key = CLIPSdpaAttention.reshape_and_transpose(key, self.batch_size, self.num_heads, self.head_dimension)
-        value = CLIPSdpaAttention.reshape_and_transpose(value, self.batch_size, self.num_heads, self.head_dimension)
+        query = CLIPSdpaAttention.reshape_and_transpose(
+            query, self.batch_size, self.num_heads, self.head_dimension
+        )
+        key = CLIPSdpaAttention.reshape_and_transpose(
+            key, self.batch_size, self.num_heads, self.head_dimension
+        )
+        value = CLIPSdpaAttention.reshape_and_transpose(
+            value, self.batch_size, self.num_heads, self.head_dimension
+        )
 
-        hidden_states = CLIPSdpaAttention.masked_attention(query, key, value, causal_attention_mask)
+        hidden_states = CLIPSdpaAttention.masked_attention(
+            query, key, value, causal_attention_mask
+        )
         hidden_states = mx.transpose(hidden_states, (0, 2, 1, 3))
-        hidden_states = mx.reshape(hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension))
+        hidden_states = mx.reshape(
+            hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension)
+        )
 
         hidden_states = self.out_proj(hidden_states)
         return hidden_states
@@ -36,9 +48,11 @@ class CLIPSdpaAttention(nn.Module):
         scores = (query * scale) @ key.transpose(0, 1, 3, 2)
         scores = scores + mask
         attn = mx.softmax(scores, axis=-1)
-        hidden_states = (attn @ value)
+        hidden_states = attn @ value
         return hidden_states
 
     @staticmethod
     def reshape_and_transpose(x, batch_size, num_heads, head_dim):
-        return mx.transpose(mx.reshape(x, (batch_size, -1, num_heads, head_dim)), (0, 2, 1, 3))
+        return mx.transpose(
+            mx.reshape(x, (batch_size, -1, num_heads, head_dim)), (0, 2, 1, 3)
+        )

--- a/src/mflux/models/text_encoder/clip_encoder/clip_text_model.py
+++ b/src/mflux/models/text_encoder/clip_encoder/clip_text_model.py
@@ -6,7 +6,6 @@ from mflux.models.text_encoder.clip_encoder.encoder_clip import EncoderCLIP
 
 
 class CLIPTextModel(nn.Module):
-
     def __init__(self, dims: int, num_encoder_layers: int):
         super().__init__()
         self.encoder = EncoderCLIP(num_encoder_layers)
@@ -15,7 +14,9 @@ class CLIPTextModel(nn.Module):
 
     def forward(self, tokens: mx.array) -> (mx.array, mx.array):
         hidden_states = self.embeddings.forward(tokens)
-        causal_attention_mask = CLIPTextModel.create_causal_attention_mask(hidden_states.shape)
+        causal_attention_mask = CLIPTextModel.create_causal_attention_mask(
+            hidden_states.shape
+        )
         encoder_outputs = self.encoder.forward(hidden_states, causal_attention_mask)
         last_hidden_state = self.final_layer_norm(encoder_outputs)
         pooled_output = last_hidden_state[0, mx.argmax(tokens, axis=-1)]

--- a/src/mflux/models/text_encoder/clip_encoder/encoder_clip.py
+++ b/src/mflux/models/text_encoder/clip_encoder/encoder_clip.py
@@ -5,7 +5,6 @@ from mflux.models.text_encoder.clip_encoder.clip_encoder_layer import CLIPEncode
 
 
 class EncoderCLIP(nn.Module):
-
     def __init__(self, num_encoder_layers: int):
         super().__init__()
         self.layers = [CLIPEncoderLayer(i) for i in range(num_encoder_layers)]
@@ -13,8 +12,5 @@ class EncoderCLIP(nn.Module):
     def forward(self, tokens: mx.array, causal_attention_mask: mx.array) -> mx.array:
         hidden_states = tokens
         for encoder_layer in self.layers:
-            hidden_states = encoder_layer.forward(
-                hidden_states,
-                causal_attention_mask
-            )
+            hidden_states = encoder_layer.forward(hidden_states, causal_attention_mask)
         return hidden_states

--- a/src/mflux/models/text_encoder/t5_encoder/t5_attention.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_attention.py
@@ -6,7 +6,6 @@ from mflux.models.text_encoder.t5_encoder.t5_self_attention import T5SelfAttenti
 
 
 class T5Attention(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.SelfAttention = T5SelfAttention()

--- a/src/mflux/models/text_encoder/t5_encoder/t5_block.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_block.py
@@ -6,7 +6,6 @@ from mflux.models.text_encoder.t5_encoder.t5_feed_forward import T5FeedForward
 
 
 class T5Block(nn.Module):
-
     def __init__(self, layer: int):
         super().__init__()
         self.attention = T5Attention()

--- a/src/mflux/models/text_encoder/t5_encoder/t5_dense_relu_dense.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_dense_relu_dense.py
@@ -5,7 +5,6 @@ import mlx.core as mx
 
 
 class T5DenseReluDense(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.wi_0 = nn.Linear(4096, 10240, bias=False)
@@ -21,4 +20,14 @@ class T5DenseReluDense(nn.Module):
 
     @staticmethod
     def new_gelu(input_array: mx.array) -> mx.array:
-        return 0.5 * input_array * (1.0 + mx.tanh(math.sqrt(2.0 / math.pi) * (input_array + 0.044715 * mx.power(input_array, 3.0))))
+        return (
+            0.5
+            * input_array
+            * (
+                1.0
+                + mx.tanh(
+                    math.sqrt(2.0 / math.pi)
+                    * (input_array + 0.044715 * mx.power(input_array, 3.0))
+                )
+            )
+        )

--- a/src/mflux/models/text_encoder/t5_encoder/t5_encoder.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_encoder.py
@@ -6,7 +6,6 @@ from mflux.models.text_encoder.t5_encoder.t5_layer_norm import T5LayerNorm
 
 
 class T5Encoder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.shared = nn.Embedding(num_embeddings=32128, dims=4096)

--- a/src/mflux/models/text_encoder/t5_encoder/t5_feed_forward.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_feed_forward.py
@@ -1,4 +1,3 @@
-import math
 
 from mlx import nn
 import mlx.core as mx

--- a/src/mflux/models/text_encoder/t5_encoder/t5_feed_forward.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_feed_forward.py
@@ -8,7 +8,6 @@ from mflux.models.text_encoder.t5_encoder.t5_layer_norm import T5LayerNorm
 
 
 class T5FeedForward(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.layer_norm = T5LayerNorm()

--- a/src/mflux/models/text_encoder/t5_encoder/t5_layer_norm.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_layer_norm.py
@@ -3,13 +3,14 @@ from mlx import nn
 
 
 class T5LayerNorm(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.weight = mx.ones((4096,))
         self.variance_epsilon = 1e-06
 
     def forward(self, hidden_states: mx.array) -> mx.array:
-        variance = mx.mean(mx.power(hidden_states.astype(mx.float32), 2), axis=-1, keepdims=True)
+        variance = mx.mean(
+            mx.power(hidden_states.astype(mx.float32), 2), axis=-1, keepdims=True
+        )
         hidden_states = hidden_states * mx.rsqrt(variance + self.variance_epsilon)
         return self.weight * hidden_states

--- a/src/mflux/models/text_encoder/t5_encoder/t5_self_attention.py
+++ b/src/mflux/models/text_encoder/t5_encoder/t5_self_attention.py
@@ -5,7 +5,6 @@ from mlx import nn
 
 
 class T5SelfAttention(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.q = nn.Linear(4096, 4096, bias=False)
@@ -39,14 +38,18 @@ class T5SelfAttention(nn.Module):
         context_position = mx.arange(start=0, stop=seq_length, step=1)[:, None]
         memory_position = mx.arange(start=0, stop=seq_length, step=1)[None, :]
         relative_position = memory_position - context_position
-        relative_position_bucket = T5SelfAttention._relative_position_bucket(relative_position)
+        relative_position_bucket = T5SelfAttention._relative_position_bucket(
+            relative_position
+        )
         values = self.relative_attention_bias(relative_position_bucket)
         values = mx.transpose(values, (2, 0, 1))
         values = mx.expand_dims(values, 0)
         return values
 
     @staticmethod
-    def _relative_position_bucket(relative_position, bidirectional=True, num_buckets=32, max_distance=128):
+    def _relative_position_bucket(
+        relative_position, bidirectional=True, num_buckets=32, max_distance=128
+    ):
         relative_buckets = mx.zeros_like(relative_position)
         num_buckets //= 2
         relative_buckets += mx.where(relative_position > 0, num_buckets, 0)
@@ -64,8 +67,10 @@ class T5SelfAttention(nn.Module):
         ).astype(mx.int32)
         relative_position_if_large = mx.minimum(
             relative_position_if_large,
-            mx.full(relative_position_if_large.shape, num_buckets - 1)
+            mx.full(relative_position_if_large.shape, num_buckets - 1),
         )
 
-        relative_buckets += mx.where(is_small, relative_position, relative_position_if_large)
+        relative_buckets += mx.where(
+            is_small, relative_position, relative_position_if_large
+        )
         return relative_buckets

--- a/src/mflux/models/transformer/ada_layer_norm_continous.py
+++ b/src/mflux/models/transformer/ada_layer_norm_continous.py
@@ -5,7 +5,6 @@ from mflux.config.config import Config
 
 
 class AdaLayerNormContinuous(nn.Module):
-
     def __init__(self, embedding_dim: int, conditioning_embedding_dim: int):
         super().__init__()
         self.embedding_dim = embedding_dim
@@ -15,8 +14,7 @@ class AdaLayerNormContinuous(nn.Module):
     def forward(self, x: mx.array, text_embeddings: mx.array) -> mx.array:
         text_embeddings = self.linear(nn.silu(text_embeddings).astype(Config.precision))
         chunk_size = self.embedding_dim
-        scale = text_embeddings[:, 0*chunk_size:1*chunk_size]
-        shift = text_embeddings[:, 1*chunk_size:2*chunk_size]
+        scale = text_embeddings[:, 0 * chunk_size : 1 * chunk_size]
+        shift = text_embeddings[:, 1 * chunk_size : 2 * chunk_size]
         x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
         return x
-

--- a/src/mflux/models/transformer/ada_layer_norm_zero.py
+++ b/src/mflux/models/transformer/ada_layer_norm_zero.py
@@ -3,7 +3,6 @@ import mlx.core as mx
 
 
 class AdaLayerNormZero(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(3072, 18432)
@@ -12,11 +11,11 @@ class AdaLayerNormZero(nn.Module):
     def forward(self, x: mx.array, text_embeddings: mx.array):
         text_embeddings = self.linear(nn.silu(text_embeddings))
         chunk_size = 18432 // 6
-        shift_msa = text_embeddings[:, 0*chunk_size:1*chunk_size]
-        scale_msa = text_embeddings[:, 1*chunk_size:2*chunk_size]
-        gate_msa = text_embeddings[:, 2*chunk_size:3*chunk_size]
-        shift_mlp = text_embeddings[:, 3*chunk_size:4*chunk_size]
-        scale_mlp = text_embeddings[:, 4*chunk_size:5*chunk_size]
-        gate_mlp = text_embeddings[:, 5*chunk_size:6*chunk_size]
+        shift_msa = text_embeddings[:, 0 * chunk_size : 1 * chunk_size]
+        scale_msa = text_embeddings[:, 1 * chunk_size : 2 * chunk_size]
+        gate_msa = text_embeddings[:, 2 * chunk_size : 3 * chunk_size]
+        shift_mlp = text_embeddings[:, 3 * chunk_size : 4 * chunk_size]
+        scale_mlp = text_embeddings[:, 4 * chunk_size : 5 * chunk_size]
+        gate_mlp = text_embeddings[:, 5 * chunk_size : 6 * chunk_size]
         x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
         return x, gate_msa, shift_mlp, scale_mlp, gate_mlp

--- a/src/mflux/models/transformer/ada_layer_norm_zero_single.py
+++ b/src/mflux/models/transformer/ada_layer_norm_zero_single.py
@@ -3,17 +3,16 @@ import mlx.core as mx
 
 
 class AdaLayerNormZeroSingle(nn.Module):
-
     def __init__(self):
         super().__init__()
-        self.linear = nn.Linear(3072, 3*3072)
+        self.linear = nn.Linear(3072, 3 * 3072)
         self.norm = nn.LayerNorm(dims=3072, eps=1e-6, affine=False)
 
     def forward(self, x: mx.array, text_embeddings: mx.array):
         text_embeddings = self.linear(nn.silu(text_embeddings))
         chunk_size = 9216 // 3
-        shift_msa = text_embeddings[:, 0*chunk_size:1*chunk_size]
-        scale_msa = text_embeddings[:, 1*chunk_size:2*chunk_size]
-        gate_msa = text_embeddings[:, 2*chunk_size:3*chunk_size]
+        shift_msa = text_embeddings[:, 0 * chunk_size : 1 * chunk_size]
+        scale_msa = text_embeddings[:, 1 * chunk_size : 2 * chunk_size]
+        gate_msa = text_embeddings[:, 2 * chunk_size : 3 * chunk_size]
         x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
         return x, gate_msa

--- a/src/mflux/models/transformer/embed_nd.py
+++ b/src/mflux/models/transformer/embed_nd.py
@@ -3,7 +3,6 @@ from mlx import nn
 
 
 class EmbedND(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.dim = 3072
@@ -20,7 +19,7 @@ class EmbedND(nn.Module):
     @staticmethod
     def rope(pos: mx.array, dim: int, theta: float) -> mx.array:
         scale = mx.arange(0, dim, 2, dtype=mx.float32) / dim
-        omega = 1.0 / (theta ** scale)
+        omega = 1.0 / (theta**scale)
         batch_size, seq_length = pos.shape
         pos_expanded = mx.expand_dims(pos, axis=-1)
         omega_expanded = mx.expand_dims(omega, axis=0)

--- a/src/mflux/models/transformer/feed_forward.py
+++ b/src/mflux/models/transformer/feed_forward.py
@@ -3,7 +3,6 @@ import mlx.core as mx
 
 
 class FeedForward(nn.Module):
-
     def __init__(self, activation_function):
         super().__init__()
         self.linear1 = nn.Linear(3072, 6144)

--- a/src/mflux/models/transformer/guidance_embedder.py
+++ b/src/mflux/models/transformer/guidance_embedder.py
@@ -3,7 +3,6 @@ import mlx.core as mx
 
 
 class GuidanceEmbedder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.linear_1 = nn.Linear(256, 3072)

--- a/src/mflux/models/transformer/joint_attention.py
+++ b/src/mflux/models/transformer/joint_attention.py
@@ -28,8 +28,6 @@ class JointAttention(nn.Module):
         encoder_hidden_states: mx.array,
         image_rotary_emb: mx.array,
     ) -> (mx.array, mx.array):
-        residual = hidden_states
-
         query = self.to_q(hidden_states)
         key = self.to_k(hidden_states)
         value = self.to_v(hidden_states)

--- a/src/mflux/models/transformer/joint_attention.py
+++ b/src/mflux/models/transformer/joint_attention.py
@@ -23,10 +23,10 @@ class JointAttention(nn.Module):
         self.norm_added_k = nn.RMSNorm(128)
 
     def forward(
-            self,
-            hidden_states: mx.array,
-            encoder_hidden_states: mx.array,
-            image_rotary_emb: mx.array
+        self,
+        hidden_states: mx.array,
+        encoder_hidden_states: mx.array,
+        image_rotary_emb: mx.array,
     ) -> (mx.array, mx.array):
         residual = hidden_states
 
@@ -45,12 +45,22 @@ class JointAttention(nn.Module):
         encoder_hidden_states_key_proj = self.add_k_proj(encoder_hidden_states)
         encoder_hidden_states_value_proj = self.add_v_proj(encoder_hidden_states)
 
-        encoder_hidden_states_query_proj = mx.transpose(mx.reshape(encoder_hidden_states_query_proj, (1, -1, 24, 128)), (0, 2, 1, 3))
-        encoder_hidden_states_key_proj = mx.transpose(mx.reshape(encoder_hidden_states_key_proj, (1, -1, 24, 128)), (0, 2, 1, 3))
-        encoder_hidden_states_value_proj = mx.transpose(mx.reshape(encoder_hidden_states_value_proj, (1, -1, 24, 128)),   (0, 2, 1, 3))
+        encoder_hidden_states_query_proj = mx.transpose(
+            mx.reshape(encoder_hidden_states_query_proj, (1, -1, 24, 128)), (0, 2, 1, 3)
+        )
+        encoder_hidden_states_key_proj = mx.transpose(
+            mx.reshape(encoder_hidden_states_key_proj, (1, -1, 24, 128)), (0, 2, 1, 3)
+        )
+        encoder_hidden_states_value_proj = mx.transpose(
+            mx.reshape(encoder_hidden_states_value_proj, (1, -1, 24, 128)), (0, 2, 1, 3)
+        )
 
-        encoder_hidden_states_query_proj = self.norm_added_q(encoder_hidden_states_query_proj)
-        encoder_hidden_states_key_proj = self.norm_added_k(encoder_hidden_states_key_proj)
+        encoder_hidden_states_query_proj = self.norm_added_q(
+            encoder_hidden_states_query_proj
+        )
+        encoder_hidden_states_key_proj = self.norm_added_k(
+            encoder_hidden_states_key_proj
+        )
 
         query = mx.concatenate([encoder_hidden_states_query_proj, query], axis=2)
         key = mx.concatenate([encoder_hidden_states_key_proj, key], axis=2)
@@ -60,10 +70,12 @@ class JointAttention(nn.Module):
 
         hidden_states = JointAttention.attention(query, key, value)
         hidden_states = mx.transpose(hidden_states, (0, 2, 1, 3))
-        hidden_states = mx.reshape(hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension))
+        hidden_states = mx.reshape(
+            hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension)
+        )
         encoder_hidden_states, hidden_states = (
             hidden_states[:, : encoder_hidden_states.shape[1]],
-            hidden_states[:, encoder_hidden_states.shape[1]:],
+            hidden_states[:, encoder_hidden_states.shape[1] :],
         )
 
         hidden_states = self.to_out[0](hidden_states)
@@ -76,7 +88,7 @@ class JointAttention(nn.Module):
         scale = 1 / mx.sqrt(query.shape[-1])
         scores = (query * scale) @ key.transpose(0, 1, 3, 2)
         attn = mx.softmax(scores, axis=-1)
-        hidden_states = (attn @ value)
+        hidden_states = attn @ value
         return hidden_states
 
     @staticmethod
@@ -85,4 +97,6 @@ class JointAttention(nn.Module):
         xk_ = xk.astype(mx.float32).reshape(*xk.shape[:-1], -1, 1, 2)
         xq_out = freqs_cis[..., 0] * xq_[..., 0] + freqs_cis[..., 1] * xq_[..., 1]
         xk_out = freqs_cis[..., 0] * xk_[..., 0] + freqs_cis[..., 1] * xk_[..., 1]
-        return xq_out.reshape(*xq.shape).astype(mx.float32), xk_out.reshape(*xk.shape).astype(mx.float32)
+        return xq_out.reshape(*xq.shape).astype(mx.float32), xk_out.reshape(
+            *xk.shape
+        ).astype(mx.float32)

--- a/src/mflux/models/transformer/joint_transformer_block.py
+++ b/src/mflux/models/transformer/joint_transformer_block.py
@@ -7,7 +7,6 @@ from mflux.models.transformer.joint_attention import JointAttention
 
 
 class JointTransformerBlock(nn.Module):
-
     def __init__(self, layer):
         super().__init__()
         self.layer = layer
@@ -20,17 +19,20 @@ class JointTransformerBlock(nn.Module):
         self.norm2_context = nn.LayerNorm(dims=1536, eps=1e-6, affine=False)
 
     def forward(
-            self,
-            hidden_states: mx.array,
-            encoder_hidden_states: mx.array,
-            text_embeddings: mx.array,
-            rotary_embeddings: mx.array
+        self,
+        hidden_states: mx.array,
+        encoder_hidden_states: mx.array,
+        text_embeddings: mx.array,
+        rotary_embeddings: mx.array,
     ) -> (mx.array, mx.array):
-        norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm1.forward(hidden_states, text_embeddings)
+        norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self.norm1.forward(hidden_states, text_embeddings)
+        )
 
-        norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = self.norm1_context.forward(
-            x=encoder_hidden_states,
-            text_embeddings=text_embeddings
+        norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = (
+            self.norm1_context.forward(
+                x=encoder_hidden_states, text_embeddings=text_embeddings
+            )
         )
 
         attn_output, context_attn_output = self.attn.forward(
@@ -42,7 +44,9 @@ class JointTransformerBlock(nn.Module):
         attn_output = mx.expand_dims(gate_msa, axis=1) * attn_output
         hidden_states = hidden_states + attn_output
         norm_hidden_states = self.norm2(hidden_states)
-        norm_hidden_states = norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        norm_hidden_states = (
+            norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        )
         ff_output = self.ff.forward(norm_hidden_states)
         ff_output = mx.expand_dims(gate_mlp, axis=1) * ff_output
         hidden_states = hidden_states + ff_output
@@ -50,7 +54,13 @@ class JointTransformerBlock(nn.Module):
         context_attn_output = mx.expand_dims(c_gate_msa, axis=1) * context_attn_output
         encoder_hidden_states = encoder_hidden_states + context_attn_output
         norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
-        norm_encoder_hidden_states = norm_encoder_hidden_states * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
+        norm_encoder_hidden_states = (
+            norm_encoder_hidden_states * (1 + c_scale_mlp[:, None])
+            + c_shift_mlp[:, None]
+        )
         context_ff_output = self.ff_context.forward(norm_encoder_hidden_states)
-        encoder_hidden_states = encoder_hidden_states + mx.expand_dims(c_gate_mlp, axis=1) * context_ff_output
+        encoder_hidden_states = (
+            encoder_hidden_states
+            + mx.expand_dims(c_gate_mlp, axis=1) * context_ff_output
+        )
         return encoder_hidden_states, hidden_states

--- a/src/mflux/models/transformer/single_block_attention.py
+++ b/src/mflux/models/transformer/single_block_attention.py
@@ -16,9 +16,7 @@ class SingleBlockAttention(nn.Module):
         self.norm_k = nn.RMSNorm(128)
 
     def forward(
-            self,
-            hidden_states: mx.array,
-            image_rotary_emb: mx.array
+        self, hidden_states: mx.array, image_rotary_emb: mx.array
     ) -> (mx.array, mx.array):
         query = self.to_q(hidden_states)
         key = self.to_k(hidden_states)
@@ -35,7 +33,9 @@ class SingleBlockAttention(nn.Module):
 
         hidden_states = SingleBlockAttention.attention(query, key, value)
         hidden_states = mx.transpose(hidden_states, (0, 2, 1, 3))
-        hidden_states = mx.reshape(hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension))
+        hidden_states = mx.reshape(
+            hidden_states, (self.batch_size, -1, self.num_heads * self.head_dimension)
+        )
 
         return hidden_states
 
@@ -44,7 +44,7 @@ class SingleBlockAttention(nn.Module):
         scale = 1 / mx.sqrt(query.shape[-1])
         scores = (query * scale) @ key.transpose(0, 1, 3, 2)
         attn = mx.softmax(scores, axis=-1)
-        hidden_states = (attn @ value)
+        hidden_states = attn @ value
         return hidden_states
 
     @staticmethod
@@ -53,4 +53,6 @@ class SingleBlockAttention(nn.Module):
         xk_ = xk.astype(mx.float32).reshape(*xk.shape[:-1], -1, 1, 2)
         xq_out = freqs_cis[..., 0] * xq_[..., 0] + freqs_cis[..., 1] * xq_[..., 1]
         xk_out = freqs_cis[..., 0] * xk_[..., 0] + freqs_cis[..., 1] * xk_[..., 1]
-        return xq_out.reshape(*xq.shape).astype(mx.float32), xk_out.reshape(*xk.shape).astype(mx.float32)
+        return xq_out.reshape(*xq.shape).astype(mx.float32), xk_out.reshape(
+            *xk.shape
+        ).astype(mx.float32)

--- a/src/mflux/models/transformer/single_transformer_block.py
+++ b/src/mflux/models/transformer/single_transformer_block.py
@@ -6,23 +6,24 @@ from mflux.models.transformer.single_block_attention import SingleBlockAttention
 
 
 class SingleTransformerBlock(nn.Module):
-
     def __init__(self, layer):
         super().__init__()
         self.layer = layer
         self.norm = AdaLayerNormZeroSingle()
-        self.proj_mlp = nn.Linear(3072, 4*3072)
+        self.proj_mlp = nn.Linear(3072, 4 * 3072)
         self.attn = SingleBlockAttention()
-        self.proj_out = nn.Linear(3072 + 4*3072, 3072)
+        self.proj_out = nn.Linear(3072 + 4 * 3072, 3072)
 
     def forward(
-            self,
-            hidden_states: mx.array,
-            text_embeddings: mx.array,
-            rotary_embeddings: mx.array
+        self,
+        hidden_states: mx.array,
+        text_embeddings: mx.array,
+        rotary_embeddings: mx.array,
     ) -> (mx.array, mx.array):
         residual = hidden_states
-        norm_hidden_states, gate = self.norm.forward(x=hidden_states, text_embeddings=text_embeddings)
+        norm_hidden_states, gate = self.norm.forward(
+            x=hidden_states, text_embeddings=text_embeddings
+        )
         mlp_hidden_states = nn.gelu_approx(self.proj_mlp(norm_hidden_states))
         attn_output = self.attn.forward(
             hidden_states=norm_hidden_states,

--- a/src/mflux/models/transformer/text_embedder.py
+++ b/src/mflux/models/transformer/text_embedder.py
@@ -3,7 +3,6 @@ import mlx.core as mx
 
 
 class TextEmbedder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.linear_1 = nn.Linear(768, 3072)

--- a/src/mflux/models/transformer/time_text_embed.py
+++ b/src/mflux/models/transformer/time_text_embed.py
@@ -10,14 +10,17 @@ from mflux.models.transformer.guidance_embedder import GuidanceEmbedder
 
 
 class TimeTextEmbed(nn.Module):
-
     def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.text_embedder = TextEmbedder()
-        self.guidance_embedder = GuidanceEmbedder() if model_config == ModelConfig.FLUX1_DEV else None
+        self.guidance_embedder = (
+            GuidanceEmbedder() if model_config == ModelConfig.FLUX1_DEV else None
+        )
         self.timestep_embedder = TimestepEmbedder()
 
-    def forward(self, time_step: mx.array, pooled_projection: mx.array, guidance: mx.array) -> mx.array:
+    def forward(
+        self, time_step: mx.array, pooled_projection: mx.array, guidance: mx.array
+    ) -> mx.array:
         time_steps_proj = self._time_proj(time_step)
         time_steps_emb = self.timestep_embedder.forward(time_steps_proj)
         if self.guidance_embedder is not None:
@@ -30,11 +33,12 @@ class TimeTextEmbed(nn.Module):
     def _time_proj(time_steps: mx.array) -> mx.array:
         max_period = 10000
         half_dim = 128
-        exponent = -math.log(max_period) * mx.arange(start=0, stop=half_dim, step=None, dtype=mx.float32)
+        exponent = -math.log(max_period) * mx.arange(
+            start=0, stop=half_dim, step=None, dtype=mx.float32
+        )
         exponent = exponent / half_dim
         emb = mx.exp(exponent)
         emb = time_steps[:, None].astype(mx.float32) * emb[None, :]
         emb = mx.concatenate([mx.sin(emb), mx.cos(emb)], axis=-1)
         emb = mx.concatenate([emb[:, half_dim:], emb[:, :half_dim]], axis=-1)
         return emb
-

--- a/src/mflux/models/transformer/timestep_embedder.py
+++ b/src/mflux/models/transformer/timestep_embedder.py
@@ -3,7 +3,6 @@ import mlx.core as mx
 
 
 class TimestepEmbedder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.linear_1 = nn.Linear(256, 3072)

--- a/src/mflux/models/transformer/transformer.py
+++ b/src/mflux/models/transformer/transformer.py
@@ -11,7 +11,6 @@ from mflux.models.transformer.time_text_embed import TimeTextEmbed
 
 
 class Transformer(nn.Module):
-
     def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.pos_embed = EmbedND()
@@ -24,18 +23,22 @@ class Transformer(nn.Module):
         self.proj_out = nn.Linear(3072, 64)
 
     def predict(
-            self,
-            t: int,
-            prompt_embeds: mx.array,
-            pooled_prompt_embeds: mx.array,
-            hidden_states: mx.array,
-            config: RuntimeConfig,
+        self,
+        t: int,
+        prompt_embeds: mx.array,
+        pooled_prompt_embeds: mx.array,
+        hidden_states: mx.array,
+        config: RuntimeConfig,
     ) -> mx.array:
         time_step = config.sigmas[t] * config.num_train_steps
         time_step = mx.broadcast_to(time_step, (1,)).astype(config.precision)
         hidden_states = self.x_embedder(hidden_states)
-        guidance = mx.broadcast_to(config.guidance * config.num_train_steps, (1,)).astype(config.precision)
-        text_embeddings = self.time_text_embed.forward(time_step, pooled_prompt_embeds, guidance)
+        guidance = mx.broadcast_to(
+            config.guidance * config.num_train_steps, (1,)
+        ).astype(config.precision)
+        text_embeddings = self.time_text_embed.forward(
+            time_step, pooled_prompt_embeds, guidance
+        )
         encoder_hidden_states = self.context_embedder(prompt_embeds)
         txt_ids = Transformer._prepare_text_ids(seq_len=prompt_embeds.shape[1])
         img_ids = Transformer._prepare_latent_image_ids(config.height, config.width)
@@ -47,7 +50,7 @@ class Transformer(nn.Module):
                 hidden_states=hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 text_embeddings=text_embeddings,
-                rotary_embeddings=image_rotary_emb
+                rotary_embeddings=image_rotary_emb,
             )
 
         hidden_states = mx.concatenate([encoder_hidden_states, hidden_states], axis=1)
@@ -56,10 +59,10 @@ class Transformer(nn.Module):
             hidden_states = block.forward(
                 hidden_states=hidden_states,
                 text_embeddings=text_embeddings,
-                rotary_embeddings=image_rotary_emb
+                rotary_embeddings=image_rotary_emb,
             )
 
-        hidden_states = hidden_states[:, encoder_hidden_states.shape[1]:, ...]
+        hidden_states = hidden_states[:, encoder_hidden_states.shape[1] :, ...]
         hidden_states = self.norm_out.forward(hidden_states, text_embeddings)
         hidden_states = self.proj_out(hidden_states)
         noise = hidden_states
@@ -70,10 +73,16 @@ class Transformer(nn.Module):
         latent_width = width // 16
         latent_height = height // 16
         latent_image_ids = mx.zeros((latent_height, latent_width, 3))
-        latent_image_ids = latent_image_ids.at[:, :, 1].add(mx.arange(0, latent_height)[:, None])
-        latent_image_ids = latent_image_ids.at[:, :, 2].add(mx.arange(0, latent_width)[None, :])
+        latent_image_ids = latent_image_ids.at[:, :, 1].add(
+            mx.arange(0, latent_height)[:, None]
+        )
+        latent_image_ids = latent_image_ids.at[:, :, 2].add(
+            mx.arange(0, latent_width)[None, :]
+        )
         latent_image_ids = mx.repeat(latent_image_ids[None, :], 1, axis=0)
-        latent_image_ids = mx.reshape(latent_image_ids, (1, latent_width * latent_height, 3))
+        latent_image_ids = mx.reshape(
+            latent_image_ids, (1, latent_width * latent_height, 3)
+        )
         return latent_image_ids
 
     @staticmethod

--- a/src/mflux/models/vae/common/attention.py
+++ b/src/mflux/models/vae/common/attention.py
@@ -5,7 +5,6 @@ from mflux.config.config import Config
 
 
 class Attention(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.group_norm = nn.GroupNorm(32, 512, pytorch_compatible=True)

--- a/src/mflux/models/vae/common/resnet_block_2d.py
+++ b/src/mflux/models/vae/common/resnet_block_2d.py
@@ -5,33 +5,24 @@ from mflux.config.config import Config
 
 
 class ResnetBlock2D(nn.Module):
-
     def __init__(
-            self,
-            norm1: int,
-            conv1_in: int,
-            conv1_out: int,
-            norm2: int,
-            conv2_in: int,
-            conv2_out: int,
-            conv_shortcut_in: int | None = None,
-            conv_shortcut_out: int | None = None,
-            is_conv_shortcut: bool = False
+        self,
+        norm1: int,
+        conv1_in: int,
+        conv1_out: int,
+        norm2: int,
+        conv2_in: int,
+        conv2_out: int,
+        conv_shortcut_in: int | None = None,
+        conv_shortcut_out: int | None = None,
+        is_conv_shortcut: bool = False,
     ):
         super().__init__()
         self.norm1 = nn.GroupNorm(
-            num_groups=32,
-            dims=norm1,
-            eps=1e-6,
-            affine=True,
-            pytorch_compatible=True
+            num_groups=32, dims=norm1, eps=1e-6, affine=True, pytorch_compatible=True
         )
         self.norm2 = nn.GroupNorm(
-            num_groups=32,
-            dims=norm2,
-            eps=1e-6,
-            affine=True,
-            pytorch_compatible=True
+            num_groups=32, dims=norm2, eps=1e-6, affine=True, pytorch_compatible=True
         )
         self.conv1 = nn.Conv2d(
             in_channels=conv1_in,
@@ -48,19 +39,27 @@ class ResnetBlock2D(nn.Module):
             padding=(1, 1),
         )
         self.is_conv_shortcut = is_conv_shortcut
-        self.conv_shortcut = None if not is_conv_shortcut else nn.Conv2d(
-            in_channels=conv_shortcut_in,
-            out_channels=conv_shortcut_out,
-            kernel_size=(1, 1),
-            stride=(1, 1),
+        self.conv_shortcut = (
+            None
+            if not is_conv_shortcut
+            else nn.Conv2d(
+                in_channels=conv_shortcut_in,
+                out_channels=conv_shortcut_out,
+                kernel_size=(1, 1),
+                stride=(1, 1),
+            )
         )
 
     def forward(self, input_array: mx.array) -> mx.array:
         input_array = mx.transpose(input_array, (0, 2, 3, 1))
-        hidden_states = self.norm1(input_array.astype(mx.float32)).astype(Config.precision)
+        hidden_states = self.norm1(input_array.astype(mx.float32)).astype(
+            Config.precision
+        )
         hidden_states = nn.silu(hidden_states)
         hidden_states = self.conv1(hidden_states)
-        hidden_states = self.norm2(hidden_states.astype(mx.float32)).astype(Config.precision)
+        hidden_states = self.norm2(hidden_states.astype(mx.float32)).astype(
+            Config.precision
+        )
         hidden_states = nn.silu(hidden_states)
         hidden_states = self.conv2(hidden_states)
         if self.is_conv_shortcut:

--- a/src/mflux/models/vae/common/unet_mid_block.py
+++ b/src/mflux/models/vae/common/unet_mid_block.py
@@ -6,13 +6,26 @@ from mflux.models.vae.common.resnet_block_2d import ResnetBlock2D
 
 
 class UnetMidBlock(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.attentions = [Attention()]
         self.resnets = [
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512)
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
         ]
 
     def forward(self, input_array: mx.array) -> mx.array:

--- a/src/mflux/models/vae/decoder/conv_in.py
+++ b/src/mflux/models/vae/decoder/conv_in.py
@@ -3,7 +3,6 @@ import mlx.nn as nn
 
 
 class ConvIn(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.conv2d = nn.Conv2d(

--- a/src/mflux/models/vae/decoder/conv_norm_out.py
+++ b/src/mflux/models/vae/decoder/conv_norm_out.py
@@ -8,14 +8,12 @@ class ConvNormOut(nn.Module):
     def __init__(self):
         super().__init__()
         self.norm = nn.GroupNorm(
-            num_groups=32,
-            dims=128,
-            eps=1e-6,
-            affine=True,
-            pytorch_compatible=True
+            num_groups=32, dims=128, eps=1e-6, affine=True, pytorch_compatible=True
         )
 
     def forward(self, input_array: mx.array) -> mx.array:
         input_array = mx.transpose(input_array, (0, 2, 3, 1))
-        hidden_states = self.norm(input_array.astype(mx.float32)).astype(Config.precision)
+        hidden_states = self.norm(input_array.astype(mx.float32)).astype(
+            Config.precision
+        )
         return mx.transpose(hidden_states, (0, 3, 1, 2))

--- a/src/mflux/models/vae/decoder/decoder.py
+++ b/src/mflux/models/vae/decoder/decoder.py
@@ -11,7 +11,6 @@ from mflux.models.vae.decoder.up_block_4 import UpBlock4
 
 
 class Decoder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.conv_in = ConvIn()

--- a/src/mflux/models/vae/decoder/up_block_1_or_2.py
+++ b/src/mflux/models/vae/decoder/up_block_1_or_2.py
@@ -6,13 +6,33 @@ from mflux.models.vae.decoder.up_sampler import UpSampler
 
 
 class UpBlock1Or2(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512)
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
         ]
         self.upsamplers = [UpSampler(conv_in=512, conv_out=512)]
 

--- a/src/mflux/models/vae/decoder/up_block_3.py
+++ b/src/mflux/models/vae/decoder/up_block_3.py
@@ -6,13 +6,36 @@ from mflux.models.vae.decoder.up_sampler import UpSampler
 
 
 class UpBlock3(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=256, norm2=256, conv2_in=256, conv2_out=256, is_conv_shortcut=True, conv_shortcut_in=512, conv_shortcut_out=256),
-            ResnetBlock2D(norm1=256, conv1_in=256, conv1_out=256, norm2=256, conv2_in=256, conv2_out=256),
-            ResnetBlock2D(norm1=256, conv1_in=256, conv1_out=256, norm2=256, conv2_in=256, conv2_out=256),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=256,
+                norm2=256,
+                conv2_in=256,
+                conv2_out=256,
+                is_conv_shortcut=True,
+                conv_shortcut_in=512,
+                conv_shortcut_out=256,
+            ),
+            ResnetBlock2D(
+                norm1=256,
+                conv1_in=256,
+                conv1_out=256,
+                norm2=256,
+                conv2_in=256,
+                conv2_out=256,
+            ),
+            ResnetBlock2D(
+                norm1=256,
+                conv1_in=256,
+                conv1_out=256,
+                norm2=256,
+                conv2_in=256,
+                conv2_out=256,
+            ),
         ]
         self.upsamplers = [UpSampler(conv_in=256, conv_out=256)]
 

--- a/src/mflux/models/vae/decoder/up_block_4.py
+++ b/src/mflux/models/vae/decoder/up_block_4.py
@@ -5,13 +5,36 @@ from mflux.models.vae.common.resnet_block_2d import ResnetBlock2D
 
 
 class UpBlock4(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=256, conv1_in=256, conv1_out=128, norm2=128, conv2_in=128, conv2_out=128, is_conv_shortcut=True, conv_shortcut_in=256, conv_shortcut_out=128),
-            ResnetBlock2D(norm1=128, conv1_in=128, conv1_out=128, norm2=128, conv2_in=128, conv2_out=128),
-            ResnetBlock2D(norm1=128, conv1_in=128, conv1_out=128, norm2=128, conv2_in=128, conv2_out=128),
+            ResnetBlock2D(
+                norm1=256,
+                conv1_in=256,
+                conv1_out=128,
+                norm2=128,
+                conv2_in=128,
+                conv2_out=128,
+                is_conv_shortcut=True,
+                conv_shortcut_in=256,
+                conv_shortcut_out=128,
+            ),
+            ResnetBlock2D(
+                norm1=128,
+                conv1_in=128,
+                conv1_out=128,
+                norm2=128,
+                conv2_in=128,
+                conv2_out=128,
+            ),
+            ResnetBlock2D(
+                norm1=128,
+                conv1_in=128,
+                conv1_out=128,
+                norm2=128,
+                conv2_in=128,
+                conv2_out=128,
+            ),
         ]
 
     def forward(self, input_array: mx.array) -> mx.array:

--- a/src/mflux/models/vae/decoder/up_sampler.py
+++ b/src/mflux/models/vae/decoder/up_sampler.py
@@ -4,7 +4,6 @@ from mlx import nn
 
 
 class UpSampler(nn.Module):
-
     def __init__(self, conv_in: int, conv_out: int):
         super().__init__()
         self.conv = nn.Conv2d(

--- a/src/mflux/models/vae/encoder/conv_in.py
+++ b/src/mflux/models/vae/encoder/conv_in.py
@@ -3,7 +3,6 @@ import mlx.nn as nn
 
 
 class ConvIn(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.conv2d = nn.Conv2d(

--- a/src/mflux/models/vae/encoder/conv_norm_out.py
+++ b/src/mflux/models/vae/encoder/conv_norm_out.py
@@ -6,11 +6,7 @@ class ConvNormOut(nn.Module):
     def __init__(self):
         super().__init__()
         self.norm = nn.GroupNorm(
-            num_groups=32,
-            dims=512,
-            eps=1e-6,
-            affine=True,
-            pytorch_compatible=True
+            num_groups=32, dims=512, eps=1e-6, affine=True, pytorch_compatible=True
         )
 
     def forward(self, input_array: mx.array) -> mx.array:

--- a/src/mflux/models/vae/encoder/down_block_1.py
+++ b/src/mflux/models/vae/encoder/down_block_1.py
@@ -6,12 +6,25 @@ from mflux.models.vae.encoder.down_sampler import DownSampler
 
 
 class DownBlock1(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=128, conv1_in=128, conv1_out=128, norm2=128, conv2_in=128, conv2_out=128),
-            ResnetBlock2D(norm1=128, conv1_in=128, conv1_out=128, norm2=128, conv2_in=128, conv2_out=128),
+            ResnetBlock2D(
+                norm1=128,
+                conv1_in=128,
+                conv1_out=128,
+                norm2=128,
+                conv2_in=128,
+                conv2_out=128,
+            ),
+            ResnetBlock2D(
+                norm1=128,
+                conv1_in=128,
+                conv1_out=128,
+                norm2=128,
+                conv2_in=128,
+                conv2_out=128,
+            ),
         ]
         self.downsamplers = [DownSampler(conv_in=128, conv_out=128)]
 

--- a/src/mflux/models/vae/encoder/down_block_2.py
+++ b/src/mflux/models/vae/encoder/down_block_2.py
@@ -6,12 +6,28 @@ from mflux.models.vae.encoder.down_sampler import DownSampler
 
 
 class DownBlock2(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=128, conv1_in=128, conv1_out=256, norm2=256, conv2_in=256, conv2_out=256, is_conv_shortcut=True, conv_shortcut_in=128, conv_shortcut_out=256),
-            ResnetBlock2D(norm1=256, conv1_in=256, conv1_out=256, norm2=256, conv2_in=256, conv2_out=256),
+            ResnetBlock2D(
+                norm1=128,
+                conv1_in=128,
+                conv1_out=256,
+                norm2=256,
+                conv2_in=256,
+                conv2_out=256,
+                is_conv_shortcut=True,
+                conv_shortcut_in=128,
+                conv_shortcut_out=256,
+            ),
+            ResnetBlock2D(
+                norm1=256,
+                conv1_in=256,
+                conv1_out=256,
+                norm2=256,
+                conv2_in=256,
+                conv2_out=256,
+            ),
         ]
         self.downsamplers = [DownSampler(conv_in=256, conv_out=256)]
 

--- a/src/mflux/models/vae/encoder/down_block_3.py
+++ b/src/mflux/models/vae/encoder/down_block_3.py
@@ -6,12 +6,28 @@ from mflux.models.vae.encoder.down_sampler import DownSampler
 
 
 class DownBlock3(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=256, conv1_in=256, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512, is_conv_shortcut=True, conv_shortcut_in=256, conv_shortcut_out=512),
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
+            ResnetBlock2D(
+                norm1=256,
+                conv1_in=256,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+                is_conv_shortcut=True,
+                conv_shortcut_in=256,
+                conv_shortcut_out=512,
+            ),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
         ]
         self.downsamplers = [DownSampler(conv_in=512, conv_out=512)]
 

--- a/src/mflux/models/vae/encoder/down_block_4.py
+++ b/src/mflux/models/vae/encoder/down_block_4.py
@@ -5,12 +5,25 @@ from mflux.models.vae.common.resnet_block_2d import ResnetBlock2D
 
 
 class DownBlock4(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.resnets = [
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
-            ResnetBlock2D(norm1=512, conv1_in=512, conv1_out=512, norm2=512, conv2_in=512, conv2_out=512),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
+            ResnetBlock2D(
+                norm1=512,
+                conv1_in=512,
+                conv1_out=512,
+                norm2=512,
+                conv2_in=512,
+                conv2_out=512,
+            ),
         ]
 
     def forward(self, input_array: mx.array) -> mx.array:

--- a/src/mflux/models/vae/encoder/down_sampler.py
+++ b/src/mflux/models/vae/encoder/down_sampler.py
@@ -4,7 +4,6 @@ from mlx import nn
 
 
 class DownSampler(nn.Module):
-
     def __init__(self, conv_in: int, conv_out: int):
         super().__init__()
         self.conv = nn.Conv2d(

--- a/src/mflux/models/vae/encoder/encoder.py
+++ b/src/mflux/models/vae/encoder/encoder.py
@@ -13,7 +13,6 @@ from mflux.models.vae.encoder.down_block_4 import DownBlock4
 
 
 class Encoder(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.conv_in = ConvIn()

--- a/src/mflux/post_processing/image.py
+++ b/src/mflux/post_processing/image.py
@@ -81,15 +81,6 @@ class Image:
             # Define the UserComment tag ID
             USER_COMMENT_TAG_ID = 0x9286
 
-            # Create an EXIF dictionary
-            exif_dict = {
-                "0th": {},
-                "Exif": {USER_COMMENT_TAG_ID: user_comment_bytes},
-                "GPS": {},
-                "1st": {},
-                "thumbnail": None,
-            }
-
             # Create a piexif-compatible dictionary structure
             exif_piexif_dict = {"Exif": {USER_COMMENT_TAG_ID: user_comment_bytes}}
 

--- a/src/mflux/post_processing/image.py
+++ b/src/mflux/post_processing/image.py
@@ -12,20 +12,19 @@ log = logging.getLogger(__name__)
 
 
 class Image:
-
     def __init__(
-            self,
-            image: PIL.Image.Image,
-            model_config: ModelConfig,
-            seed: int,
-            prompt: str,
-            steps: int,
-            guidance: float | None,
-            precision: mx.Dtype,
-            quantization: int,
-            generation_time: float,
-            lora_paths: list[str],
-            lora_scales: list[float],
+        self,
+        image: PIL.Image.Image,
+        model_config: ModelConfig,
+        seed: int,
+        prompt: str,
+        steps: int,
+        guidance: float | None,
+        precision: mx.Dtype,
+        quantization: int,
+        generation_time: float,
+        lora_paths: list[str],
+        lora_scales: list[float],
     ):
         self.image = image
         self.model_config = model_config
@@ -59,7 +58,7 @@ class Image:
 
             # Optionally save json metadata file
             if export_json_metadata:
-                with open(f"{file_path.with_suffix('.json')}", 'w') as json_file:
+                with open(f"{file_path.with_suffix('.json')}", "w") as json_file:
                     json.dump(self._get_metadata(), json_file, indent=4)
 
             # Embed metadata
@@ -77,33 +76,27 @@ class Image:
             metadata_str = str(metadata)
 
             # Convert the string to bytes (using UTF-8 encoding)
-            user_comment_bytes = metadata_str.encode('utf-8')
+            user_comment_bytes = metadata_str.encode("utf-8")
 
             # Define the UserComment tag ID
             USER_COMMENT_TAG_ID = 0x9286
 
             # Create an EXIF dictionary
             exif_dict = {
-                '0th': {},
-                'Exif': {
-                    USER_COMMENT_TAG_ID: user_comment_bytes
-                },
-                'GPS': {},
-                '1st': {},
-                'thumbnail': None
+                "0th": {},
+                "Exif": {USER_COMMENT_TAG_ID: user_comment_bytes},
+                "GPS": {},
+                "1st": {},
+                "thumbnail": None,
             }
 
             # Create a piexif-compatible dictionary structure
-            exif_piexif_dict = {
-                'Exif': {
-                    USER_COMMENT_TAG_ID: user_comment_bytes
-                }
-            }
+            exif_piexif_dict = {"Exif": {USER_COMMENT_TAG_ID: user_comment_bytes}}
 
             # Load the image and embed the EXIF data
             image = PIL.Image.open(path)
             exif_bytes = piexif.dump(exif_piexif_dict)
-            image.info['exif'] = exif_bytes
+            image.info["exif"] = exif_bytes
 
             # Save the image with metadata
             image.save(path, exif=exif_bytes)
@@ -113,14 +106,20 @@ class Image:
 
     def _get_metadata(self) -> dict:
         return {
-            'model': str(self.model_config.alias),
-            'seed': str(self.seed),
-            'steps': str(self.steps),
-            'guidance': "None" if self.model_config == ModelConfig.FLUX1_SCHNELL else str(self.guidance),
-            'precision': f"{self.precision}",
-            'quantization': "None" if self.quantization is None else f"{self.quantization} bit",
-            'generation_time': f"{self.generation_time:.2f} seconds",
-            'lora_paths': ', '.join(self.lora_paths) if self.lora_paths else '',
-            'lora_scales': ', '.join([f"{scale:.2f}" for scale in self.lora_scales]) if self.lora_scales else '',
-            'prompt': self.prompt,
+            "model": str(self.model_config.alias),
+            "seed": str(self.seed),
+            "steps": str(self.steps),
+            "guidance": "None"
+            if self.model_config == ModelConfig.FLUX1_SCHNELL
+            else str(self.guidance),
+            "precision": f"{self.precision}",
+            "quantization": "None"
+            if self.quantization is None
+            else f"{self.quantization} bit",
+            "generation_time": f"{self.generation_time:.2f} seconds",
+            "lora_paths": ", ".join(self.lora_paths) if self.lora_paths else "",
+            "lora_scales": ", ".join([f"{scale:.2f}" for scale in self.lora_scales])
+            if self.lora_scales
+            else "",
+            "prompt": self.prompt,
         }

--- a/src/mflux/post_processing/image_util.py
+++ b/src/mflux/post_processing/image_util.py
@@ -1,5 +1,4 @@
 import PIL
-from PIL import Image
 import mlx.core as mx
 import numpy as np
 

--- a/src/mflux/post_processing/image_util.py
+++ b/src/mflux/post_processing/image_util.py
@@ -8,17 +8,16 @@ from mflux.post_processing.image import Image
 
 
 class ImageUtil:
-
     @staticmethod
     def to_image(
-            decoded_latents: mx.array,
-            seed: int,
-            prompt: str,
-            quantization: int,
-            generation_time: float,
-            lora_paths: list[str],
-            lora_scales: list[float],
-            config: RuntimeConfig,
+        decoded_latents: mx.array,
+        seed: int,
+        prompt: str,
+        quantization: int,
+        generation_time: float,
+        lora_paths: list[str],
+        lora_scales: list[float],
+        config: RuntimeConfig,
     ) -> Image:
         normalized = ImageUtil._denormalize(decoded_latents)
         normalized_numpy = ImageUtil._to_numpy(normalized)

--- a/src/mflux/save.py
+++ b/src/mflux/save.py
@@ -2,17 +2,38 @@ import argparse
 import os
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mflux.flux.flux import Flux1
 from mflux.config.model_config import ModelConfig
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Save a quantized version of Flux.1 to disk.')
-    parser.add_argument('--path', type=str, required=True, help='Local path for loading a model from disk')
-    parser.add_argument('--model', "-m", type=str, required=True, choices=["dev", "schnell"], help='The model to use ("schnell" or "dev").')
-    parser.add_argument('--quantize',  "-q", type=int, choices=[4, 8], default=8, help='Quantize the model (4 or 8, Default is 8)')
+    parser = argparse.ArgumentParser(
+        description="Save a quantized version of Flux.1 to disk."
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        required=True,
+        help="Local path for loading a model from disk",
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        type=str,
+        required=True,
+        choices=["dev", "schnell"],
+        help='The model to use ("schnell" or "dev").',
+    )
+    parser.add_argument(
+        "--quantize",
+        "-q",
+        type=int,
+        choices=[4, 8],
+        default=8,
+        help="Quantize the model (4 or 8, Default is 8)",
+    )
 
     args = parser.parse_args()
 
@@ -28,5 +49,5 @@ def main():
     print(f"Model saved at {args.path}\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/mflux/tokenizer/t5_tokenizer.py
+++ b/src/mflux/tokenizer/t5_tokenizer.py
@@ -3,7 +3,6 @@ from transformers import T5Tokenizer
 
 
 class TokenizerT5:
-
     def __init__(self, tokenizer: T5Tokenizer, max_length: int = 256):
         self.tokenizer = tokenizer
         self.max_length = max_length

--- a/src/mflux/tokenizer/tokenizer_handler.py
+++ b/src/mflux/tokenizer/tokenizer_handler.py
@@ -7,29 +7,30 @@ from mflux.tokenizer.clip_tokenizer import TokenizerCLIP
 
 
 class TokenizerHandler:
-
-    def __init__(self, repo_id: str, max_t5_length: int = 256, local_path: str | None = None):
-        root_path = Path(local_path) if local_path else TokenizerHandler._download_or_get_cached_tokenizers(repo_id)
+    def __init__(
+        self, repo_id: str, max_t5_length: int = 256, local_path: str | None = None
+    ):
+        root_path = (
+            Path(local_path)
+            if local_path
+            else TokenizerHandler._download_or_get_cached_tokenizers(repo_id)
+        )
 
         self.clip = transformers.CLIPTokenizer.from_pretrained(
             pretrained_model_name_or_path=root_path / "tokenizer",
             local_files_only=True,
-            max_length=TokenizerCLIP.MAX_TOKEN_LENGTH
+            max_length=TokenizerCLIP.MAX_TOKEN_LENGTH,
         )
         self.t5 = transformers.T5Tokenizer.from_pretrained(
             pretrained_model_name_or_path=root_path / "tokenizer_2",
             local_files_only=True,
-            max_length=max_t5_length
+            max_length=max_t5_length,
         )
 
     @staticmethod
     def _download_or_get_cached_tokenizers(repo_id: str) -> Path:
         return Path(
             snapshot_download(
-                repo_id=repo_id,
-                allow_patterns=[
-                    "tokenizer/**",
-                    "tokenizer_2/**"
-                ]
+                repo_id=repo_id, allow_patterns=["tokenizer/**", "tokenizer_2/**"]
             )
         )

--- a/src/mflux/weights/lora_converter.py
+++ b/src/mflux/weights/lora_converter.py
@@ -25,7 +25,6 @@ class LoRAConverter:
     def _load_pytorch_weights(lora_path: str) -> dict:
         state_dict = {}
         with safe_open(lora_path, framework="pt") as f:
-            metadata = f.metadata()
             for k in f.keys():
                 state_dict[k] = f.get_tensor(k)
         return state_dict

--- a/src/mflux/weights/lora_converter.py
+++ b/src/mflux/weights/lora_converter.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 # This script is based on `convert_flux_lora.py` from `kohya-ss/sd-scripts`.
 # For more info, see: https://github.com/kohya-ss/sd-scripts/blob/sd3/networks/convert_flux_lora.py
 
-class LoRAConverter:
 
+class LoRAConverter:
     @staticmethod
     def load_weights(lora_path: str) -> dict:
         state_dict = LoRAConverter._load_pytorch_weights(lora_path)
@@ -38,7 +38,7 @@ class LoRAConverter:
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_img_attn_proj",
-                f"transformer.transformer_blocks.{i}.attn.to_out.0"
+                f"transformer.transformer_blocks.{i}.attn.to_out.0",
             )
             LoRAConverter._convert_to_diffusers_cat(
                 source,
@@ -54,25 +54,25 @@ class LoRAConverter:
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_img_mlp_0",
-                f"transformer.transformer_blocks.{i}.ff.net.0.proj"
+                f"transformer.transformer_blocks.{i}.ff.net.0.proj",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_img_mlp_2",
-                f"transformer.transformer_blocks.{i}.ff.net.2"
+                f"transformer.transformer_blocks.{i}.ff.net.2",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_img_mod_lin",
-                f"transformer.transformer_blocks.{i}.norm1.linear"
+                f"transformer.transformer_blocks.{i}.norm1.linear",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_txt_attn_proj",
-                f"transformer.transformer_blocks.{i}.attn.to_add_out"
+                f"transformer.transformer_blocks.{i}.attn.to_add_out",
             )
             LoRAConverter._convert_to_diffusers_cat(
                 source,
@@ -88,19 +88,19 @@ class LoRAConverter:
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_txt_mlp_0",
-                f"transformer.transformer_blocks.{i}.ff_context.net.0.proj"
+                f"transformer.transformer_blocks.{i}.ff_context.net.0.proj",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_txt_mlp_2",
-                f"transformer.transformer_blocks.{i}.ff_context.net.2"
+                f"transformer.transformer_blocks.{i}.ff_context.net.2",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
                 target,
                 f"lora_unet_double_blocks_{i}_txt_mod_lin",
-                f"transformer.transformer_blocks.{i}.norm1_context.linear"
+                f"transformer.transformer_blocks.{i}.norm1_context.linear",
             )
 
         for i in range(38):
@@ -120,12 +120,13 @@ class LoRAConverter:
                 source,
                 target,
                 f"lora_unet_single_blocks_{i}_linear2",
-                f"transformer.single_transformer_blocks.{i}.proj_out"
+                f"transformer.single_transformer_blocks.{i}.proj_out",
             )
             LoRAConverter._convert_to_diffusers(
                 source,
-                target, f"lora_unet_single_blocks_{i}_modulation_lin",
-                f"transformer.single_transformer_blocks.{i}.norm.linear"
+                target,
+                f"lora_unet_single_blocks_{i}_modulation_lin",
+                f"transformer.single_transformer_blocks.{i}.norm.linear",
             )
 
         if len(source) > 0:
@@ -134,10 +135,7 @@ class LoRAConverter:
 
     @staticmethod
     def _convert_to_diffusers(
-            source: dict,
-            target: dict,
-            source_key: str,
-            target_key: str
+        source: dict, target: dict, source_key: str, target_key: str
     ):
         if source_key + ".lora_down.weight" not in source:
             return
@@ -146,7 +144,9 @@ class LoRAConverter:
         # scale weight by alpha and dim
         rank = down_weight.shape[0]
         alpha = source.pop(source_key + ".alpha").item()  # alpha is scalar
-        scale = alpha / rank  # LoRA is scaled by 'alpha / rank' in forward pass, so we need to scale it back here
+        scale = (
+            alpha / rank
+        )  # LoRA is scaled by 'alpha / rank' in forward pass, so we need to scale it back here
 
         # calculate scale_down and scale_up to keep the same value. if scale is 4, scale_down is 2 and scale_up is 2
         scale_down = scale
@@ -156,15 +156,13 @@ class LoRAConverter:
             scale_up /= 2
 
         target[target_key + ".lora_A.weight"] = down_weight * scale_down
-        target[target_key + ".lora_B.weight"] = source.pop(source_key + ".lora_up.weight") * scale_up
+        target[target_key + ".lora_B.weight"] = (
+            source.pop(source_key + ".lora_up.weight") * scale_up
+        )
 
     @staticmethod
     def _convert_to_diffusers_cat(
-            source: dict,
-            target: dict,
-            source_key: str,
-            target_keys: list[str],
-            dims=None
+        source: dict, target: dict, source_key: str, target_keys: list[str], dims=None
     ):
         if source_key + ".lora_down.weight" not in source:
             return
@@ -204,7 +202,12 @@ class LoRAConverter:
                     if j == k:
                         continue
                     is_sparse = is_sparse and torch.all(
-                        up_weight[i: i + dims[j], k * diffusers_rank: (k + 1) * diffusers_rank] == 0)
+                        up_weight[
+                            i : i + dims[j],
+                            k * diffusers_rank : (k + 1) * diffusers_rank,
+                        ]
+                        == 0
+                    )
                 i += dims[j]
             if is_sparse:
                 logger.info(f"weight is sparse: {source_key}")
@@ -217,15 +220,31 @@ class LoRAConverter:
             target.update({k: down_weight for k in diffusers_down_keys})
 
             # up_weight is split to each split
-            target.update({k: v for k, v in zip(diffusers_up_keys, torch.split(up_weight, dims, dim=0))})
+            target.update(
+                {
+                    k: v
+                    for k, v in zip(
+                        diffusers_up_keys, torch.split(up_weight, dims, dim=0)
+                    )
+                }
+            )
         else:
             # down_weight is chunked to each split
-            target.update({k: v for k, v in zip(diffusers_down_keys, torch.chunk(down_weight, num_splits, dim=0))})
+            target.update(
+                {
+                    k: v
+                    for k, v in zip(
+                        diffusers_down_keys, torch.chunk(down_weight, num_splits, dim=0)
+                    )
+                }
+            )
 
             # up_weight is sparse: only non-zero values are copied to each split
             i = 0
             for j in range(len(dims)):
-                target[diffusers_up_keys[j]] = up_weight[i: i + dims[j], j * diffusers_rank: (j + 1) * diffusers_rank].contiguous()
+                target[diffusers_up_keys[j]] = up_weight[
+                    i : i + dims[j], j * diffusers_rank : (j + 1) * diffusers_rank
+                ].contiguous()
                 i += dims[j]
 
     @staticmethod

--- a/src/mflux/weights/lora_util.py
+++ b/src/mflux/weights/lora_util.py
@@ -88,7 +88,7 @@ class LoraUtil:
                     if parentKey not in visited:
                         visited[parentKey] = {}
                     visited[parentKey][splitKey] = weight
-                    if not "weight" in target:
+                    if "weight" not in target:
                         raise ValueError(
                             f"LoRA weights for layer {parentKey} cannot be loaded into the model."
                         )

--- a/src/mflux/weights/lora_util.py
+++ b/src/mflux/weights/lora_util.py
@@ -6,34 +6,44 @@ log = logging.getLogger(__name__)
 
 
 class LoraUtil:
-
     @staticmethod
-    def apply_loras(transformer: dict, lora_files: list[str], lora_scales: list[float] | None = None) -> None:
+    def apply_loras(
+        transformer: dict, lora_files: list[str], lora_scales: list[float] | None = None
+    ) -> None:
         lora_scales = LoraUtil._validate_lora_scales(lora_files, lora_scales)
 
         for lora_file, lora_scale in zip(lora_files, lora_scales):
             LoraUtil._apply_lora(transformer, lora_file, lora_scale)
 
     @staticmethod
-    def _validate_lora_scales(lora_files: list[str], lora_scales: list[float]) -> list[float]:
+    def _validate_lora_scales(
+        lora_files: list[str], lora_scales: list[float]
+    ) -> list[float]:
         if len(lora_files) == 1:
             if not lora_scales:
                 lora_scales = [1.0]
             if len(lora_scales) > 1:
-                raise ValueError("Please provide a single scale for the LoRA, or skip it to default to 1")
+                raise ValueError(
+                    "Please provide a single scale for the LoRA, or skip it to default to 1"
+                )
         elif len(lora_files) > 1:
             if len(lora_files) != len(lora_scales):
-                raise ValueError("When providing multiple LoRAs, be sure to specify a scale for each one respectively")
+                raise ValueError(
+                    "When providing multiple LoRAs, be sure to specify a scale for each one respectively"
+                )
         return lora_scales
 
     @staticmethod
     def _apply_lora(transformer: dict, lora_file: str, lora_scale: float) -> None:
         from mflux.weights.weight_handler import WeightHandler
+
         lora_transformer, _ = WeightHandler.load_transformer(lora_path=lora_file)
         LoraUtil._apply_transformer(transformer, lora_transformer, lora_scale)
 
     @staticmethod
-    def _apply_transformer(transformer: dict, lora_transformer: dict, lora_scale: float) -> None:
+    def _apply_transformer(
+        transformer: dict, lora_transformer: dict, lora_scale: float
+    ) -> None:
         lora_weights = tree_flatten(lora_transformer)
         visited = {}
 
@@ -54,14 +64,18 @@ class LoraUtil:
                     visiting.append(splitKey)
                 else:
                     parentKey = ".".join(visiting)
-                    if parentKey in visited and 'lora_A' in visited[parentKey] and 'lora_B' in visited[parentKey]:
+                    if (
+                        parentKey in visited
+                        and "lora_A" in visited[parentKey]
+                        and "lora_B" in visited[parentKey]
+                    ):
                         continue
                     if not splitKey.startswith("lora_"):
                         visiting.append(splitKey)
                         parentKey = ".".join(visiting)
                         if splitKey == "net":
-                            target['net'] = list({})
-                            target = target['net']
+                            target["net"] = list({})
+                            target = target["net"]
                         elif splitKey == "0":
                             target.append({})
                             target = target[0]
@@ -74,11 +88,16 @@ class LoraUtil:
                     if parentKey not in visited:
                         visited[parentKey] = {}
                     visited[parentKey][splitKey] = weight
-                    if not 'weight' in target:
-                        raise ValueError(f"LoRA weights for layer {parentKey} cannot be loaded into the model.")
-                    if 'lora_A' in visited[parentKey] and 'lora_B' in visited[parentKey]:
-                        lora_a = visited[parentKey]['lora_A']
-                        lora_b = visited[parentKey]['lora_B']
-                        transWeight = target['weight']
+                    if not "weight" in target:
+                        raise ValueError(
+                            f"LoRA weights for layer {parentKey} cannot be loaded into the model."
+                        )
+                    if (
+                        "lora_A" in visited[parentKey]
+                        and "lora_B" in visited[parentKey]
+                    ):
+                        lora_a = visited[parentKey]["lora_A"]
+                        lora_b = visited[parentKey]["lora_B"]
+                        transWeight = target["weight"]
                         weight = transWeight + lora_scale * (lora_b @ lora_a)
-                        target['weight'] = weight
+                        target["weight"] = weight

--- a/src/mflux/weights/weight_handler.py
+++ b/src/mflux/weights/weight_handler.py
@@ -10,32 +10,41 @@ from mflux.weights.weight_util import WeightUtil
 
 
 class WeightHandler:
-
     def __init__(
-            self,
-            repo_id: str | None = None,
-            local_path: str | None = None,
-            lora_paths: list[str] | None = None,
-            lora_scales: list[float] | None = None,
+        self,
+        repo_id: str | None = None,
+        local_path: str | None = None,
+        lora_paths: list[str] | None = None,
+        lora_scales: list[float] | None = None,
     ):
-        root_path = Path(local_path) if local_path else WeightHandler._download_or_get_cached_weights(repo_id)
+        root_path = (
+            Path(local_path)
+            if local_path
+            else WeightHandler._download_or_get_cached_weights(repo_id)
+        )
 
         self.clip_encoder, _ = WeightHandler.load_clip_encoder(root_path=root_path)
         self.t5_encoder, _ = WeightHandler.load_t5_encoder(root_path=root_path)
         self.vae, _ = WeightHandler.load_vae(root_path=root_path)
-        self.transformer, self.quantization_level = WeightHandler.load_transformer(root_path=root_path)
+        self.transformer, self.quantization_level = WeightHandler.load_transformer(
+            root_path=root_path
+        )
 
         if lora_paths:
             LoraUtil.apply_loras(self.transformer, lora_paths, lora_scales)
 
     @staticmethod
     def load_clip_encoder(root_path: Path) -> (dict, int):
-        weights, quantization_level = WeightHandler._get_weights("text_encoder", root_path)
+        weights, quantization_level = WeightHandler._get_weights(
+            "text_encoder", root_path
+        )
         return weights, quantization_level
 
     @staticmethod
     def load_t5_encoder(root_path: Path) -> (dict, int):
-        weights, quantization_level = WeightHandler._get_weights("text_encoder_2", root_path)
+        weights, quantization_level = WeightHandler._get_weights(
+            "text_encoder_2", root_path
+        )
 
         # Quantized weights (i.e. ones exported from this project) don't need any post-processing.
         if quantization_level is not None:
@@ -53,19 +62,27 @@ class WeightHandler:
         weights["t5_blocks"] = weights["encoder"]["block"]
 
         # Only the first layer has the weights for "relative_attention_bias", we duplicate them here to keep code simple
-        relative_attention_bias = weights["t5_blocks"][0]["attention"]["SelfAttention"]["relative_attention_bias"]
+        relative_attention_bias = weights["t5_blocks"][0]["attention"]["SelfAttention"][
+            "relative_attention_bias"
+        ]
         for block in weights["t5_blocks"][1:]:
-            block["attention"]["SelfAttention"]["relative_attention_bias"] = relative_attention_bias
+            block["attention"]["SelfAttention"]["relative_attention_bias"] = (
+                relative_attention_bias
+            )
 
         weights.pop("encoder")
         return weights, quantization_level
 
     @staticmethod
-    def load_transformer(root_path: Path | None = None, lora_path: str | None = None) -> (dict, int):
-        weights, quantization_level = WeightHandler._get_weights("transformer", root_path, lora_path)
+    def load_transformer(
+        root_path: Path | None = None, lora_path: str | None = None
+    ) -> (dict, int):
+        weights, quantization_level = WeightHandler._get_weights(
+            "transformer", root_path, lora_path
+        )
 
         if lora_path:
-            if 'transformer' not in weights:
+            if "transformer" not in weights:
                 weights = LoRAConverter.load_weights(lora_path)
             weights = weights["transformer"]
 
@@ -79,12 +96,12 @@ class WeightHandler:
                 if block.get("ff") is not None:
                     block["ff"] = {
                         "linear1": block["ff"]["net"][0]["proj"],
-                        "linear2": block["ff"]["net"][2]
+                        "linear2": block["ff"]["net"][2],
                     }
                 if block.get("ff_context") is not None:
                     block["ff_context"] = {
                         "linear1": block["ff_context"]["net"][0]["proj"],
-                        "linear2": block["ff_context"]["net"][2]
+                        "linear2": block["ff_context"]["net"][2],
                     }
         return weights, quantization_level
 
@@ -97,22 +114,30 @@ class WeightHandler:
             return weights, quantization_level
 
         # Reshape and process the huggingface weights
-        weights['decoder']['conv_in'] = {'conv2d': weights['decoder']['conv_in']}
-        weights['decoder']['conv_out'] = {'conv2d': weights['decoder']['conv_out']}
-        weights['decoder']['conv_norm_out'] = {'norm': weights['decoder']['conv_norm_out']}
-        weights['encoder']['conv_in'] = {'conv2d': weights['encoder']['conv_in']}
-        weights['encoder']['conv_out'] = {'conv2d': weights['encoder']['conv_out']}
-        weights['encoder']['conv_norm_out'] = {'norm': weights['encoder']['conv_norm_out']}
+        weights["decoder"]["conv_in"] = {"conv2d": weights["decoder"]["conv_in"]}
+        weights["decoder"]["conv_out"] = {"conv2d": weights["decoder"]["conv_out"]}
+        weights["decoder"]["conv_norm_out"] = {
+            "norm": weights["decoder"]["conv_norm_out"]
+        }
+        weights["encoder"]["conv_in"] = {"conv2d": weights["encoder"]["conv_in"]}
+        weights["encoder"]["conv_out"] = {"conv2d": weights["encoder"]["conv_out"]}
+        weights["encoder"]["conv_norm_out"] = {
+            "norm": weights["encoder"]["conv_norm_out"]
+        }
         return weights, quantization_level
 
     @staticmethod
-    def _get_weights(model_name: str, root_path: Path | None = None, lora_path: str | None = None) -> (dict, int):
+    def _get_weights(
+        model_name: str, root_path: Path | None = None, lora_path: str | None = None
+    ) -> (dict, int):
         weights = []
         quantization_level = None
 
         if root_path is not None:
             for file in sorted(root_path.glob(model_name + "/*.safetensors")):
-                quantization_level = mx.load(str(file), return_metadata=True)[1].get("quantization_level")
+                quantization_level = mx.load(str(file), return_metadata=True)[1].get(
+                    "quantization_level"
+                )
                 weight = list(mx.load(str(file)).items())
                 weights.extend(weight)
 
@@ -140,6 +165,6 @@ class WeightHandler:
                     "text_encoder_2/*.safetensors",
                     "transformer/*.safetensors",
                     "vae/*.safetensors",
-                ]
+                ],
             )
         )

--- a/src/mflux/weights/weight_util.py
+++ b/src/mflux/weights/weight_util.py
@@ -2,7 +2,6 @@ from mflux.config.config import Config
 
 
 class WeightUtil:
-
     @staticmethod
     def flatten(params):
         return [(k, v) for p in params for (k, v) in p]


### PR DESCRIPTION
Following the `ruff format` and `ruff check` contributor proposal in #50, this would be the one time big patch to cleanse the repo state, from which point a pre-commit hook or a server-side CI check can be introduced to enforce future deviations.

If accepted, we should allow a few more ongoing PRs to merge to `main` first, then come back to this branch to `rebase` and do another catch up format/check.