### PR TITLE
Image Outpaint Feature: prepare the CLI and ImageUtil helpers for extended canvas

### DIFF
--- a/src/mflux/ui/box_values.py
+++ b/src/mflux/ui/box_values.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AbsoluteBoxValues:
+    top: int
+    right: int
+    bottom: int
+    left: int
+
+
+@dataclass
+class BoxValues:
+    top: int | str
+    right: int | str
+    bottom: int | str
+    left: int | str
+
+    def normalize_to_dimensions(self, width, height) -> AbsoluteBoxValues:
+        parts = []
+        dimension_base = [height, width, height, width]
+        for index, part in enumerate([self.top, self.right, self.bottom, self.left]):
+            if isinstance(part, str) and part.endswith("%"):
+                parts.append(int(int(part.strip("%")) / 100 * dimension_base[index]))
+            else:
+                # simple integer value
+                parts.append(int(part))
+        return AbsoluteBoxValues(*parts)
+
+
+class BoxValueError(ValueError):
+    pass
+
+
+def parse_box_value(value, delimiter=","):
+    """
+    Parse CSS-style padding values into a dictionary.
+
+    Accepts formats:
+    - Single value (all sides)
+    - Two values (vertical | horizontal)
+    - Three values (top | horizontal | bottom)
+    - Four values (top | right | bottom | left)
+
+    Args:
+        value: A string containing CSS-style box values
+
+    Returns:
+        BoxValues dataclass with 'top', 'right', 'bottom', and 'left' attributes
+    """
+    parts = []
+    for part_value in value.strip().split(delimiter):
+        try:
+            part = int(part_value.strip())
+            parts.append(part)
+        except ValueError:  # noqa: PERF203
+            # not an int - is it a %?
+            if (part_value := part_value.strip()).endswith("%"):
+                parts.append(part_value)
+            else:
+                raise BoxValueError(f"Invalid padding value: {part_value}")
+
+    if len(parts) == 1:
+        # If only one value is provided, apply to all sides
+        return BoxValues(top=parts[0], right=parts[0], bottom=parts[0], left=parts[0])
+    elif len(parts) == 2:
+        # If two values: first is top/bottom, second is left/right
+        return BoxValues(top=parts[0], right=parts[1], bottom=parts[0], left=parts[1])
+    elif len(parts) == 3:
+        # If three values: top, left/right, bottom
+        return BoxValues(top=parts[0], right=parts[1], bottom=parts[2], left=parts[1])
+    elif len(parts) == 4:
+        # If four values: top, right, bottom, left
+        return BoxValues(top=parts[0], right=parts[1], bottom=parts[2], left=parts[3])
+    else:
+        raise BoxValueError(
+            "Invalid outpaint padding box value format: {value} "
+            "Expected: 1 (all-sides), 2 (top/bottom, left/right) "
+            "or 4 (top, right, bottom, left)values of int or percentages. e.g. 10px, 20%"
+        )

--- a/tests/image_generation/test_image_util.py
+++ b/tests/image_generation/test_image_util.py
@@ -1,0 +1,134 @@
+import PIL.Image
+import pytest
+
+from mflux.post_processing.image_util import ImageUtil
+
+
+@pytest.fixture
+def test_image():
+    # Create a simple test image
+    return PIL.Image.new("RGB", (100, 80), color="blue")
+
+
+def test_expand_image_with_pixels(test_image):
+    # Test expanding with pixel values
+    expanded = ImageUtil.expand_image(
+        test_image,
+        top=20,
+        right=30,
+        bottom=40,
+        left=10,
+        fill_color=(255, 0, 0),  # red
+    )
+
+    # Check dimensions
+    assert expanded.width == 100 + 30 + 10  # original + right + left
+    assert expanded.height == 80 + 20 + 40  # original + top + bottom
+
+    # Check color at corners (should be the fill color)
+    assert expanded.getpixel((0, 0)) == (255, 0, 0)  # top-left
+    assert expanded.getpixel((139, 0)) == (255, 0, 0)  # top-right
+    assert expanded.getpixel((0, 139)) == (255, 0, 0)  # bottom-left
+    assert expanded.getpixel((139, 139)) == (255, 0, 0)  # bottom-right
+
+    # Check original image is preserved in the middle
+    assert expanded.getpixel((15, 25)) == (0, 0, 255)  # blue
+
+
+def test_expand_image_with_percentages(test_image):
+    # Test expanding with percentage values
+    expanded = ImageUtil.expand_image(
+        test_image,
+        top="25%",
+        right="30%",
+        bottom="50%",
+        left="10%",
+        fill_color=(0, 255, 0),  # green
+    )
+
+    # Calculate expected dimensions
+    expected_top = int(0.25 * 80)  # 25% of height
+    expected_right = int(0.3 * 100)  # 30% of width
+    expected_bottom = int(0.5 * 80)  # 50% of height
+    expected_left = int(0.1 * 100)  # 10% of width
+
+    expected_width = 100 + expected_right + expected_left
+    expected_height = 80 + expected_top + expected_bottom
+
+    # Check dimensions
+    assert expanded.width == expected_width
+    assert expanded.height == expected_height
+
+    # Check fill color
+    assert expanded.getpixel((0, 0)) == (0, 255, 0)
+
+
+def test_expand_image_with_invalid_values(test_image):
+    # Test with invalid percentage string (a string that does not end with %"
+    with pytest.raises(ValueError):
+        ImageUtil.expand_image(test_image, top="25#", right="30", bottom="50%", left="10")
+
+    with pytest.raises(ValueError):
+        ImageUtil.expand_image(test_image, top="25", right="30$", bottom="50%", left="10")
+
+    with pytest.raises(ValueError):
+        ImageUtil.expand_image(test_image, top="25", right="30", bottom="50#", left="10")
+
+    with pytest.raises(ValueError):
+        ImageUtil.expand_image(test_image, top="25", right="30", bottom="50#", left="10*")
+
+
+def test_create_outpaint_mask_image():
+    # Test with various padding values
+    orig_width = 100
+    orig_height = 80
+    top_padding = 20
+    right_padding = 30
+    bottom_padding = 40
+    left_padding = 10
+
+    mask = ImageUtil.create_outpaint_mask_image(
+        orig_width=orig_width,
+        orig_height=orig_height,
+        top=top_padding,
+        right=right_padding,
+        bottom=bottom_padding,
+        left=left_padding,
+    )
+
+    # Check dimensions of the mask
+    expected_width = orig_width + right_padding + left_padding
+    expected_height = orig_height + bottom_padding + top_padding
+    assert mask.width == expected_width
+    assert mask.height == expected_height
+
+    # Check padding areas are white (255, 255, 255)
+    # Top-left corner
+    assert mask.getpixel((5, 5)) == (255, 255, 255)
+
+    # Top-right corner
+    assert mask.getpixel((expected_width - 5, 5)) == (255, 255, 255)
+
+    # Bottom-left corner
+    assert mask.getpixel((5, expected_height - 5)) == (255, 255, 255)
+
+    # Bottom-right corner
+    assert mask.getpixel((expected_width - 5, expected_height - 5)) == (255, 255, 255)
+
+    # Check center is black (0, 0, 0)
+    center_x = left_padding + (orig_width // 2)
+    center_y = top_padding + (orig_height // 2)
+    assert mask.getpixel((center_x, center_y)) == (0, 0, 0)
+
+    # Check boundaries
+    # Top edge of center box
+    assert mask.getpixel((left_padding + 10, top_padding)) == (0, 0, 0)
+
+    # Right edge of center box
+    assert mask.getpixel((left_padding + orig_width - 1, top_padding + 10)) == (0, 0, 0)
+
+    # Bottom edge of center box
+    assert mask.getpixel((left_padding + 10, top_padding + orig_height - 1)) == (0, 0, 0)
+
+    # Left edge of center box
+    assert mask.getpixel((left_padding, top_padding + 10)) == (0, 0, 0)

--- a/tools/create_outpaint_image_canvas_and_mask.py
+++ b/tools/create_outpaint_image_canvas_and_mask.py
@@ -1,0 +1,69 @@
+import pathlib
+import sys
+
+from mflux.post_processing.image_util import ImageUtil
+from mflux.ui.box_values import AbsoluteBoxValues, BoxValues
+from mflux.ui.cli.parsers import CommandLineParser
+
+
+def main():
+    parser = CommandLineParser(description="Create expanded canvas and mask for outpainting")
+    parser.add_argument("image_path", type=pathlib.Path, help="Path to the input image file")
+    parser.add_image_outpaint_arguments(required=True)
+    args = parser.parse_args()
+
+    if not args.image_path.exists():
+        print(f"Input image not found: {args.image_path}")
+        return 1
+
+    try:
+        # Load the image
+        image = ImageUtil.load_image(args.image_path)
+        # Get original dimensions
+        orig_width, orig_height = image.width, image.height
+        print(f"Loaded original image: {args.image_path} ({orig_width}x{orig_height})")
+
+        # Calculate padding values
+        padding: BoxValues = args.image_outpaint_padding
+        print(f"{padding=}")
+
+        # Create expanded canvas
+        expanded_image = ImageUtil.expand_image(
+            image=image,
+            top=padding.top,
+            right=padding.right,
+            bottom=padding.bottom,
+            left=padding.left,
+        )
+
+        abs_padding: AbsoluteBoxValues = args.image_outpaint_padding.normalize_to_dimensions(orig_width, orig_height)
+        # Create mask image
+        mask_image = ImageUtil.create_outpaint_mask_image(
+            orig_width=orig_width,
+            orig_height=orig_height,
+            top=abs_padding.top,
+            right=abs_padding.right,
+            bottom=abs_padding.bottom,
+            left=abs_padding.left,
+        )
+
+        # Construct output paths
+        expanded_output_path = args.image_path.with_stem(f"{args.image_path.stem}_expanded")
+        mask_output_path = args.image_path.with_stem(f"{args.image_path.stem}_mask")
+
+        # Save the images
+        ImageUtil.save_image(expanded_image, expanded_output_path)
+        ImageUtil.save_image(mask_image, mask_output_path)
+
+        print(f"Saved expanded canvas: {expanded_output_path}")
+        print(f"Saved mask image: {mask_output_path}")
+
+        return 0
+
+    except Exception as e:  # noqa: BLE001
+        print(f"Error processing image: {e}")
+        raise e
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Overview

In anticipation of the Image Outpainting feature that will follow #129's inpainting implementation, this PR prepares the CLI and ImageUtil for Outpaint without introducing the tensor implementations.

I interpret "outpaint" as simply extending the canvas of the source image, and then applying the adjacent "inpaint" logic in the padding regions.

Goal: This PR can be accepted without introducing outpaint, because `add_image_outpaint_arguments()` aren't invoked in the generator entry points yet.

# Summary

- new helper to expand source with padding
- new helper to create the masked image (maybe ultimately not needed, if we can construct the arrays directly), however this is helpful for the tool
- `create_outpaint_image_canvas_and_mask.py` - which uses the new parser and helpers above to save the expanded canvas and the outpaint mask image. This acts as a visual functional test, with output artifacts that can be verified in the Finder directly.
- had to make some parser changes around assumptions of `--model` and `--low-ram` arg existence