### PR TITLE
Fix test: auto seed count == 1 sporadic test failure

### DIFF
--- a/tests/arg_parser/test_cli_argparser.py
+++ b/tests/arg_parser/test_cli_argparser.py
@@ -230,7 +230,7 @@ def test_auto_seeds_arg(mflux_generate_parser, mflux_generate_minimal_model_argv
         assert "_seed_{seed}" in args.output
 
     for _ in range(0, 10):
-        random_auto_seed_count = random.randint(0, 100)
+        random_auto_seed_count = random.randint(2, 100)
         with patch("sys.argv", mflux_generate_minimal_model_argv + ["--auto-seeds", str(random_auto_seed_count)]):
             args = mflux_generate_parser.parse_args()
             assert len(set(args.seed)) == random_auto_seed_count


### PR DESCRIPTION
The sporadic error was due to the output file name having different behavior when auto seeds count is 1 vs > 1. By adjusting the test to always ask for n > 1, we can bypass this issue.

The offending code in `src/mflux/ui/cli/parsers.py`:

```python
if self.supports_image_generation and len(namespace.seed) > 1:
    # auto append seed-$value to output names for multi image generations
    # e.g. output.png -> output_seed_101.png output_seed_102.png, etc
    output_path = Path(namespace.output)
    namespace.output = str(output_path.with_stem(output_path.stem + "_seed_{seed}"))
```