### PR TITLE
release 0.6.0 – comprehensive ModelConfig refactor to support compatible HuggingFace dev/schnell models

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ from mflux import Flux1, Config
 
 # Load the model
 flux = Flux1.from_name(
-   alias="schnell",  # "schnell" or "dev"
-   quantize=8,       # 4 or 8
+   model_name="schnell",  # "schnell" or "dev"
+   quantize=8,            # 4 or 8
 )
 
 # Generate an image

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Or, with the correct python environment active, create and run a separate script
 from mflux import Flux1, Config
 
 # Load the model
-flux = Flux1.from_alias(
+flux = Flux1.from_name(
    alias="schnell",  # "schnell" or "dev"
    quantize=8,       # 4 or 8
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mflux"
-version = "0.5.1"
+version = "0.6.0"
 description = "A MLX port of FLUX based on the Huggingface Diffusers implementation."
 readme = "README.md"
 keywords = ["diffusers", "flux", "mlx"]

--- a/src/mflux/__init__.py
+++ b/src/mflux/__init__.py
@@ -1,5 +1,5 @@
 from mflux.config.config import Config, ConfigControlnet
-from mflux.config.model_config import ModelConfig
+from mflux.config.model_config import ModelConfig, ModelLookup
 from mflux.controlnet.flux_controlnet import Flux1Controlnet
 from mflux.error.exceptions import StopImageGenerationException
 from mflux.flux.flux import Flux1
@@ -11,6 +11,7 @@ __all__ = [
     "Config",
     "ConfigControlnet",
     "ModelConfig",
+    "ModelLookup",
     "ImageUtil",
     "StopImageGenerationException",
 ]

--- a/src/mflux/config/model_config.py
+++ b/src/mflux/config/model_config.py
@@ -1,27 +1,98 @@
-from enum import Enum
+from dataclasses import dataclass
+from typing import Literal
+
+DEFAULT_TRAIN_STEPS = 1000
+
+KNOWN_SEQUENCE_LENGTH_BY_BASE_MODEL = {"dev": 512, "schnell": 256}
 
 
-class ModelConfig(Enum):
-    FLUX1_DEV = ("black-forest-labs/FLUX.1-dev", "dev", 1000, 512)
-    FLUX1_SCHNELL = ("black-forest-labs/FLUX.1-schnell", "schnell", 1000, 256)
+class ModelConfigError(ValueError):
+    """User error in model config."""
 
-    def __init__(
-        self,
-        model_name: str,
-        alias: str,
-        num_train_steps: int,
-        max_sequence_length: int,
-    ):
-        self.alias = alias
-        self.model_name = model_name
-        self.num_train_steps = num_train_steps
-        self.max_sequence_length = max_sequence_length
 
+class InvalidBaseModel(ModelConfigError):
+    """Invalid base model, cannot infer model properties."""
+
+
+@dataclass
+class ModelConfig:
+    model_name: str
+    num_train_steps: int
+    max_sequence_length: int
+    supports_guidance: bool
+    base_model: str | None
+
+    @property
+    def alias(self):
+        # maintain compatibility with < 0.4.0 behavior
+        # where alias is the name of an official model
+        if self.model_name.startswith("black-forest-labs/FLUX.1-"):
+            return self.model_name[len("black-forest-labs/FLUX.1-") :].lower()
+        return None
+
+
+DefaultModelConfigs = {
+    "dev": ModelConfig(
+        model_name="black-forest-labs/FLUX.1-dev",
+        num_train_steps=DEFAULT_TRAIN_STEPS,
+        max_sequence_length=KNOWN_SEQUENCE_LENGTH_BY_BASE_MODEL["dev"],
+        supports_guidance=True,
+        base_model=None,
+    ),
+    "schnell": ModelConfig(
+        model_name="black-forest-labs/FLUX.1-schnell",
+        num_train_steps=DEFAULT_TRAIN_STEPS,
+        max_sequence_length=KNOWN_SEQUENCE_LENGTH_BY_BASE_MODEL["schnell"],
+        supports_guidance=False,
+        base_model=None,
+    ),
+}
+
+
+class ModelLookup:
     @staticmethod
-    def from_alias(alias: str) -> "ModelConfig":
-        try:
-            for model in ModelConfig:
-                if model.alias == alias:
-                    return model
-        except KeyError:
-            raise ValueError(f"'{alias}' is not a valid model")
+    def from_name(
+        alias: str,
+        base_model: Literal["dev", "schnell"] | None = None,
+    ) -> ModelConfig:
+        if alias in DefaultModelConfigs:
+            return DefaultModelConfigs[alias]
+
+        if all(["dev" not in alias, "schnell" not in alias, base_model is None]):
+            raise ModelConfigError(
+                "Cannot infer base model and max_sequence_length "
+                f"from model reference: {alias!r}. "
+                "Please specify --base-model [dev | schnell]"
+            )
+
+        if base_model is not None and base_model not in ["dev", "schnell"]:
+            raise InvalidBaseModel("As of this version, mflux only recognizes base models dev or schnell")
+
+        if base_model is None:
+            # infer base model on apparent model namming
+            if "dev" in alias:
+                base_model = "dev"
+            elif "schnell" in alias:
+                base_model = "schnell"
+
+        if base_model == "dev":
+            supports_guidance = True
+            max_sequence_length = KNOWN_SEQUENCE_LENGTH_BY_BASE_MODEL["dev"]
+        elif base_model == "schnell":
+            supports_guidance = False
+            max_sequence_length = KNOWN_SEQUENCE_LENGTH_BY_BASE_MODEL["schnell"]
+
+        return ModelConfig(
+            alias,  # actually this arg is model_name
+            DEFAULT_TRAIN_STEPS,
+            max_sequence_length,
+            supports_guidance,
+            base_model,
+        )
+
+
+# maintain old `ModelConfig.from_alias` function name for backwards compatibility in user code and docs
+ModelConfig.from_alias = ModelLookup.from_name
+# keep these class members to be backwards compatible with < 0.5.0 ModelConfig Enum implementation
+ModelConfig.FLUX1_DEV = DefaultModelConfigs["dev"]
+ModelConfig.FLUX1_SCHNELL = DefaultModelConfigs["schnell"]

--- a/src/mflux/config/model_config.py
+++ b/src/mflux/config/model_config.py
@@ -46,7 +46,7 @@ class ModelLookup:
     @staticmethod
     def from_alias(alias: str) -> ModelConfig:
         warnings.warn(
-            "from_alias is deprecated and will be removed in a future release. " "Please use from_name instead.",
+            "from_alias is deprecated and will be removed in a future release. Please use from_name instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/mflux/flux/flux.py
+++ b/src/mflux/flux/flux.py
@@ -139,7 +139,7 @@ class Flux1(nn.Module):
     @staticmethod
     def from_alias(alias: str, quantize: int | None = None) -> "Flux1":
         warnings.warn(
-            "from_alias is deprecated and will be removed in a future release. " "Please use from_name instead.",
+            "from_alias is deprecated and will be removed in a future release. Please use from_name instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/mflux/flux/flux.py
+++ b/src/mflux/flux/flux.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import mlx.core as mx
@@ -136,14 +137,20 @@ class Flux1(nn.Module):
         )
 
     @staticmethod
+    def from_alias(alias: str, quantize: int | None = None) -> "Flux1":
+        warnings.warn(
+            "from_alias is deprecated and will be removed in a future release. " "Please use from_name instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Flux1.from_name(model_name=alias, quantize=quantize)
+
+    @staticmethod
     def from_name(model_name: str, quantize: int | None = None) -> "Flux1":
         return Flux1(
-            model_config=ModelLookup.from_name(model_name),
+            model_config=ModelLookup.from_name(model_name=model_name, base_model=None),
             quantize=quantize,
         )
-
-    # maintain old `from_alias` function name for backwards compatibility in user code and docs
-    from_alias = from_name
 
     def save_model(self, base_path: str) -> None:
         ModelSaver.save_model(self, self.bits, base_path)

--- a/src/mflux/flux/flux.py
+++ b/src/mflux/flux/flux.py
@@ -5,7 +5,7 @@ from mlx import nn
 from tqdm import tqdm
 
 from mflux.config.config import Config
-from mflux.config.model_config import ModelConfig
+from mflux.config.model_config import ModelConfig, ModelLookup
 from mflux.config.runtime_config import RuntimeConfig
 from mflux.error.exceptions import StopImageGenerationException
 from mflux.latent_creator.latent_creator import LatentCreator
@@ -136,11 +136,14 @@ class Flux1(nn.Module):
         )
 
     @staticmethod
-    def from_alias(alias: str, quantize: int | None = None) -> "Flux1":
+    def from_name(model_name: str, quantize: int | None = None) -> "Flux1":
         return Flux1(
-            model_config=ModelConfig.from_alias(alias),
+            model_config=ModelLookup.from_name(model_name),
             quantize=quantize,
         )
+
+    # maintain old `from_alias` function name for backwards compatibility in user code and docs
+    from_alias = from_name
 
     def save_model(self, base_path: str) -> None:
         ModelSaver.save_model(self, self.bits, base_path)

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -17,7 +17,7 @@ def main():
 
     # Load the model
     flux = Flux1(
-        model_config=ModelLookup.from_name(args.model, base_model=args.base_model),
+        model_config=ModelLookup.from_name(model_name=args.model, base_model=args.base_model),
         quantize=args.quantize,
         local_path=args.path,
         lora_paths=args.lora_paths,

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -1,7 +1,7 @@
 import time
 from pathlib import Path
 
-from mflux import Config, Flux1, ModelConfig, StopImageGenerationException
+from mflux import Config, Flux1, ModelLookup, StopImageGenerationException
 from mflux.ui.cli.parsers import CommandLineParser
 
 
@@ -17,7 +17,7 @@ def main():
 
     # Load the model
     flux = Flux1(
-        model_config=ModelConfig.from_alias(args.model),
+        model_config=ModelLookup.from_name(args.model, base_model=args.base_model),
         quantize=args.quantize,
         local_path=args.path,
         lora_paths=args.lora_paths,

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -1,7 +1,7 @@
 import time
 from pathlib import Path
 
-from mflux import ConfigControlnet, Flux1Controlnet, ModelConfig, StopImageGenerationException
+from mflux import ConfigControlnet, Flux1Controlnet, ModelLookup, StopImageGenerationException
 from mflux.ui.cli.parsers import CommandLineParser
 
 
@@ -16,7 +16,7 @@ def main():
 
     # Load the model
     flux = Flux1Controlnet(
-        model_config=ModelConfig.from_alias(args.model),
+        model_config=ModelLookup.from_name(args.model, base_model=args.base_model),
         quantize=args.quantize,
         local_path=args.path,
         lora_paths=args.lora_paths,

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -16,7 +16,7 @@ def main():
 
     # Load the model
     flux = Flux1Controlnet(
-        model_config=ModelLookup.from_name(args.model, base_model=args.base_model),
+        model_config=ModelLookup.from_name(model_name=args.model, base_model=args.base_model),
         quantize=args.quantize,
         local_path=args.path,
         lora_paths=args.lora_paths,

--- a/src/mflux/models/transformer/time_text_embed.py
+++ b/src/mflux/models/transformer/time_text_embed.py
@@ -14,7 +14,7 @@ class TimeTextEmbed(nn.Module):
     def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.text_embedder = TextEmbedder()
-        self.guidance_embedder = GuidanceEmbedder() if model_config == ModelConfig.FLUX1_DEV else None
+        self.guidance_embedder = GuidanceEmbedder() if model_config.supports_guidance else None
         self.timestep_embedder = TimestepEmbedder()
 
     def __call__(

--- a/src/mflux/post_processing/generated_image.py
+++ b/src/mflux/post_processing/generated_image.py
@@ -57,9 +57,7 @@ class GeneratedImage:
             # mflux_version is used by future metadata readers
             # to determine supportability of metadata-derived workflows
             "mflux_version": GeneratedImage.get_version(),
-            "model": str(self.model_config.alias)
-            if self.model_config.alias is not None
-            else self.model_config.model_name,
+            "model": self.model_config.model_name,
             "base_model": str(self.model_config.base_model),
             "seed": self.seed,
             "steps": self.steps,

--- a/src/mflux/post_processing/generated_image.py
+++ b/src/mflux/post_processing/generated_image.py
@@ -57,10 +57,13 @@ class GeneratedImage:
             # mflux_version is used by future metadata readers
             # to determine supportability of metadata-derived workflows
             "mflux_version": GeneratedImage.get_version(),
-            "model": str(self.model_config.alias),
+            "model": str(self.model_config.alias)
+            if self.model_config.alias is not None
+            else self.model_config.model_name,
+            "base_model": str(self.model_config.base_model),
             "seed": self.seed,
             "steps": self.steps,
-            "guidance": self.guidance if ModelConfig.FLUX1_DEV else None,  # only the dev model supports guidance
+            "guidance": self.guidance if self.model_config.supports_guidance else None,
             "precision": str(self.precision),
             "quantize": self.quantization,
             "generation_time_seconds": round(self.generation_time, 2),

--- a/src/mflux/save.py
+++ b/src/mflux/save.py
@@ -1,4 +1,4 @@
-from mflux import Flux1, ModelConfig
+from mflux import Flux1, ModelLookup
 from mflux.ui.cli.parsers import CommandLineParser
 
 
@@ -11,7 +11,7 @@ def main():
     print(f"Saving model {args.model} with quantization level {args.quantize}\n")
 
     flux = Flux1(
-        model_config=ModelConfig.from_alias(args.model),
+        model_config=ModelLookup.from_name(args.model, base_model=args.base_model),
         quantize=args.quantize,
         lora_paths=args.lora_paths,
         lora_scales=args.lora_scales,

--- a/tests/arg_parser/test_cli_argparser.py
+++ b/tests/arg_parser/test_cli_argparser.py
@@ -93,10 +93,12 @@ def test_model_arg_not_in_file(mflux_generate_parser, mflux_generate_minimal_arg
     with patch('sys.argv', mflux_generate_minimal_argv + ['--model', 'dev', '--config-from-metadata', metadata_file.as_posix()]):  # fmt: off
         args = mflux_generate_parser.parse_args()
         assert args.model == "dev"
+        assert args.base_model is None
     # test value read from flag
     with patch('sys.argv', mflux_generate_minimal_argv + ['--model', 'schnell', '--config-from-metadata', metadata_file.as_posix()]):  # fmt: off
         args = mflux_generate_parser.parse_args()
         assert args.model == "schnell"
+        assert args.base_model is None
 
 
 def test_model_arg_in_file(mflux_generate_parser, mflux_generate_minimal_argv, base_metadata_dict, temp_dir):
@@ -112,6 +114,25 @@ def test_model_arg_in_file(mflux_generate_parser, mflux_generate_minimal_argv, b
     with patch('sys.argv', mflux_generate_minimal_argv + ['--model', 'schnell', '--config-from-metadata', metadata_file.as_posix()]):  # fmt: off
         args = mflux_generate_parser.parse_args()
         assert args.model == "schnell"
+
+
+def test_base_model_arg_in_file(mflux_generate_parser, mflux_generate_minimal_argv, base_metadata_dict, temp_dir):
+    metadata_file = temp_dir / "model.json"
+    with metadata_file.open("wt") as m:
+        base_metadata_dict["model"] = "some-lab/some-model"
+        base_metadata_dict["base_model"] = "dev"
+        json.dump(base_metadata_dict, m, indent=4)
+    # test value read from file
+    with patch('sys.argv', mflux_generate_minimal_argv + ['--config-from-metadata', metadata_file.as_posix()]):  # fmt: off
+        args = mflux_generate_parser.parse_args()
+        assert args.model == "some-lab/some-model"
+        assert args.base_model == "dev"
+    # test value read from flag, overrides value from file
+    with patch('sys.argv', mflux_generate_minimal_argv + ['--base-model', 'schnell', '--config-from-metadata', metadata_file.as_posix()]):  # fmt: off
+        args = mflux_generate_parser.parse_args()
+        assert args.model == "some-lab/some-model"
+        # override metadata base model with CLI --base-model
+        assert args.base_model == "schnell"
 
 
 def test_prompt_arg(mflux_generate_parser, mflux_generate_minimal_argv, base_metadata_dict, temp_dir):

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,68 @@
+import pytest
+
+from mflux.config.model_config import InvalidBaseModel, ModelConfig, ModelConfigError, ModelLookup
+
+
+def test_from_alias_function_redirect():
+    # backwards compatibility for when user follows older docs
+    # but is using a newer mflux version >= 0.5
+    assert ModelConfig.from_alias == ModelLookup.from_name
+
+
+def test_model_config_class_members_and_alias():
+    # these FLUX1_* class members and the alias attribute
+    # existed as members of ModelConfig when it was an Enum
+    # keep them around for backwards compatibility
+    assert ModelConfig.FLUX1_DEV.alias == "dev"
+    assert ModelConfig.FLUX1_SCHNELL.alias == "schnell"
+
+
+def test_bfl_dev():
+    model_attrs = ModelLookup.from_name("dev")
+    assert model_attrs.model_name.startswith("black-forest-labs/")
+    assert model_attrs.max_sequence_length == 512
+    assert model_attrs.supports_guidance is True
+
+
+def test_bfl_schnell():
+    model_attrs = ModelLookup.from_name("schnell")
+    assert model_attrs.model_name.startswith("black-forest-labs/")
+    assert model_attrs.max_sequence_length == 256
+    assert model_attrs.supports_guidance is False
+
+
+def test_community_dev_implicit_base_model():
+    model_attrs = ModelLookup.from_name("acme-lab/some-awesome-dev-model")
+    assert model_attrs.max_sequence_length == 512
+    assert model_attrs.supports_guidance is True
+
+
+def test_community_schnell_implicit_base_model():
+    model_attrs = ModelLookup.from_name("acme-lab/some-quick-schnell-model")
+    assert model_attrs.max_sequence_length == 256
+    assert model_attrs.supports_guidance is False
+
+
+def test_community_dev_explicit_base_model():
+    model_attrs = ModelLookup.from_name("acme-lab/some-awesome-model", base_model="dev")
+    assert model_attrs.max_sequence_length == 512
+    assert model_attrs.supports_guidance is True
+
+
+def test_community_schnell_explicit_base_model():
+    model_attrs = ModelLookup.from_name("acme-lab/some-awesome-model", base_model="schnell")
+    assert model_attrs.max_sequence_length == 256
+    assert model_attrs.supports_guidance is False
+
+
+def test_model_config_error():
+    assert pytest.raises(ModelConfigError, ModelLookup.from_name, "acme-lab/some-model-who-knows-what-its-based-on")
+
+
+def test_invalid_base_model_error():
+    assert pytest.raises(
+        InvalidBaseModel,
+        ModelLookup.from_name,
+        "acme-lab/some-model-who-knows-what-its-based-on",
+        base_model="something_unknown",
+    )

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,20 +1,6 @@
 import pytest
 
-from mflux.config.model_config import InvalidBaseModel, ModelConfig, ModelConfigError, ModelLookup
-
-
-def test_from_alias_function_redirect():
-    # backwards compatibility for when user follows older docs
-    # but is using a newer mflux version >= 0.5
-    assert ModelConfig.from_alias == ModelLookup.from_name
-
-
-def test_model_config_class_members_and_alias():
-    # these FLUX1_* class members and the alias attribute
-    # existed as members of ModelConfig when it was an Enum
-    # keep them around for backwards compatibility
-    assert ModelConfig.FLUX1_DEV.alias == "dev"
-    assert ModelConfig.FLUX1_SCHNELL.alias == "schnell"
+from mflux.config.model_config import InvalidBaseModel, ModelConfigError, ModelLookup
 
 
 def test_bfl_dev():
@@ -24,8 +10,22 @@ def test_bfl_dev():
     assert model_attrs.supports_guidance is True
 
 
+def test_bfl_dev_from_alias():
+    model_attrs = ModelLookup.from_alias("dev")
+    assert model_attrs.model_name.startswith("black-forest-labs/")
+    assert model_attrs.max_sequence_length == 512
+    assert model_attrs.supports_guidance is True
+
+
 def test_bfl_schnell():
     model_attrs = ModelLookup.from_name("schnell")
+    assert model_attrs.model_name.startswith("black-forest-labs/")
+    assert model_attrs.max_sequence_length == 256
+    assert model_attrs.supports_guidance is False
+
+
+def test_bfl_schnell_from_alias():
+    model_attrs = ModelLookup.from_alias("schnell")
     assert model_attrs.model_name.startswith("black-forest-labs/")
     assert model_attrs.max_sequence_length == 256
     assert model_attrs.supports_guidance is False


### PR DESCRIPTION
## change

1. a re-attempt of #84 but this time I don't have to explicitly endorse any org (i.e. Freepik or Shuttle) It should reduce expectation that the maintainers actually support the models, and eliminate future asks to support yet-another pre-config.
2. support issues like #102 (let users go ahead and test any HF model, as long as they bring the `--base-model` arg when needed
3. re-establish model config before going into #101 to support the Flux.1 Tools

## goals

1. keep the prior behavior as-is and pass existing tests and add backwards compatibility test cases
2. maintainers can continue to add the default configs list
3. early adopters can get readme/issues-level hints on how to use reportedly-compatible models

## demo: shuttle-3

https://huggingface.co/shuttleai/shuttle-3-diffusion

```sh
# didn't expect this to work, given shuttle-3 derives from schnell 
mflux-generate \
  --seed 42 \
  --base-model dev \
  --model shuttleai/shuttle-3-diffusion \
  --steps 4 \
  --prompt "A cat holding a sign that says hello world"
```
![image](https://github.com/user-attachments/assets/e829e507-8058-4553-a183-17c1ad6f1aa0)

now, running as schnell, actually looks... better??

```sh
# same as above but with schnell
mflux-generate \
  --seed 42 \
  --base-model schnell \ 
  --model shuttleai/shuttle-3-diffusion \
  --steps 4 \
  --prompt "A cat holding a sign that says hello world"
```

![image](https://github.com/user-attachments/assets/8dcc8fe6-5659-49e9-9b32-6ca5d07cc3f3)

### performance

- M1 Max 64GB, ~24s/step, 4 steps ~= 1m38s runtime

## demo: Freepik

https://huggingface.co/Freepik/flux.1-lite-8B-alpha

```sh
mflux-generate --base-model dev --steps 22 --model Freepik/flux.1-lite-8B-alpha --prompt "A cat holding a sign that says hello world"
```

![image](https://github.com/user-attachments/assets/c0ec24f1-0ca7-4094-9fe6-c5ab4e60ccd2)
