### PR TITLE
More Scheduler Choices beyond default linear option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Run the powerful [FLUX](https://blackforestlabs.ai/#get-flux) models from [Black
   * [Memory issues](#memory-issues)
   * [Misc](#misc)
 - [🕹️ Controlnet](#%EF%B8%8F-controlnet)
+- [📊 Noise Schedulers](#-noise-schedulers)
+  * [Available Schedulers](#available-schedulers)
 - [🚧 Current limitations](#-current-limitations)
 - [💡Workflow tips](#workflow-tips)
 - [✅ TODO](#-todo)
@@ -175,6 +177,8 @@ mflux-generate --model dev --prompt "Luxury food photograph" --steps 25 --seed 2
 - **`--steps`** (optional, `int`, default: `4`): Number of inference steps.
 
 - **`--guidance`** (optional, `float`, default: `3.5`): Guidance scale (only used for `"dev"` model).
+
+- **`--noise-scheduler`** (optional, `str`, default: `"linear"`): Noise scheduler algorithm to use. Options are `"linear"`, `"cosine"`, `"exponential"`, `"sqrt"`, or `"scaled_linear"`. Each scheduler has different characteristics that affect the denoising process.
 
 - **`--path`** (optional, `str`, default: `None`): Path to a local model on disk.
 
@@ -942,6 +946,30 @@ Controlnet can also work well together with [LoRA adapters](#-lora). In the exam
 with different prompts and LoRA adapters active.
 
 ![image](src/mflux/assets/controlnet2.jpg)
+
+### 📊 Noise Schedulers
+
+MFLUX provides multiple noise scheduling algorithms that control how noise is reduced during the diffusion process. Each scheduler has unique characteristics that can affect image quality and generation style.
+
+You can specify the noise scheduler with the `--noise-scheduler` parameter:
+
+```sh
+mflux-generate --model dev --prompt "A serene landscape" --noise-scheduler cosine
+```
+
+#### Available Schedulers
+
+- **Linear** (default): The original noise scheduler that decreases noise in a linear fashion. Works well for most prompts and is computationally efficient.
+
+- **Cosine**: Provides smoother transitions between noise levels, often resulting in better perceptual quality for both simple and complex images. Based on research from Nichol & Dhariwal's "Improved Denoising Diffusion Probabilistic Models." Particularly effective for high-detail subjects.
+
+- **Exponential**: Accelerates the denoising process at the beginning and slows it at the end for more detail refinement. This can help with complex textures and fine detail work.
+
+- **Sqrt**: Uses a square root transformation to focus more steps in the higher noise regions. This helps preserve global structure while still ensuring good detail preservation in complex areas.
+
+- **Scaled Linear**: Applies a scaling factor to adjust the rate of noise reduction, making it more adaptable to different image types. Slower initial denoising and faster final denoising provide a balanced approach.
+
+Each scheduler is best suited for different types of prompts and imagery. Experimenting with different schedulers can help achieve optimal results for specific use cases.
 
 ### 🚧 Current limitations
 

--- a/src/mflux/config/config.py
+++ b/src/mflux/config/config.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import mlx.core as mx
 
+from mflux.config.constants import NoiseSchedulerType
+
 log = logging.getLogger(__name__)
 
 
@@ -18,6 +20,7 @@ class Config:
         image_path: Path | None = None,
         image_strength: float | None = None,
         controlnet_strength: float | None = None,
+        noise_scheduler: NoiseSchedulerType = NoiseSchedulerType.LINEAR,
     ):
         if width % 16 != 0 or height % 16 != 0:
             log.warning("Width and height should be multiples of 16. Rounding down.")
@@ -28,3 +31,4 @@ class Config:
         self.image_path = image_path
         self.image_strength = image_strength
         self.controlnet_strength = controlnet_strength
+        self.noise_scheduler = noise_scheduler

--- a/src/mflux/config/constants.py
+++ b/src/mflux/config/constants.py
@@ -1,0 +1,23 @@
+import enum
+
+
+class NoiseSchedulerType(enum.Enum):
+    LINEAR = "linear"
+    COSINE = "cosine"
+    EXPONENTIAL = "exponential"
+    SQRT = "sqrt"
+    SCALED_LINEAR = "scaled_linear"
+
+    @classmethod
+    def choices(cls) -> list[str]:
+        """Return a list of all available noise scheduler values as strings."""
+        return [e.value for e in cls]
+
+    @classmethod
+    def from_string(cls, value: str) -> "NoiseSchedulerType":
+        """Convert a string to the corresponding enum member."""
+        for member in cls:
+            if member.value == value:
+                return member
+        valid_values = ", ".join(cls.choices())
+        raise ValueError(f"Invalid noise scheduler type: {value}. Valid choices: {valid_values}")

--- a/src/mflux/config/runtime_config.py
+++ b/src/mflux/config/runtime_config.py
@@ -1,9 +1,11 @@
 import logging
+import math
 
 import mlx.core as mx
 import numpy as np
 
 from mflux.config.config import Config
+from mflux.config.constants import NoiseSchedulerType
 from mflux.config.model_config import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -81,19 +83,186 @@ class RuntimeConfig:
 
     @staticmethod
     def _create_sigmas(config: Config, model_config: ModelConfig) -> mx.array:
-        sigmas = RuntimeConfig._create_sigmas_values(config.num_inference_steps)
+        scheduler_type = getattr(config, "noise_scheduler", NoiseSchedulerType.LINEAR)
+
+        if scheduler_type == NoiseSchedulerType.LINEAR:
+            sigmas = RuntimeConfig._create_linear_sigmas(config.num_inference_steps)
+        elif scheduler_type == NoiseSchedulerType.COSINE:
+            sigmas = RuntimeConfig._create_cosine_sigmas(config.num_inference_steps)
+        elif scheduler_type == NoiseSchedulerType.EXPONENTIAL:
+            sigmas = RuntimeConfig._create_exponential_sigmas(config.num_inference_steps)
+        elif scheduler_type == NoiseSchedulerType.SQRT:
+            # Create a square root transformed schedule using manual implementation
+            steps = np.linspace(0, 1, config.num_inference_steps)
+            sigmas = np.sqrt(1 - steps)
+            sigmas = mx.array(sigmas).astype(mx.float32)
+            sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+        elif scheduler_type == NoiseSchedulerType.SCALED_LINEAR:
+            sigmas = RuntimeConfig._create_scaled_linear_sigmas(config.num_inference_steps)
+        else:
+            logger.warning(f"Unknown scheduler type: {scheduler_type}, falling back to linear")
+            sigmas = RuntimeConfig._create_linear_sigmas(config.num_inference_steps)
+
         if model_config.is_dev():
             sigmas = RuntimeConfig._shift_sigmas(sigmas=sigmas, width=config.width, height=config.height)
+
         return sigmas
 
     @staticmethod
-    def _create_sigmas_values(num_inference_steps: int) -> mx.array:
+    def _create_linear_sigmas(num_inference_steps: int) -> mx.array:
+        """
+        Create a linear noise schedule where noise level decreases linearly.
+
+        This is the original implementation of the DDPM scheduler, widely used as
+        a baseline in diffusion models.
+
+        References:
+        - DDPM Paper: https://arxiv.org/abs/2006.11239 (Ho et al., 2020)
+        - PyTorch Implementation: https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_ddpm.py
+        """
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
         sigmas = mx.array(sigmas).astype(mx.float32)
         return mx.concatenate([sigmas, mx.zeros(1)])
 
     @staticmethod
+    def _create_cosine_sigmas(num_inference_steps: int) -> mx.array:
+        """
+        Create a cosine noise schedule. This provides smoother transitions between
+        noise levels and often generates better results for both simple and complex images.
+
+        The cosine scheduler offers better perceptual quality and is particularly effective
+        for image generation tasks. It allocates more diffusion steps to both high and low noise
+        regions, which leads to better detail preservation and overall image quality.
+
+        References:
+        - Paper: "Improved Denoising Diffusion Probabilistic Models" by Nichol & Dhariwal (2021)
+          https://arxiv.org/abs/2102.09672
+        - PyTorch Implementation:
+          https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+        - OpenAI Implementation:
+          https://github.com/openai/improved-diffusion/blob/main/improved_diffusion/gaussian_diffusion.py
+        """
+        # Using a cosine schedule for better perceptual quality
+        s = 0.008
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.cos(((steps + s) / (1 + s)) * math.pi * 0.5) ** 2
+        sigmas = sigmas / sigmas[0]  # Normalize to 1.0
+
+        # Convert to MLX array
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        return mx.concatenate([sigmas, mx.zeros(1)])
+
+    @staticmethod
+    def _create_exponential_sigmas(num_inference_steps: int, beta: float = 5.0) -> mx.array:
+        """
+        Create an exponential noise schedule. This accelerates the denoising process
+        at the beginning and slows it at the end for more detail refinement.
+
+        The exponential scheduler focuses computation on low-noise steps, which is where
+        fine details are added to the generated image. This approach is inspired by the
+        exponential noise schedules used in various diffusion models and has been shown to
+        produce high-quality results with fewer steps.
+
+        Value of beta determines the rate of decay.
+        The default beta value of 5.0 is an empirical choice observed to work well in practice.
+        In an exponential schedule, beta controls how rapidly the noise (sigma) decays.
+        A beta of 5.0 results in a quick drop-off in noise,
+        which has been found useful in balancing the gradual denoising process in diffusion models.
+
+        References:
+        - Paper: "Score-Based Generative Modeling through Stochastic Differential Equations" (Song et al., 2021)
+          https://arxiv.org/abs/2011.13456
+        - Related PyTorch implementation in DDIM scheduler:
+          https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_ddim.py
+        """
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.exp(-beta * steps)
+
+        # Convert to MLX array
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        return mx.concatenate([sigmas, mx.zeros(1)])
+
+    @staticmethod
+    def _create_sqrt_sigmas(num_inference_steps: int) -> mx.array:
+        """
+        Create a square root transformed noise schedule. This applies a square root transformation
+        to a linear schedule, focusing more steps in the higher noise regions.
+
+        This scheduler applies a square root transformation to a linear schedule, concentrating
+        more denoising steps in areas with higher noise. This approach helps preserve global
+        structure and coherence in the generated images while still maintaining good detail in
+        the final result. The square root transformation is particularly effective for balancing
+        the trade-off between global structure and local detail.
+
+        References:
+        - Related to variance scheduling in: "Deep Unsupervised Learning using Nonequilibrium Thermodynamics"
+          (Sohl-Dickstein et al., 2015) https://arxiv.org/abs/1503.03585
+        - Similar approach in PNDM scheduler:
+          https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_pndm.py
+        - Square root transformation similar to that used in some variants of the DPM-Solver:
+          https://github.com/LuChengTHU/dpm-solver
+        """
+        # Use square root transformation for a moderate focus on early steps
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.sqrt(1 - steps)
+
+        # Convert to MLX array
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        return mx.concatenate([sigmas, mx.zeros(1)])
+
+    @staticmethod
+    def _create_scaled_linear_sigmas(num_inference_steps: int) -> mx.array:
+        """
+        Create a properly scaled linear noise schedule. This applies a scaling factor to
+        adjust the rate of noise reduction, making it more adaptable to different image types.
+
+        Unlike the square root transformation, this is a true linear schedule with a scaling factor
+        that controls the slope of the linear decay. The default scaling (0.5) results in slower initial
+        denoising and faster final denoising for a more balanced approach to noise reduction.
+
+        Parameters:
+            num_inference_steps: Number of inference steps
+
+        References:
+        - Inspired by scaled schedulers in various diffusion implementations
+        - Related to noise scheduling techniques in: "Denoising Diffusion Probabilistic Models"
+          (Ho et al., 2020) https://arxiv.org/abs/2006.11239
+        """
+        # Create a scaled linear schedule
+        start = 1.0
+        end = 1.0 / num_inference_steps
+
+        # Apply scaling to create non-uniform step sizes while maintaining linearity in the schedule
+        # The fixed scale_factor of 0.5 creates smaller steps at the beginning and larger steps at the end
+        scale_factor = 0.5  # Fixed scale factor for a balanced approach
+        steps = np.linspace(0, 1, num_inference_steps) ** scale_factor
+        steps = steps / steps[-1]  # Normalize to ensure we end at 1.0
+
+        # Map the normalized steps to the sigma range
+        sigmas = start + steps * (end - start)
+
+        # Convert to MLX array
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        return mx.concatenate([sigmas, mx.zeros(1)])
+
+    @staticmethod
     def _shift_sigmas(sigmas: mx.array, width: int, height: int) -> mx.array:
+        """
+        Adjusts the noise schedule based on image resolution, applying stronger denoising
+        for higher resolution images.
+
+        This adaptive approach scales the noise levels based on the total number of pixels,
+        which helps maintain consistent quality across different resolutions. The implementation
+        uses a logistic transformation that's parameterized based on image dimensions.
+
+        References:
+        - Related to the resolution-dependent noise adjustment in Stable Diffusion:
+          https://github.com/Stability-AI/stablediffusion/
+        - Similar approaches discussed in: "High-Resolution Image Synthesis with Latent Diffusion Models"
+          (Rombach et al., 2022) https://arxiv.org/abs/2112.10752
+        - Implementation inspired by similar techniques in advanced diffusion samplers that adapt
+          to image resolution to improve quality for high-resolution generation
+        """
         y1 = 0.5
         x1 = 256
         m = (1.15 - y1) / (4096 - x1)

--- a/src/mflux/post_processing/generated_image.py
+++ b/src/mflux/post_processing/generated_image.py
@@ -7,6 +7,7 @@ import PIL.Image
 import toml
 
 from mflux.config.model_config import ModelConfig
+from mflux.ui.defaults import DEFAULT_SCHEDULER
 
 
 class GeneratedImage:
@@ -27,6 +28,7 @@ class GeneratedImage:
         controlnet_strength: float | None = None,
         image_path: str | pathlib.Path | None = None,
         image_strength: float | None = None,
+        noise_scheduler: str = DEFAULT_SCHEDULER,
     ):
         self.image = image
         self.model_config = model_config
@@ -43,6 +45,7 @@ class GeneratedImage:
         self.controlnet_strength = controlnet_strength
         self.image_path = image_path
         self.image_strength = image_strength
+        self.noise_scheduler = noise_scheduler
 
     def get_right_half(self) -> "GeneratedImage":
         # Calculate the coordinates for the right half
@@ -66,6 +69,7 @@ class GeneratedImage:
             controlnet_strength=self.controlnet_strength,
             image_path=self.image_path,
             image_strength=self.image_strength,
+            noise_scheduler=self.noise_scheduler,
         )
 
     def save(
@@ -100,6 +104,7 @@ class GeneratedImage:
             "image_strength": self.image_strength if self.image_path else None,
             "controlnet_image_path": str(self.controlnet_image_path) if self.controlnet_image_path else None,
             "controlnet_strength": round(self.controlnet_strength, 2) if self.controlnet_strength else None,
+            "noise_scheduler": str(self.noise_scheduler),
             "prompt": self.prompt,
         }
 

--- a/src/mflux/post_processing/image_util.py
+++ b/src/mflux/post_processing/image_util.py
@@ -10,6 +10,7 @@ import PIL.Image
 
 from mflux.config.runtime_config import RuntimeConfig
 from mflux.post_processing.generated_image import GeneratedImage
+from mflux.ui.defaults import DEFAULT_SCHEDULER
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ class ImageUtil:
             image_strength=image_strength,
             controlnet_image_path=controlnet_image_path,
             controlnet_strength=config.controlnet_strength,
+            noise_scheduler=getattr(config.config, "noise_scheduler", DEFAULT_SCHEDULER),
         )
 
     @staticmethod

--- a/src/mflux/ui/defaults.py
+++ b/src/mflux/ui/defaults.py
@@ -1,3 +1,6 @@
+# Import NoiseSchedulerType enum
+from mflux.config.constants import NoiseSchedulerType
+
 CONTROLNET_STRENGTH = 0.4
 GUIDANCE_SCALE = 3.5
 HEIGHT, WIDTH = 1024, 1024
@@ -8,3 +11,5 @@ MODEL_INFERENCE_STEPS = {
     "schnell": 4,
 }
 QUANTIZE_CHOICES = [3, 4, 6, 8]
+DEFAULT_SCHEDULER = NoiseSchedulerType.LINEAR
+SCHEDULER_CHOICES = NoiseSchedulerType.choices()

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,0 +1,360 @@
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+from mflux.config.runtime_config import RuntimeConfig
+
+
+@pytest.fixture
+def num_inference_steps():
+    """Number of inference steps for testing schedulers."""
+    return 20
+
+
+@pytest.fixture
+def rtol():
+    """Relative tolerance for float comparison."""
+    return 1e-5
+
+
+@pytest.fixture
+def atol():
+    """Absolute tolerance for float comparison."""
+    return 1e-8
+
+
+@pytest.fixture
+def model_config():
+    """Mock ModelConfig for testing."""
+    return ModelConfig(
+        alias="test",
+        model_name="test_model",
+        supports_guidance=True,
+        num_train_steps=1000,
+        max_sequence_length=512,
+        base_model=None,
+    )
+
+
+class TestLinearScheduler:
+    """Tests for the linear noise scheduler."""
+
+    def test_shape_and_type(self, num_inference_steps):
+        """Test the shape and dtype of the linear scheduler output."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+        assert sigmas.shape == (num_inference_steps + 1,)
+        assert sigmas.dtype == mx.float32
+
+    def test_boundary_conditions(self, num_inference_steps, rtol, atol):
+        """Test the boundary values of the linear scheduler."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check start and end values (excluding final 0)
+        assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+        assert np.isclose(sigmas_np[-2], 1.0 / num_inference_steps, rtol=rtol, atol=atol)
+        assert sigmas_np[-1] == 0.0
+
+    def test_linear_decay(self, num_inference_steps, rtol, atol):
+        """Test that the linear scheduler has consistent step sizes."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check that differences between consecutive steps are consistent (linear)
+        diffs = np.diff(sigmas_np[:-1])  # Exclude the final 0
+        assert np.allclose(diffs, diffs[0], rtol=rtol, atol=atol)
+
+
+class TestCosineScheduler:
+    """Tests for the cosine noise scheduler."""
+
+    def test_shape_and_type(self, num_inference_steps):
+        """Test the shape and dtype of the cosine scheduler output."""
+        sigmas = RuntimeConfig._create_cosine_sigmas(num_inference_steps)
+        assert sigmas.shape == (num_inference_steps + 1,)
+        assert sigmas.dtype == mx.float32
+
+    def test_boundary_conditions(self, num_inference_steps, rtol, atol):
+        """Test the boundary values of the cosine scheduler."""
+        sigmas = RuntimeConfig._create_cosine_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check boundary conditions
+        assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+        assert sigmas_np[-1] == 0.0
+
+    def test_cosine_shape(self, num_inference_steps):
+        """Test the shape properties of the cosine scheduler curve."""
+        sigmas = RuntimeConfig._create_cosine_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Verify cosine shape properties - values should decrease more rapidly at extremes
+        # and more slowly in the middle compared to linear
+        diffs = np.diff(sigmas_np[:-1])  # Exclude the final 0
+
+        # Earlier diffs should be smaller (in absolute value) than middle diffs
+        assert abs(diffs[0]) < abs(diffs[len(diffs) // 2])
+
+        # Verify that middle section has the steepest slope
+        mid_idx = len(diffs) // 2
+        assert abs(diffs[mid_idx]) > abs(diffs[0])  # Middle should be steeper than beginning
+
+    def test_cosine_formula(self, num_inference_steps, rtol, atol):
+        """Test the cosine values against the expected formula."""
+        sigmas = RuntimeConfig._create_cosine_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Directly test values against the expected formula
+        s = 0.008
+        steps = np.linspace(0, 1, num_inference_steps)
+        expected_sigmas = np.cos(((steps + s) / (1 + s)) * math.pi * 0.5) ** 2
+        expected_sigmas = expected_sigmas / expected_sigmas[0]
+
+        for i in range(num_inference_steps):
+            assert np.isclose(sigmas_np[i], expected_sigmas[i], rtol=rtol, atol=atol)
+
+
+class TestExponentialScheduler:
+    """Tests for the exponential noise scheduler."""
+
+    def test_shape_and_type(self, num_inference_steps):
+        """Test the shape and dtype of the exponential scheduler output."""
+        sigmas = RuntimeConfig._create_exponential_sigmas(num_inference_steps)
+        assert sigmas.shape == (num_inference_steps + 1,)
+        assert sigmas.dtype == mx.float32
+
+    def test_boundary_conditions(self, num_inference_steps, rtol, atol):
+        """Test the boundary values of the exponential scheduler."""
+        sigmas = RuntimeConfig._create_exponential_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check boundary conditions
+        assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+        assert sigmas_np[-1] == 0.0
+
+    def test_exponential_decay(self, num_inference_steps):
+        """Test the exponential decay property of the scheduler."""
+        sigmas = RuntimeConfig._create_exponential_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Verify exponential characteristics - decay should be more rapid at first
+        diffs = np.diff(sigmas_np[:-1])  # Exclude the final 0
+
+        # Verify that each diff is smaller (in absolute value) than the previous,
+        # which indicates exponential decay
+        for i in range(1, len(diffs)):
+            assert abs(diffs[i]) < abs(diffs[i - 1])
+
+    def test_exponential_formula(self, num_inference_steps, rtol, atol):
+        """Test the exponential values against the expected formula."""
+        sigmas = RuntimeConfig._create_exponential_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Directly test values against the expected formula
+        beta = 5.0
+        steps = np.linspace(0, 1, num_inference_steps)
+        expected_sigmas = np.exp(-beta * steps)
+
+        for i in range(num_inference_steps):
+            assert np.isclose(sigmas_np[i], expected_sigmas[i], rtol=rtol, atol=atol)
+
+
+class TestSqrtScheduler:
+    """Tests for the square root transformation noise scheduler."""
+
+    def test_shape_and_type(self, num_inference_steps):
+        """Test the shape and dtype of the sqrt scheduler output."""
+        # Create a square root transformation manually for testing
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.sqrt(1 - steps)
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+
+        assert sigmas.shape == (num_inference_steps + 1,)
+        assert sigmas.dtype == mx.float32
+
+    def test_boundary_conditions(self, num_inference_steps, rtol, atol):
+        """Test the boundary values of the sqrt scheduler."""
+        # Create a square root transformation manually for testing
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.sqrt(1 - steps)
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+
+        sigmas_np = np.array(sigmas)
+
+        # Check boundary conditions
+        assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+        assert sigmas_np[-1] == 0.0
+
+    def test_sqrt_formula(self, num_inference_steps, rtol, atol):
+        """Test the square root values against the expected formula."""
+        # Create a square root transformation manually for testing
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.sqrt(1 - steps)
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+
+        sigmas_np = np.array(sigmas)
+
+        # Verify square root transformation effects
+        expected_sigmas = np.sqrt(1 - steps)
+        for i in range(num_inference_steps):
+            assert np.isclose(sigmas_np[i], expected_sigmas[i], rtol=rtol, atol=atol)
+
+    def test_sqrt_increasing_steps(self, num_inference_steps):
+        """Test that the step sizes increase with the sqrt scheduler."""
+        # Create a square root transformation manually for testing
+        steps = np.linspace(0, 1, num_inference_steps)
+        sigmas = np.sqrt(1 - steps)
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+
+        sigmas_np = np.array(sigmas)
+
+        # The difference between consecutive steps should increase as we go
+        diffs = np.diff(sigmas_np[:-1])  # Exclude the final 0
+        for i in range(1, len(diffs)):
+            assert abs(diffs[i]) > abs(diffs[i - 1])
+
+
+class TestScaledLinearScheduler:
+    """Tests for the properly scaled linear noise scheduler."""
+
+    def test_shape_and_type(self, num_inference_steps):
+        """Test the shape and dtype of the scaled linear scheduler output."""
+        sigmas = RuntimeConfig._create_scaled_linear_sigmas(num_inference_steps)
+        assert sigmas.shape == (num_inference_steps + 1,)
+        assert sigmas.dtype == mx.float32
+
+    def test_boundary_conditions(self, num_inference_steps, rtol, atol):
+        """Test the boundary values of the scaled linear scheduler."""
+        sigmas = RuntimeConfig._create_scaled_linear_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check boundary conditions
+        assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+        assert sigmas_np[-1] == 0.0
+
+    def test_scaled_linear_monotonic_decrease(self, num_inference_steps):
+        """Test the monotonic decrease property of the scaled linear scheduler."""
+        sigmas = RuntimeConfig._create_scaled_linear_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # Check that the curve decreases monotonically
+        diffs = np.diff(sigmas_np[:-1])
+        assert np.all(diffs < 0)  # All differences should be negative (decreasing)
+
+    def test_scaled_linear_increasing_steps(self, num_inference_steps):
+        """Test that the step sizes increase with the scaled linear scheduler."""
+        sigmas = RuntimeConfig._create_scaled_linear_sigmas(num_inference_steps)
+        sigmas_np = np.array(sigmas)
+
+        # The differences should increase in magnitude (steeper curve toward the end)
+        diffs = np.diff(sigmas_np[:-1])
+        for i in range(1, len(diffs)):
+            assert abs(diffs[i]) > abs(diffs[i - 1])
+
+
+class TestSigmaShifting:
+    """Tests for the sigma shifting function used for high-resolution images."""
+
+    @pytest.fixture
+    def resolutions(self):
+        """Resolutions to test with."""
+        return [
+            (512, 512),  # Smaller resolution
+            (1024, 1024),  # Medium resolution
+            (2048, 2048),  # Larger resolution
+        ]
+
+    def test_shift_shape_and_type(self, num_inference_steps, resolutions):
+        """Test the shape and type of shifted sigmas output."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+
+        for width, height in resolutions:
+            shifted_sigmas = RuntimeConfig._shift_sigmas(sigmas=sigmas, width=width, height=height)
+
+            # Check shape and type
+            assert shifted_sigmas.shape == sigmas.shape
+            assert shifted_sigmas.dtype == sigmas.dtype
+
+    def test_shift_boundary_conditions(self, num_inference_steps, resolutions):
+        """Test boundary conditions for shifted sigmas."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+
+        for width, height in resolutions:
+            shifted_sigmas = RuntimeConfig._shift_sigmas(sigmas=sigmas, width=width, height=height)
+
+            # Check that the last value is still 0
+            assert shifted_sigmas[-1] == 0.0
+
+            # Check that values are between 0 and 1
+            shifted_np = np.array(shifted_sigmas)
+            assert np.all(shifted_np >= 0.0)
+            assert np.all(shifted_np <= 1.0)
+
+    def test_shift_increases_with_resolution(self, num_inference_steps, resolutions):
+        """Test that higher resolutions produce higher shift values."""
+        sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+
+        for width, height in resolutions:
+            if width > 512 and height > 512:
+                shifted_sigmas = RuntimeConfig._shift_sigmas(sigmas=sigmas, width=width, height=height)
+
+                # For most points, the shifted value should be higher than the original
+                # (but not necessarily all, and we need to exclude the 0 at the end)
+                shifted_np = np.array(shifted_sigmas)
+                orig_np = np.array(sigmas)[:-1]
+                shift_np = shifted_np[:-1]
+                assert np.sum(shift_np > orig_np) > len(orig_np) // 2
+
+
+class TestSchedulerSelection:
+    """Tests for the scheduler selection based on config."""
+
+    @pytest.fixture
+    def schedulers(self):
+        """List of scheduler types to test."""
+        return ["linear", "cosine", "exponential", "sqrt", "scaled_linear"]
+
+    def test_scheduler_selection(self, num_inference_steps, rtol, atol, model_config, schedulers):
+        """Test that _create_sigmas selects the correct scheduler based on the config."""
+        for scheduler in schedulers:
+            config = Config(num_inference_steps=num_inference_steps, noise_scheduler=scheduler)
+            sigmas = RuntimeConfig._create_sigmas(config, model_config)
+
+            # Create the expected sigmas based on scheduler type
+            if scheduler == "linear":
+                expected_sigmas = RuntimeConfig._create_linear_sigmas(num_inference_steps)
+            elif scheduler == "cosine":
+                expected_sigmas = RuntimeConfig._create_cosine_sigmas(num_inference_steps)
+            elif scheduler == "exponential":
+                expected_sigmas = RuntimeConfig._create_exponential_sigmas(num_inference_steps)
+            elif scheduler == "sqrt":
+                # Create a square root transformation manually for testing
+                steps = np.linspace(0, 1, num_inference_steps)
+                expected_sigmas = np.sqrt(1 - steps)
+                expected_sigmas = mx.array(expected_sigmas).astype(mx.float32)
+                expected_sigmas = mx.concatenate([expected_sigmas, mx.zeros(1)])
+            elif scheduler == "scaled_linear":
+                expected_sigmas = RuntimeConfig._create_scaled_linear_sigmas(num_inference_steps)
+
+            # Convert to numpy for comparison
+            sigmas_np = np.array(sigmas)
+            expected_np = np.array(expected_sigmas)
+
+            # Check that the right scheduler was used
+            if scheduler == "sqrt":
+                # For sqrt, just check that we're getting the expected pattern
+                assert sigmas.shape == expected_sigmas.shape
+                assert sigmas.dtype == expected_sigmas.dtype
+                # Check basic properties
+                assert np.isclose(sigmas_np[0], 1.0, rtol=rtol, atol=atol)
+                assert sigmas_np[-1] == 0.0
+            else:
+                assert np.allclose(sigmas_np, expected_np, rtol=rtol, atol=atol)


### PR DESCRIPTION
This is a WIP PR to let @filipstrand I'm tackling this scope and everyone knows it's in flight.

1. 90% vibe coded with Claude Code
2. refined with prompts to adhere to project style and preferences (about 10-20 iterations of edits)
3. manually eyeball-reviewed and edited prior to this WIP PR, passes lint checks
4. **PENDING**: thorough review of the vibe-coded algorithms to make sure they really do what it advertises. I already caught an egregious error where the first attempt at scaled linear was actually implemented as square root transformation. So until the math can be checked out by @filipstrand and others, this PR is not ready for merge.

-----

Pasting the README update in the diff:

- **Linear** (default): The original noise scheduler that decreases noise in a linear fashion. Works well for most prompts and is computationally efficient.

- **Cosine**: Provides smoother transitions between noise levels, often resulting in better perceptual quality for both simple and complex images. Based on research from Nichol & Dhariwal's "Improved Denoising Diffusion Probabilistic Models." Particularly effective for high-detail subjects.

- **Exponential**: Accelerates the denoising process at the beginning and slows it at the end for more detail refinement. This can help with complex textures and fine detail work.

- **Sqrt**: Uses a square root transformation to focus more steps in the higher noise regions. This helps preserve global structure while still ensuring good detail preservation in complex areas.

- **Scaled Linear**: Applies a scaling factor to adjust the rate of noise reduction, making it more adaptable to different image types. Slower initial denoising and faster final denoising provide a balanced approach.

Each scheduler is best suited for different types of prompts and imagery. Experimenting with different schedulers can help achieve optimal results for specific use cases.

# Status

FWIW, the tests pass in isolation:

```
tests/test_schedulers.py::TestLinearScheduler::test_shape_and_type PASSED [  4%]
tests/test_schedulers.py::TestLinearScheduler::test_boundary_conditions PASSED [  8%]
tests/test_schedulers.py::TestLinearScheduler::test_linear_decay PASSED  [ 13%]
tests/test_schedulers.py::TestCosineScheduler::test_shape_and_type PASSED [ 17%]
tests/test_schedulers.py::TestCosineScheduler::test_boundary_conditions PASSED [ 21%]
tests/test_schedulers.py::TestCosineScheduler::test_cosine_shape PASSED  [ 26%]
tests/test_schedulers.py::TestCosineScheduler::test_cosine_formula PASSED [ 30%]
tests/test_schedulers.py::TestExponentialScheduler::test_shape_and_type PASSED [ 34%]
tests/test_schedulers.py::TestExponentialScheduler::test_boundary_conditions PASSED [ 39%]
tests/test_schedulers.py::TestExponentialScheduler::test_exponential_decay PASSED [ 43%]
tests/test_schedulers.py::TestExponentialScheduler::test_exponential_formula PASSED [ 47%]
tests/test_schedulers.py::TestSqrtScheduler::test_shape_and_type PASSED  [ 52%]
tests/test_schedulers.py::TestSqrtScheduler::test_boundary_conditions PASSED [ 56%]
tests/test_schedulers.py::TestSqrtScheduler::test_sqrt_formula PASSED    [ 60%]
tests/test_schedulers.py::TestSqrtScheduler::test_sqrt_increasing_steps PASSED [ 65%]
tests/test_schedulers.py::TestScaledLinearScheduler::test_shape_and_type PASSED [ 69%]
tests/test_schedulers.py::TestScaledLinearScheduler::test_boundary_conditions PASSED [ 73%]
tests/test_schedulers.py::TestScaledLinearScheduler::test_scaled_linear_monotonic_decrease PASSED [ 78%]
tests/test_schedulers.py::TestScaledLinearScheduler::test_scaled_linear_increasing_steps PASSED [ 82%]
tests/test_schedulers.py::TestSigmaShifting::test_shift_shape_and_type PASSED [ 86%]
tests/test_schedulers.py::TestSigmaShifting::test_shift_boundary_conditions PASSED [ 91%]
tests/test_schedulers.py::TestSigmaShifting::test_shift_increases_with_resolution PASSED [ 95%]
tests/test_schedulers.py::TestSchedulerSelection::test_scheduler_selection PASSED [100%]

============================== 23 passed in 1.08s ==============================

```