### PR TITLE
clear prompt cache for training

### DIFF
--- a/src/mflux/dreambooth/dreambooth.py
+++ b/src/mflux/dreambooth/dreambooth.py
@@ -62,6 +62,7 @@ class DreamBooth:
                 )  # fmt: off
                 image.save(path=training_state.get_current_validation_image_path(training_spec))
                 del image
+                flux.prompt_cache = {}
 
             # Save checkpoint periodically
             if training_state.should_save(training_spec):


### PR DESCRIPTION
Hi again :)

I noticed that the prompt cache was breaking the training loop.

I just added a line to clear the prompt cache after image generation in training.