### PR TITLE
Inversion

### DIFF
--- a/src/mflux/config/runtime_config.py
+++ b/src/mflux/config/runtime_config.py
@@ -53,7 +53,7 @@ class RuntimeConfig:
 
     @property
     def init_time_step(self) -> int:
-        is_txt2img = self.config.init_image_path is None or self.config.init_image_strength == 0.0
+        is_txt2img = True
 
         if is_txt2img:
             return 0

--- a/src/mflux/flux/v_cache.py
+++ b/src/mflux/flux/v_cache.py
@@ -1,0 +1,18 @@
+import mlx.core as mx
+import numpy as np
+
+
+class VCache:
+    is_inverting = True
+    v_cache = {}
+    t_max = 5
+
+    @staticmethod
+    def save_dict(data_dict, filename):
+        np_dict = {k: v.tolist() for k, v in data_dict.items()}
+        np.savez_compressed(filename, **np_dict)
+
+    @staticmethod
+    def load_dict(filename):
+        data = np.load(filename)
+        return {k: mx.array(v) for k, v in data.items()}

--- a/src/mflux/latent_creator/latent_creator.py
+++ b/src/mflux/latent_creator/latent_creator.py
@@ -57,13 +57,7 @@ class LatentCreator:
             )
 
             # 2. Encode the image
-            scaled_user_image = ImageUtil.scale_to_dimensions(
-                image=ImageUtil.load_image(img2img.init_image_path).convert("RGB"),
-                target_width=width,
-                target_height=height,
-            )
-            encoded = img2img.vae.encode(ImageUtil.to_array(scaled_user_image))
-            latents = ArrayUtil.pack_latents(latents=encoded, height=height, width=width)
+            latents = LatentCreator.encode_image(height=height, width=width, img2img=img2img)
 
             # 3. Find the appropriate sigma value
             sigma = img2img.sigmas[img2img.init_time_step]
@@ -74,6 +68,17 @@ class LatentCreator:
                 noise=pure_noise,
                 sigma=sigma
             )  # fmt: off
+
+    @staticmethod
+    def encode_image(height: int, width: int, img2img: Img2Img):
+        scaled_user_image = ImageUtil.scale_to_dimensions(
+            image=ImageUtil.load_image(img2img.init_image_path).convert("RGB"),
+            target_width=width,
+            target_height=height,
+        )
+        encoded = img2img.vae.encode(ImageUtil.to_array(scaled_user_image))
+        latents = ArrayUtil.pack_latents(latents=encoded, height=height, width=width)
+        return latents
 
     @staticmethod
     def add_noise_by_interpolation(clean: mx.array, noise: mx.array, sigma: float) -> mx.array:

--- a/src/mflux/models/transformer/joint_attention.py
+++ b/src/mflux/models/transformer/joint_attention.py
@@ -5,8 +5,9 @@ from mflux.models.transformer.common.attention_utils import AttentionUtils
 
 
 class JointAttention(nn.Module):
-    def __init__(self):
+    def __init__(self, layer: int):
         super().__init__()
+        self.layer = layer
         self.head_dimension = 128
         self.batch_size = 1
         self.num_heads = 24
@@ -26,12 +27,16 @@ class JointAttention(nn.Module):
 
     def __call__(
         self,
+        t: int,
         hidden_states: mx.array,
         encoder_hidden_states: mx.array,
         image_rotary_emb: mx.array,
     ) -> (mx.array, mx.array):
         # 1a. Compute Q,K,V for hidden_states
         query, key, value = AttentionUtils.process_qkv(
+            t=t,
+            block=self,
+            should_cache=False,
             hidden_states=hidden_states,
             to_q=self.to_q,
             to_k=self.to_k,
@@ -44,6 +49,9 @@ class JointAttention(nn.Module):
 
         # 1b. Compute Q,K,V for encoder_hidden_states
         enc_query, enc_key, enc_value = AttentionUtils.process_qkv(
+            t=t,
+            block=self,
+            should_cache=False,
             hidden_states=encoder_hidden_states,
             to_q=self.add_q_proj,
             to_k=self.add_k_proj,

--- a/src/mflux/models/transformer/joint_transformer_block.py
+++ b/src/mflux/models/transformer/joint_transformer_block.py
@@ -12,7 +12,7 @@ class JointTransformerBlock(nn.Module):
         self.layer = layer
         self.norm1 = AdaLayerNormZero()
         self.norm1_context = AdaLayerNormZero()
-        self.attn = JointAttention()
+        self.attn = JointAttention(layer)
         self.norm2 = nn.LayerNorm(dims=3072, eps=1e-6, affine=False)
         self.norm2_context = nn.LayerNorm(dims=1536, eps=1e-6, affine=False)
         self.ff = FeedForward(activation_function=nn.gelu)
@@ -20,6 +20,7 @@ class JointTransformerBlock(nn.Module):
 
     def __call__(
         self,
+        t: int,
         hidden_states: mx.array,
         encoder_hidden_states: mx.array,
         text_embeddings: mx.array,
@@ -39,6 +40,7 @@ class JointTransformerBlock(nn.Module):
 
         # 2. Compute attention
         attn_output, context_attn_output = self.attn(
+            t=t,
             hidden_states=norm_hidden_states,
             encoder_hidden_states=norm_encoder_hidden_states,
             image_rotary_emb=rotary_embeddings,

--- a/src/mflux/models/transformer/single_block_attention.py
+++ b/src/mflux/models/transformer/single_block_attention.py
@@ -5,8 +5,9 @@ from mflux.models.transformer.common.attention_utils import AttentionUtils
 
 
 class SingleBlockAttention(nn.Module):
-    def __init__(self):
+    def __init__(self, layer: int):
         super().__init__()
+        self.layer = layer
         self.head_dimension = 128
         self.batch_size = 1
         self.num_heads = 24
@@ -17,9 +18,12 @@ class SingleBlockAttention(nn.Module):
         self.norm_q = nn.RMSNorm(128)
         self.norm_k = nn.RMSNorm(128)
 
-    def __call__(self, hidden_states: mx.array, image_rotary_emb: mx.array) -> mx.array:
+    def __call__(self, t: int, hidden_states: mx.array, image_rotary_emb: mx.array) -> mx.array:
         # 1a. Compute Q,K,V for hidden_states
         query, key, value = AttentionUtils.process_qkv(
+            t=t,
+            block=self,
+            should_cache=True,
             hidden_states=hidden_states,
             to_q=self.to_q,
             to_k=self.to_k,

--- a/src/mflux/models/transformer/single_transformer_block.py
+++ b/src/mflux/models/transformer/single_transformer_block.py
@@ -8,16 +8,17 @@ from mflux.models.transformer.single_block_attention import SingleBlockAttention
 
 
 class SingleTransformerBlock(nn.Module):
-    def __init__(self, layer):
+    def __init__(self, layer: int):
         super().__init__()
         self.layer = layer
         self.norm = AdaLayerNormZeroSingle()
-        self.attn = SingleBlockAttention()
+        self.attn = SingleBlockAttention(layer)
         self.proj_mlp = nn.Linear(3072, 4 * 3072)
         self.proj_out = nn.Linear(3072 + 4 * 3072, 3072)
 
     def __call__(
         self,
+        t: int,
         hidden_states: mx.array,
         text_embeddings: mx.array,
         rotary_embeddings: mx.array,
@@ -33,6 +34,7 @@ class SingleTransformerBlock(nn.Module):
 
         # 2. Compute attention
         attn_output = self.attn(
+            t=t,
             hidden_states=norm_hidden_states,
             image_rotary_emb=rotary_embeddings,
         )


### PR DESCRIPTION
Testing out some inversion techniques. WIP at the moment and will have to be properly integrated later. Also have a WIP PR up for [FlowEdit](https://github.com/filipstrand/mflux/pull/114). Still evaluating them this stage...

 Been looking at two techniques so far mentioned in [https://github.com/logtd/ComfyUI-Fluxtapoz?tab=readme-ov-file](https://github.com/logtd/ComfyUI-Fluxtapoz?tab=readme-ov-file):
 
 - RF Inversion (simple, does not need any architecture change, have tested this briefly in local branch, a bit mixed results so far, more testing required...)
 - RF Edit - currently in this branch (adds higher order term to the noise schedule (+1 extra transformer call for each step - and if I have not made any mistake the [Algorithm 1](https://arxiv.org/pdf/2411.04746) in their paper simplifies a bit to simply the "noise2" term in this branch),  need to save the inverted attention V-values in a cache for a later forward generation). Pretty good results on some images so far
 
  
<img width="1509" alt="Screenshot 2025-01-03 at 19 07 38" src="https://github.com/user-attachments/assets/ca401e2a-bffd-4513-9ba5-bb2e660240ca" />

 

<img width="1506" alt="Screenshot 2025-01-04 at 09 26 43" src="https://github.com/user-attachments/assets/f3c915a3-0428-4bcf-9f42-0b4be2e7cc96" />

