### PR TITLE
Issue #74 - python 3.13 pip install now working

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ uv tool install --upgrade mflux
 to get the `mflux-generate` and related command line executables. You can skip to the usage guides below.
 
 <details>
+<summary>For Python 3.13 dev preview</summary>
+```sh
+uv venv --python 3.13
+python -V  # e.g. Python 3.13.0rc2
+source .venv/bin/activate
+uv pip install --pre --extra-index-url https://download.pytorch.org/whl/nightly -e .
+```
+</details>
+
+<details>
 <summary>For the classic way to create a user virtual environment:</summary>
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,18 @@ to get the `mflux-generate` and related command line executables. You can skip t
 
 <details>
 <summary>For Python 3.13 dev preview</summary>
+
+The [T5 encoder](https://huggingface.co/docs/transformers/en/model_doc/t5) is dependent on [sentencepiece](https://pypi.org/project/sentencepiece/), which does not have a installable wheel artifact for Python 3.13 as of Nov 2024. Until Google [publishes a 3.13 wheel](https://pypi.org/project/sentencepiece/), you need to build your own wheel with [official build instructions](https://github.com/google/sentencepiece/blob/master/python/README.md#build-and-install-sentencepiece) or for your convenience use a `.whl` pre-built by contributor @anthonywu. The steps below should work for most developers though your system may vary.
+
 ```sh
 uv venv --python 3.13
 python -V  # e.g. Python 3.13.0rc2
 source .venv/bin/activate
+
+# for your convenience, you can use the contributor wheel
+uv pip install https://github.com/anthonywu/sentencepiece/releases/download/0.2.1-py13dev/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl
+
+# enable the pytorch nightly 
 uv pip install --pre --extra-index-url https://download.pytorch.org/whl/nightly -e .
 ```
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,18 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "huggingface-hub>=0.24.5,<1.0",
-    "mlx>=0.16.0,<1.0",
+    "mlx>=0.20.0,<1.0",
     "numpy>=2.0.1,<3.0",
     "opencv-python>=4.10.0,<5.0",
     "piexif>=1.1.3,<2.0",
-    "pillow>=10.4.0,<11.0",
+    "pillow>=10.4.0,<11.0; python_version<'3.13'",
+    "pillow>=11.0,<12.0; python_version>='3.13'",
     "safetensors>=0.4.4,<1.0",
-    "sentencepiece>=0.2.0,<1.0",
-    "torch>=2.3.1,<3.0",
+    "sentencepiece>=0.2.0,<1.0; python_version<'3.13'",
+    "tokenizers>=0.20.3; python_version>='3.13'",  # transformers -> tokenizers
+    "torch>=2.3.1,<3.0; python_version<'3.13'",
+    # torch dev builds: pip install --pre --index-url https://download.pytorch.org/whl/nightly
+    "torch>=2.6.0.dev20241106; python_version>='3.13'",
     "tqdm>=4.66.5,<5.0",
     "transformers>=4.44.0,<5.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pillow>=10.4.0,<11.0; python_version<'3.13'",
     "pillow>=11.0,<12.0; python_version>='3.13'",
     "safetensors>=0.4.4,<1.0",
+    # python 3.13 workaround for now:
+    # use temporary community build of py13 wheel, use until official project build
+    # uv pip install https://github.com/anthonywu/sentencepiece/releases/download/0.2.1-py13dev/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl
     "sentencepiece>=0.2.0,<1.0; python_version<'3.13'",
     "tokenizers>=0.20.3; python_version>='3.13'",  # transformers -> tokenizers
     "torch>=2.3.1,<3.0; python_version<'3.13'",


### PR DESCRIPTION
This moves forward Issue #74. For devs or early adopters who want to use Python 3.13 to install mflux from repo, this unblocks.

# test

```sh
$ uv tool install --python 3.13 git+https://github.com/anthonywu/mflux.git@py13-dev-working
 Updated https://github.com/anthonywu/mflux.git (391d29f)
Resolved 29 packages in 79ms
   Built mflux @ git+https://github.com/anthonywu/mflux.git@391d29fe4fc06b89d7caf690d37a47a2fc17b08e
Prepared 1 package in 819ms
Installed 1 package in 3ms
 + mflux==0.4.1 (from git+https://github.com/anthonywu/mflux.git@391d29fe4fc06b89d7caf690d37a47a2fc17b08e)
Installed 3 executables: mflux-generate, mflux-generate-controlnet, mflux-save
```