### PR TITLE
support HF models - freepik as first example

### DIFF
--- a/src/mflux/config/model_config.py
+++ b/src/mflux/config/model_config.py
@@ -2,8 +2,12 @@ from enum import Enum
 
 
 class ModelConfig(Enum):
+    # ==== black-forest-labs official models =====
     FLUX1_DEV = ("black-forest-labs/FLUX.1-dev", "dev", 1000, 512)
     FLUX1_SCHNELL = ("black-forest-labs/FLUX.1-schnell", "schnell", 1000, 256)
+    # ==== third party compatible models - best effort compatibility =====
+    # https://huggingface.co/Freepik/flux.1-lite-8B-alpha distilled from dev
+    FLUX1_FREEPIK_LITE_8B_ALPHA = ("Freepik/flux.1-lite-8B-alpha", "freepik-lite-8b-alpha", 1000, 512)
 
     def __init__(
         self,

--- a/src/mflux/ui/defaults.py
+++ b/src/mflux/ui/defaults.py
@@ -2,9 +2,10 @@ CONTROLNET_STRENGTH = 0.4
 GUIDANCE_SCALE = 3.5
 HEIGHT, WIDTH = 1024, 1024
 INIT_IMAGE_STRENGTH = 0.4  # for image-to-image init_image
-MODEL_CHOICES = ["dev", "schnell"]
+MODEL_CHOICES = ["dev", "schnell", "freepik-lite-8b-alpha"]
 MODEL_INFERENCE_STEPS = {
     "dev": 14,
     "schnell": 4,
+    "freepik-lite-8b-alpha": 22,
 }
 QUANTIZE_CHOICES = [4, 8]


### PR DESCRIPTION
### Change

I nominate that we support compatible and trending 3rd party models based on:

1. curation for quality and reputation
2. compatibility

The first model to meet this criteria for me is: https://huggingface.co/Freepik/flux.1-lite-8B-alpha - it's a distilled version of flux.1 dev, read more at the link.

the claim:

> Flux.1 Lite, an 8B parameter transformer model distilled from the FLUX.1-dev model. This version uses 7 GB less RAM and runs 23% faster while maintaining the same precision (bfloat16) as the original model.

### Tradeoffs

the model configs are hard-coded for now, to hypothetically let anyone choose any huggingface-hosted model is possible but requires some config refactoring, but also invites anyone to attempt an incompatible model and creating Issues tracker noise

For now, I think this can make some users happy (those with less RAM) while mflux can be seen as inclusive of third party releases.
