### PR TITLE
Update arg parser test fixture

### DIFF
--- a/src/mflux/train.py
+++ b/src/mflux/train.py
@@ -6,6 +6,7 @@ from mflux.ui.cli.parsers import CommandLineParser
 
 def main():
     parser = CommandLineParser(description="Finetune a LoRA adapter")
+    parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False)
     parser.add_training_arguments()
     args = parser.parse_args()

--- a/tests/arg_parser/test_cli_argparser.py
+++ b/tests/arg_parser/test_cli_argparser.py
@@ -10,6 +10,7 @@ from mflux.ui.cli.parsers import CommandLineParser
 
 def _create_mflux_generate_parser(with_controlnet=False) -> CommandLineParser:
     parser = CommandLineParser(description="Generate an image based on a prompt.")
+    parser.add_general_arguments()
     parser.add_model_arguments(require_model_arg=False)
     parser.add_image_generator_arguments(supports_metadata_config=True)
     parser.add_lora_arguments()
@@ -33,6 +34,7 @@ def mflux_generate_controlnet_parser() -> CommandLineParser:
 @pytest.fixture
 def mflux_save_parser() -> CommandLineParser:
     parser = CommandLineParser(description="Save a quantized version of Flux.1 to disk.")  # fmt: off
+    parser.add_general_arguments()
     parser.add_model_arguments(path_type="save", require_model_arg=True)
     parser.add_lora_arguments()
     return parser


### PR DESCRIPTION
Hi there,

When I was testing the latest updates I noticed that the parser tests were failing.

I updated the test fixture to include the new low-ram parameter. 