### PR TITLE
More low-ram improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 
 - **`--config-from-metadata`** or **`-C`** (optional, `str`): [EXPERIMENTAL] Path to a prior file saved via `--metadata`, or a compatible handcrafted config file adhering to the expected args schema.
 
-- **`--low-ram`** (optional): Reduces GPU memory usage by constraining the MLX cache size and releasing text encoders and transformer components after use. This option is only compatible with single image generation. While it may slightly decrease performance, it helps prevent system memory swapping to disk, allowing generation on systems with limited RAM.
+- **`--low-ram`** (optional): Reduces GPU memory usage by limiting the MLX cache size and releasing text encoders and transformer components after use (single image generation only). While this may slightly decrease performance, it helps prevent system memory swapping to disk, allowing image generation on systems with limited RAM.
 
 - **`--lora-name`** (optional, `str`, default: `None`): The name of the LoRA to download from Hugging Face.
 

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -34,7 +34,7 @@ def main():
 
     memory_saver = None
     if args.low_ram:
-        memory_saver = MemorySaver(flux)
+        memory_saver = MemorySaver(flux=flux, keep_transformer=len(args.seed) > 1)
         CallbackRegistry.register_before_loop(memory_saver)
         CallbackRegistry.register_in_loop(memory_saver)
         CallbackRegistry.register_after_loop(memory_saver)

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -37,7 +37,7 @@ def main():
 
     memory_saver = None
     if args.low_ram:
-        memory_saver = MemorySaver(flux)
+        memory_saver = MemorySaver(flux=flux, keep_transformer=len(args.seed) > 1)
         CallbackRegistry.register_before_loop(memory_saver)
         CallbackRegistry.register_in_loop(memory_saver)
         CallbackRegistry.register_after_loop(memory_saver)

--- a/src/mflux/generate_fill.py
+++ b/src/mflux/generate_fill.py
@@ -39,7 +39,7 @@ def main():
 
     memory_saver = None
     if args.low_ram:
-        memory_saver = MemorySaver(flux)
+        memory_saver = MemorySaver(flux, keep_transformer=len(args.seed) > 1)
         CallbackRegistry.register_before_loop(memory_saver)
         CallbackRegistry.register_in_loop(memory_saver)
         CallbackRegistry.register_after_loop(memory_saver)

--- a/src/mflux/generate_in_context.py
+++ b/src/mflux/generate_in_context.py
@@ -38,7 +38,7 @@ def main():
 
     memory_saver = None
     if args.low_ram:
-        memory_saver = MemorySaver(flux)
+        memory_saver = MemorySaver(flux, keep_transformer=len(args.seed) > 1)
         CallbackRegistry.register_before_loop(memory_saver)
         CallbackRegistry.register_in_loop(memory_saver)
         CallbackRegistry.register_after_loop(memory_saver)

--- a/src/mflux/ui/cli/parsers.py
+++ b/src/mflux/ui/cli/parsers.py
@@ -220,7 +220,4 @@ class CommandLineParser(argparse.ArgumentParser):
             namespace.image_outpaint_padding = box_values.parse_box_value(namespace.image_outpaint_padding)
             print(f"{namespace.image_outpaint_padding=}")
 
-        if getattr(namespace, 'low_ram', False) and len(namespace.seed) > 1:
-            self.error("--low-ram cannot be used with multiple seeds")
-
         return namespace


### PR DESCRIPTION
This is the second part of memory optimizations. This time I have applied the ruff format and run some tests (the image generation failed on my system even without this changeset). 

I have removed the limitation of just single image generation. As we have the prompt cache, keeping the transformers allows us to repeatedly generate images. That increases memory but it might be more useful for some.

I have also added an explicit evaluation in the decoder (and encoder) so things don't accumulate and consume memory. That made some noticeable difference (with 1024x1024) The reported peak MLX memory usage now also captures the decoding phase. Here are some stats for this changeset:

### schnell q4, 4 steps, 1024x1024

- low-ram: 10.35 GB
- low-ram without eval during decode: 12.66 GB
- low-ram multiple seeds: 15.86 GB
- low-ram multiple seeds without eval during decode: 19.35 GB

### schnell q4, 4 steps, 512x512

- low-ram: 8.38 GB
- low-ram without eval during decode: 8.38 GB
- low-ram multiple seeds: 10.90 GB
- low-ram multiple seeds without eval during decode: 10.90 GB

