### PR TITLE
Fix the parser error in save

### DIFF
--- a/src/mflux/ui/cli/parsers.py
+++ b/src/mflux/ui/cli/parsers.py
@@ -196,7 +196,7 @@ class CommandLineParser(argparse.ArgumentParser):
         if self.supports_image_generation and namespace.steps is None:
             namespace.steps = ui_defaults.MODEL_INFERENCE_STEPS.get(namespace.model, None)
 
-        if namespace.low_ram and len(namespace.seed) > 1:
+        if getattr(namespace, 'low_ram', False) and len(namespace.seed) > 1:
             self.error("--low-ram cannot be used with multiple seeds")
 
         return namespace


### PR DESCRIPTION
comand:
```text
mflux-save \
    --path /Users/gokdenizgulmez/Library/Mobile\ Documents/com\~apple\~CloudDocs/Transformer\ Models/MLX/dev-realism-8bit \
    --model dev \
    --quantize 8 \
    --lora-repo-id XLabs-AI/flux-RealismLora \
    --lora-scales 0.7
```

Error before:
```text
Traceback (most recent call last):
  File "/Users/gokdenizgulmez/.local/bin/mflux-save", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/gokdenizgulmez/.local/share/uv/tools/mflux/lib/python3.12/site-packages/mflux/save.py", line 9, in main
    args = parser.parse_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/gokdenizgulmez/.local/share/uv/tools/mflux/lib/python3.12/site-packages/mflux/ui/cli/parsers.py", line 199, in parse_args
    if namespace.low_ram and len(namespace.seed) > 1:
       ^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'low_ram'
```

After Fix:
```text
Saving model dev with quantization level 8

Fetching 8 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 15534.46it/s]
Fetching 7 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 68759.08it/s]
Model saved at /Users/gokdenizgulmez/Library/Mobile Documents/com~apple~CloudDocs/Transformer Models/MLX/dev-realism-8bit
```
