### PR TITLE
support multiple seeds batch generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 
 - **`--model`** or **`-m`** (required, `str`): Model to use for generation (`"schnell"` or `"dev"`).
 
-- **`--output`** (optional, `str`, default: `"image.png"`): Output image filename.
+- **`--output`** (optional, `str`, default: `"image.png"`): Output image filename. If `--seed` `--auto-seeds` establishes N > 1 seed values, the "stem" of the output file name will automatically append `_seed_{value}`.
 
-- **`--seed`** (optional, `int`, default: `None`): Seed for random number generation. Default is time-based.
+- **`--seed`** (optional, repeatable `int` args, default: `None`): 1 or more seeds for random number generation. e.g. `--seed 42` or `--seed 123 456 789`. Default is a single time-based value.
+
+- **`--auto-seeds`** (optional, `int`, default: `None`): Auto generate N random Seeds in a series of image generations. Superceded by `--seed` arg and `seed` values in `--config-from-metadata` files.
 
 - **`--height`** (optional, `int`, default: `1024`): Height of the output image in pixels.
 

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 
 from mflux import Config, Flux1, ModelLookup, StopImageGenerationException
@@ -25,23 +24,23 @@ def main():
     )
 
     try:
-        # Generate an image
-        image = flux.generate_image(
-            seed=int(time.time()) if args.seed is None else args.seed,
-            prompt=args.prompt,
-            stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
-            config=Config(
-                num_inference_steps=args.steps,
-                height=args.height,
-                width=args.width,
-                guidance=args.guidance,
-                init_image_path=args.init_image_path,
-                init_image_strength=args.init_image_strength,
-            ),
-        )
-
-        # Save the image
-        image.save(path=args.output, export_json_metadata=args.metadata)
+        for seed_value in args.seed:  # 1+ values: see argparser --seed and --auto-seeds
+            # Generate an image for each seed value
+            image = flux.generate_image(
+                seed=seed_value,
+                prompt=args.prompt,
+                stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
+                config=Config(
+                    num_inference_steps=args.steps,
+                    height=args.height,
+                    width=args.width,
+                    guidance=args.guidance,
+                    init_image_path=args.init_image_path,
+                    init_image_strength=args.init_image_strength,
+                ),
+            )
+            # Save the image
+            image.save(path=args.output.format(seed=seed_value), export_json_metadata=args.metadata)
     except StopImageGenerationException as stop_exc:
         print(stop_exc)
 

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 
 from mflux import ConfigControlnet, Flux1Controlnet, ModelLookup, StopImageGenerationException
@@ -24,25 +23,26 @@ def main():
     )
 
     try:
-        # Generate an image
-        image = flux.generate_image(
-            seed=int(time.time()) if args.seed is None else args.seed,
-            prompt=args.prompt,
-            output=args.output,
-            controlnet_image_path=args.controlnet_image_path,
-            controlnet_save_canny=args.controlnet_save_canny,
-            stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
-            config=ConfigControlnet(
-                num_inference_steps=args.steps,
-                height=args.height,
-                width=args.width,
-                guidance=args.guidance,
-                controlnet_strength=args.controlnet_strength,
-            ),
-        )
+        for seed_value in args.seed:  # 1+ values: see argparser --seed and --auto-seeds
+            # Generate an image for each seed value
+            image = flux.generate_image(
+                seed=seed_value,
+                prompt=args.prompt,
+                output=args.output,
+                controlnet_image_path=args.controlnet_image_path,
+                controlnet_save_canny=args.controlnet_save_canny,
+                stepwise_output_dir=Path(args.stepwise_image_output_dir) if args.stepwise_image_output_dir else None,
+                config=ConfigControlnet(
+                    num_inference_steps=args.steps,
+                    height=args.height,
+                    width=args.width,
+                    guidance=args.guidance,
+                    controlnet_strength=args.controlnet_strength,
+                ),
+            )
 
-        # Save the image
-        image.save(path=args.output, export_json_metadata=args.metadata)
+            # Save the image
+            image.save(path=args.output.format(seed=seed_value), export_json_metadata=args.metadata)
     except StopImageGenerationException as stop_exc:
         print(stop_exc)
 


### PR DESCRIPTION
This partially addresses the requests in #112 and #115.

Iterating on `seed` values while keeping all other values constant is the easiest of all the variable parameters. I think this satisfies a common user intent where they just want to see many variations of the same prompt/configs without reloading the model files.

In this PR, I attempt to:

- keep the `--seed` arg as is, but allow it to support n > 1 args.
- introduce a `--auto-seeds` arg, where you can allow the program to generate N seeds, giving up control of how the seeds are generated (it's just `random` library underneath)
- when seed count > 1, _smartly_ manipulate the `--output` name to embed each output file with the seed value so each file in the batch is named differently

# Examples

```sh
mflux-generate --model schnell --steps 4 \
  --prompt "a male lion protects his lion cub at Pride Rock" \
  --seed 1 2 3
```

produces `image_seed_1.png` `image_seed_2.png` `image_seed_3.png`

```sh
mflux-generate --model schnell --steps 4 \
  --prompt "a male lion protects his lion cub at Pride Rock" \
  --auto-seeds 5
```

produces something like: `image_seed_1561024.png` `image_seed_4756892.png` `image_seed_5976159.png` `image_seed_6479222.png` `image_seed_9434512.png`


# Future

It's possible to keep the model files loaded and iterate over N values of `width`, `height`, `steps`, `guidance`, and `init_image_*` values, but supporting all of those possible combinations can make the library code very complicated, so we may have to stop here for the official CLIs.

In my personal work, I have custom Python scripts that iterate over the configs without reloading model files, so we should just provide cookbook recipes for more complex examples, or defer to a separate CLI to be developed later in-library or as a third party tool.