### PR TITLE
design discussion: generators yield

### DIFF
--- a/src/mflux/flux/flux.py
+++ b/src/mflux/flux/flux.py
@@ -80,6 +80,7 @@ class Flux1:
         prompt: str,
         config: Config = Config(),
         stepwise_output_dir: Path = None,
+        stepwise_yield: bool = False,
     ) -> GeneratedImage:
         # Create a new runtime config based on the model type and input parameters
         config = RuntimeConfig(config, self.model_config)
@@ -121,10 +122,12 @@ class Flux1:
                 latents += noise * dt
 
                 # Handle stepwise output if enabled
-                stepwise_handler.process_step(t, latents)
+                stepwise_output = stepwise_handler.process_step(t, latents)
 
                 # Evaluate to enable progress tracking
                 mx.eval(latents)
+                if stepwise_yield:
+                    yield stepwise_output
 
             except KeyboardInterrupt:
                 stepwise_handler.handle_interruption()

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -16,6 +16,7 @@ def main():
     parser.add_argument("--width", type=int, default=1024, help="Image width (Default is 1024)")
     parser.add_argument("--steps", type=int, default=None, help="Inference Steps")
     parser.add_argument('--stepwise-image-output-dir', type=str, default=None, help='[EXPERIMENTAL] Output dir to write step-wise images and their final composite image to. This feature may change in future versions.')
+    parser.add_argument('--resume-from-time-step', type=int, default=0, help='[EXPERIMENTAL] Resume from saved latents at this step.')
     parser.add_argument("--guidance", type=float, default=3.5, help="Guidance Scale (Default is 3.5)")
     parser.add_argument("--quantize",  "-q", type=int, choices=[4, 8], default=None, help="Quantize the model (4 or 8, Default is None)")
     parser.add_argument("--path", type=str, default=None, help="Local path for loading a model from disk")
@@ -42,11 +43,11 @@ def main():
     )
 
     try:
-        # Generate an image
-        image = flux.generate_image(
+        image_gen_steps = flux.generate_image(
             seed=int(time.time()) if args.seed is None else args.seed,
             prompt=args.prompt,
             stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
+            stepwise_yield=True,
             config=Config(
                 num_inference_steps=args.steps,
                 height=args.height,
@@ -54,12 +55,20 @@ def main():
                 guidance=args.guidance,
             ),
         )
-
-        # Save the image
+        while True:
+            stepwise_output = next(image_gen_steps)
+            print(f"Stepwise output: {stepwise_output}")
+    except StopIteration as e:
+        # Save the image returned after the stepwise iterations
+        image = e.value
+        print(f"Image Generator returned final image: {image}")
         image.save(path=args.output, export_json_metadata=args.metadata)
     except StopImageGenerationException as stop_exc:
         print(stop_exc)
 
 
 if __name__ == "__main__":
+    import logging
+
+    logging.setLevel(logging.INFO)
     main()

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -16,7 +16,6 @@ def main():
     parser.add_argument("--width", type=int, default=1024, help="Image width (Default is 1024)")
     parser.add_argument("--steps", type=int, default=None, help="Inference Steps")
     parser.add_argument('--stepwise-image-output-dir', type=str, default=None, help='[EXPERIMENTAL] Output dir to write step-wise images and their final composite image to. This feature may change in future versions.')
-    parser.add_argument('--resume-from-time-step', type=int, default=0, help='[EXPERIMENTAL] Resume from saved latents at this step.')
     parser.add_argument("--guidance", type=float, default=3.5, help="Guidance Scale (Default is 3.5)")
     parser.add_argument("--quantize",  "-q", type=int, choices=[4, 8], default=None, help="Quantize the model (4 or 8, Default is None)")
     parser.add_argument("--path", type=str, default=None, help="Local path for loading a model from disk")

--- a/src/mflux/post_processing/stepwise_handler.py
+++ b/src/mflux/post_processing/stepwise_handler.py
@@ -1,10 +1,22 @@
 from pathlib import Path
+from dataclasses import dataclass
 
 import mlx.core as mx
 
 from mflux.config.runtime_config import RuntimeConfig
 from mflux.post_processing.array_util import ArrayUtil
+from mflux.post_processing.generated_image import GeneratedImage
 from mflux.post_processing.image_util import ImageUtil
+
+
+@dataclass
+class StepwiseOutput:
+    image: GeneratedImage
+    image_path: Path
+    time_step: int
+
+    def __str__(self):
+        return f"Stepwise output: time_step={self.time_step} image_path={self.image_path}"
 
 
 class StepwiseHandler:
@@ -45,9 +57,10 @@ class StepwiseHandler:
             self.step_wise_images.append(stepwise_img)
 
             stepwise_img.save(
-                path=self.output_dir / f"seed_{self.seed}_step{step + 1}of{len(self.time_steps)}.png",
+                path=(image_path := self.output_dir / f"seed_{self.seed}_step{step + 1}of{len(self.time_steps)}.png"),
                 export_json_metadata=False,
             )
+            return StepwiseOutput(image=stepwise_img, image_path=image_path, time_step=step)
 
     def handle_interruption(self):
         if self.step_wise_images:


### PR DESCRIPTION
For now, just draft PR to discuss potential interface change with @filipstrand 

# Motivation

- I want to create CLI and UI interfaces that generate many images at once
- However, due to limited compute for target users, generating one image to finish takes too long when user wants to iterate over e.g. N seeds or N prompt variations without waiting for one image to finish at a time

# Proposed Change

I don't like to break existing interfaces, or introduce complexity, so this proposal is an option that does not break existing docs, but does introduce behavior developers need to know (when to use it like a iterator, when to use it like a normal function)

Future work this enables:

- a different CLI e.g. `mflux-generate-many --attempts 5` or `mflux-generate-many --seeds 1 2 3 4 5` or `mflux-generate-prompts --prompt-file <some file in some format>`
- for now, I hijack the existing `mflux-generate` to demo the proposed iterator behavior - I would isolate the "create-many" behavior into a new script in the final implementation.
