### PR TITLE
dev ux: simplify import paths of frequently used items in scripts and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 Or, with the correct python environment active, create and run a separate script like the following:
 
 ```python
-from mflux.flux.flux import Flux1
-from mflux.config.config import Config
+from mflux import Flux1, Config
 
 # Load the model
 flux = Flux1.from_alias(

--- a/src/mflux/__init__.py
+++ b/src/mflux/__init__.py
@@ -1,5 +1,8 @@
-from mflux.flux.flux import Flux1
 from mflux.config.config import Config
+from mflux.config.config import ConfigControlnet
 from mflux.config.model_config import ModelConfig
+from mflux.controlnet.flux_controlnet import Flux1Controlnet
+from mflux.flux.flux import Flux1
+from mflux.post_processing.image_util import ImageUtil
 
-__all__ = ["Flux1", "Config", "ModelConfig"]
+__all__ = ["Flux1", "Flux1Controlnet", "Config", "ConfigControlnet", "ModelConfig", "ImageUtil"]

--- a/src/mflux/__init__.py
+++ b/src/mflux/__init__.py
@@ -1,0 +1,5 @@
+from mflux.flux.flux import Flux1
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+
+__all__ = ["Flux1", "Config", "ModelConfig"]

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -1,6 +1,4 @@
 import argparse
-import os
-import sys
 import time
 
 from mflux import Flux1, Config, ModelConfig

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -5,9 +5,7 @@ import time
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from mflux.config.model_config import ModelConfig
-from mflux.config.config import Config
-from mflux.flux.flux import Flux1
+from mflux import Flux1, Config, ModelConfig
 
 
 def main():

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -3,8 +3,6 @@ import os
 import sys
 import time
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from mflux import Flux1, Config, ModelConfig
 
 

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -1,14 +1,7 @@
 import argparse
-import os
-import sys
 import time
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from mflux.config.model_config import ModelConfig
-from mflux.config.config import ConfigControlnet
-from mflux.controlnet.flux_controlnet import Flux1Controlnet
-from mflux.post_processing.image_util import ImageUtil
+from mflux import Flux1Controlnet, ConfigControlnet, ModelConfig, ImageUtil
 
 
 def main():

--- a/src/mflux/save.py
+++ b/src/mflux/save.py
@@ -4,8 +4,7 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from mflux.flux.flux import Flux1
-from mflux.config.model_config import ModelConfig
+from mflux import Flux1, ModelConfig
 
 
 def main():

--- a/src/mflux/save.py
+++ b/src/mflux/save.py
@@ -2,8 +2,6 @@ import argparse
 import os
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from mflux import Flux1, ModelConfig
 
 

--- a/tests/test_readme_example.sh
+++ b/tests/test_readme_example.sh
@@ -1,0 +1,7 @@
+mflux-generate \
+    --prompt "Luxury food photograph" \
+    --model schnell \
+    --steps 2 \
+    --seed 2 \
+    --height 1024 \
+    --width 1024


### PR DESCRIPTION
I propose making common scripts/demos less verbose (i.e. developer onboarding), we can make the most commonly imported objects auto-imported at the top level of the package.

before

```py
from mflux.config.model_config import ModelConfig
from mflux.config.config import Config
from mflux.flux.flux import Flux1
```

after

```py
from mflux import Flux1, Config, ModelConfig
```

considerations:

- any package/module re-organizations in the future can be transparent to the user
- this is soft change, any pre-existing code that does the full path import will still work
- imports within the package implementation should still use full path imports following `explicit is better than implicit` value, as code at that level is meant for maintainers
- added a basic test that would exercise the `import`s via `generate.py`

-----

also taking opportunity to address the seemingly unnecessary (probably debug artifact from the past):

`os.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))`

is `src/mflux` and was being inserted as the first element of `sys.path`, which probably fixed an import path error in the past. I think this is a no-op removal.
