### PR TITLE
option to save stepwise and composite images, add interruptibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 *.json
 
 *.egg-info
+
+# build/ generated from 'pip install -e .' in developer mode
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ respect-gitignore = true
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["BLE", "E4", "E7", "E9", "F", "ICN", "LOG", "PERF", "W"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/src/mflux/__init__.py
+++ b/src/mflux/__init__.py
@@ -3,6 +3,7 @@ from mflux.config.config import ConfigControlnet
 from mflux.config.model_config import ModelConfig
 from mflux.controlnet.flux_controlnet import Flux1Controlnet
 from mflux.flux.flux import Flux1
+from mflux.exceptions import StopImageGenerationException
 from mflux.post_processing.image_util import ImageUtil
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "ConfigControlnet",
     "ModelConfig",
     "ImageUtil",
+    "StopImageGenerationException",
 ]

--- a/src/mflux/exceptions.py
+++ b/src/mflux/exceptions.py
@@ -1,0 +1,18 @@
+class MFluxException(Exception):
+    """base class for all custom exceptions in mflux package."""
+
+
+class ImageSavingException(MFluxException):
+    """error ocurred while attempting to save image to storage."""
+
+
+class MetadataEmbedException(MFluxException):
+    """error ocurred while attempting to embed metadata in image"""
+
+
+class MFluxUserException(MFluxException):
+    """an exception raised by user behavior or intention."""
+
+
+class StopImageGenerationException(MFluxUserException):
+    """user has requested to stop a image generation in progress."""

--- a/src/mflux/exceptions.py
+++ b/src/mflux/exceptions.py
@@ -3,11 +3,11 @@ class MFluxException(Exception):
 
 
 class ImageSavingException(MFluxException):
-    """error ocurred while attempting to save image to storage."""
+    """error occurred while attempting to save image to storage."""
 
 
 class MetadataEmbedException(MFluxException):
-    """error ocurred while attempting to embed metadata in image"""
+    """error occurred while attempting to embed metadata in image"""
 
 
 class MFluxUserException(MFluxException):

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -1,7 +1,8 @@
 import argparse
 import time
+from pathlib import Path
 
-from mflux import Flux1, Config, ModelConfig
+from mflux import Flux1, Config, ModelConfig, StopImageGenerationException
 
 
 def main():
@@ -14,6 +15,7 @@ def main():
     parser.add_argument("--height", type=int, default=1024, help="Image height (Default is 1024)")
     parser.add_argument("--width", type=int, default=1024, help="Image width (Default is 1024)")
     parser.add_argument("--steps", type=int, default=None, help="Inference Steps")
+    parser.add_argument('--stepwise-image-output-dir', type=str, default=None, help='Output dir to write step-wise images and their final composite image to.')
     parser.add_argument("--guidance", type=float, default=3.5, help="Guidance Scale (Default is 3.5)")
     parser.add_argument("--quantize",  "-q", type=int, choices=[4, 8], default=None, help="Quantize the model (4 or 8, Default is None)")
     parser.add_argument("--path", type=str, default=None, help="Local path for loading a model from disk")
@@ -39,20 +41,24 @@ def main():
         lora_scales=args.lora_scales,
     )
 
-    # Generate an image
-    image = flux.generate_image(
-        seed=int(time.time()) if args.seed is None else args.seed,
-        prompt=args.prompt,
-        config=Config(
-            num_inference_steps=args.steps,
-            height=args.height,
-            width=args.width,
-            guidance=args.guidance,
-        ),
-    )
+    try:
+        # Generate an image
+        image = flux.generate_image(
+            seed=int(time.time()) if args.seed is None else args.seed,
+            prompt=args.prompt,
+            config=Config(
+                num_inference_steps=args.steps,
+                height=args.height,
+                width=args.width,
+                guidance=args.guidance,
+            ),
+            stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
+        )
 
-    # Save the image
-    image.save(path=args.output, export_json_metadata=args.metadata)
+        # Save the image
+        image.save(path=args.output, export_json_metadata=args.metadata)
+    except StopImageGenerationException as stop_exc:
+        print(stop_exc)
 
 
 if __name__ == "__main__":

--- a/src/mflux/post_processing/generated_image.py
+++ b/src/mflux/post_processing/generated_image.py
@@ -1,5 +1,6 @@
 import importlib
-
+import pathlib
+import typing as t
 import PIL.Image
 import mlx.core as mx
 
@@ -37,7 +38,7 @@ class GeneratedImage:
         self.controlnet_image = controlnet_image_path
         self.controlnet_strength = controlnet_strength
 
-    def save(self, path: str, export_json_metadata: bool = False) -> None:
+    def save(self, path: t.Union[str, pathlib.Path], export_json_metadata: bool = False) -> None:
         from mflux import ImageUtil
 
         ImageUtil.save_image(self.image, path, self._get_metadata(), export_json_metadata)

--- a/src/mflux/post_processing/image_util.py
+++ b/src/mflux/post_processing/image_util.py
@@ -1,7 +1,7 @@
 import typing as t
 import json
 import logging
-from pathlib import Path
+import pathlib
 import PIL
 import PIL.Image
 import mlx.core as mx
@@ -47,6 +47,7 @@ class ImageUtil:
             controlnet_strength=config.controlnet_strength if isinstance(config.config, ConfigControlnet) else None,
         )
 
+    @staticmethod
     def to_composite_image(generated_images: t.List[GeneratedImage]) -> Image:
         # stitch horizontally
         total_width = sum(gen_img.image.width for gen_img in generated_images)
@@ -100,11 +101,11 @@ class ImageUtil:
     @staticmethod
     def save_image(
             image: PIL.Image.Image,
-            path: str,
+            path: t.Union[str, pathlib.Path],
             metadata: dict | None = None,
             export_json_metadata: bool = False
     ) -> None:  # fmt: off
-        file_path = Path(path)
+        file_path = pathlib.Path(path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_name = file_path.stem
         file_extension = file_path.suffix

--- a/tests/test_readme_example.sh
+++ b/tests/test_readme_example.sh
@@ -1,7 +1,39 @@
+#!/bin/zsh -e
+# ^ safe to assume Mac devs have zsh installed
+#   default since Catalina in 2019
+
+mkdir -p /tmp/mflux-test
+
 mflux-generate \
     --prompt "Luxury food photograph" \
     --model schnell \
     --steps 2 \
     --seed 2 \
-    --height 1024 \
-    --width 1024
+    --height 512 \
+    --width 512 \
+    --output /tmp/mflux-test/luxury_food.png
+
+# generate an image of a blue bird, then use it as input for the following test
+mflux-generate \
+    --prompt "blue bird, morning, spring" \
+    --model schnell \
+    --steps 2 \
+    --seed 24 \
+    --height 512 \
+    --width 512 \
+    --stepwise-image-output-dir /tmp/mflux-test \
+    --output /tmp/mflux-test/sf_blue_bird.png
+
+# use the image from the prior test, generate an image with similar visual structure
+mflux-generate-controlnet \
+    --prompt "yellow bird, afternoon, snowy mountain" \
+    --model schnell \
+    --controlnet-image-path /tmp/mflux-test/sf_blue_bird.png \
+    --controlnet-strength 0.7 \
+    --controlnet-save-canny \
+    --steps 2 \
+    --seed 42 \
+    --height 512 \
+    --width 512 \
+    --output /tmp/mflux-test/controlnet_sf_yellow_bird.png \
+    --stepwise-image-output-dir /tmp/mflux-test


### PR DESCRIPTION
This is my own original take on the objectives of #21 by user @madroidmaq, who wanted the stepwise images to be saved to disk. I commented in the PR that I'd like to see the objective completed.

In this PR, I am proposing:

1. make the generation flow more CLI `Ctrl-C` friendly during long generations, especially relevant with `dev` model and 10+ steps. This opens up the possibility that users can quit early if the early steps do not fit their expectations for any reason. (todo: a diff interrupt mechanism needs to be introduced for hypothetical GUI operations, TBD)
2. You can choose to output the stepwise images one by one as they become available, or wait for the end and a composite will be stitched together for you. The panel can help users evaluate diff time/quality tradeoffs in adjusting the steps parameter.
3. there is some duplication of structure and code in `src/mflux/flux/flux.py` vs `src/mflux/controlnet/flux_controlnet.py`, but in prior PRs I think @filipstrand you were okay with the (hopefully) temporary duplication, and now that we have a working baseline, we can use the tests to refactor forward (I can help, but it'll be a P2/P3 given things work well right now)

- [x] This is a PR that will need to be rebased on expected major formatting changes in other pending PRs.
