### PR TITLE
Approx tests

### DIFF
--- a/tests/image_generation/helpers/image_generation_controlnet_test_helper.py
+++ b/tests/image_generation/helpers/image_generation_controlnet_test_helper.py
@@ -51,13 +51,18 @@ class ImageGeneratorControlnetTestHelper:
             image.save(path=output_image_path)
 
             # then
-            np.testing.assert_array_equal(
-                np.array(Image.open(output_image_path)),
-                np.array(Image.open(reference_image_path)),
-                err_msg="Generated image doesn't match reference image",
+            mse = ImageGeneratorTestHelper.mse(
+                Image.open(output_image_path),
+                Image.open(reference_image_path),
             )
+
+            assert mse < 5.0, f"Generated image doesn't match reference image (MSE: {mse})"
 
         finally:
             # cleanup
             if os.path.exists(output_image_path):
                 os.remove(output_image_path)
+
+    @staticmethod
+    def mse(image1: Image, image2: Image) -> float:
+        return np.mean(np.square(np.array(image1) - np.array(image2)))

--- a/tests/image_generation/helpers/image_generation_test_helper.py
+++ b/tests/image_generation/helpers/image_generation_test_helper.py
@@ -58,12 +58,6 @@ class ImageGeneratorTestHelper:
 
             assert mse < 5.0, f"Generated image doesn't match reference image (MSE: {mse})"
 
-        # except:
-        # # cleanup
-        # # if os.path.exists(output_image_path):
-        # # os.remove(output_image_path)
-        # raise
-
         finally:
             # cleanup
             if os.path.exists(output_image_path):

--- a/tests/image_generation/helpers/image_generation_test_helper.py
+++ b/tests/image_generation/helpers/image_generation_test_helper.py
@@ -51,11 +51,18 @@ class ImageGeneratorTestHelper:
             image.save(path=output_image_path)
 
             # then
-            np.testing.assert_array_equal(
-                np.array(Image.open(output_image_path)),
-                np.array(Image.open(reference_image_path)),
-                err_msg=f"Generated image doesn't match reference image. Check {output_image_path} vs {reference_image_path}",
+            mse = ImageGeneratorTestHelper.mse(
+                Image.open(output_image_path),
+                Image.open(reference_image_path),
             )
+
+            assert mse < 5.0, f"Generated image doesn't match reference image (MSE: {mse})"
+
+        # except:
+        # # cleanup
+        # # if os.path.exists(output_image_path):
+        # # os.remove(output_image_path)
+        # raise
 
         finally:
             # cleanup
@@ -67,3 +74,7 @@ class ImageGeneratorTestHelper:
         if path is None:
             return None
         return Path(__file__).parent.parent.parent / "resources" / path
+
+    @staticmethod
+    def mse(image1: Image, image2: Image) -> float:
+        return np.mean(np.square(np.array(image1) - np.array(image2)))


### PR DESCRIPTION
Hi there,

I love your project!  It has been a great tool for me to train LoRAs locally on my mac. I was playing around and trying to run tests locally.

I noticed that the image generation tests failed on a pixel by pixel comparison, but the images looked perceptually identical.

For example:
![dev-output](https://github.com/user-attachments/assets/80228146-aadb-4d5a-a53b-3977bab73ca5)
![devdiff](https://github.com/user-attachments/assets/b72b9eac-6444-4c76-bd8b-e241fa9178d8)


![lora_output](https://github.com/user-attachments/assets/9ff80294-9baa-4679-9366-a5d51716866c)
![devloradiff](https://github.com/user-attachments/assets/fa7d53b3-c0ab-40c1-af24-9603df069b92)

![schnell-out](https://github.com/user-attachments/assets/a88a4008-e7c5-467b-aac2-371bb0874067)
![schnell-diff](https://github.com/user-attachments/assets/ca463f67-5fc2-4687-ba74-daa60d619991)

Is there a reason to expect outputs to be pixel-identical on different setups?  It makes sense to me that there would be some small differences from float arith etc...

For reference I'm using an M4 Max.

Anyway I made a MSE comparison that is still pretty strict but still allows for some small differences in output.
What do you think?