### PR TITLE
Save weight metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,9 +503,29 @@ mflux-generate \
 *Also Note: Once we have a local model (quantized [or not](#-running-a-non-quantized-model-directly-from-disk)) specified via the `--path` argument, the huggingface cache models are not required to launch the model.
 In other words, you can reclaim the 34GB diskspace (per model) by deleting the full 16-bit model from the [Huggingface cache](#%EF%B8%8F-generating-an-image) if you choose.*
 
+⚠️ * Quantized models saved with mflux < v.0.6.0 will not work with v.0.6.0 and later due to updated implementation. The solution is to [save a new quantized local copy](https://github.com/filipstrand/mflux/issues/149) 
+
 *If you don't want to download the full models and quantize them yourself, the 4-bit weights are available here for a direct download:*
-- [madroid/flux.1-schnell-mflux-4bit](https://huggingface.co/madroid/flux.1-schnell-mflux-4bit)
-- [madroid/flux.1-dev-mflux-4bit](https://huggingface.co/madroid/flux.1-dev-mflux-4bit)
+- For mflux < v.0.6.0:
+  - [madroid/flux.1-schnell-mflux-4bit](https://huggingface.co/madroid/flux.1-schnell-mflux-4bit)
+  - [madroid/flux.1-dev-mflux-4bit](https://huggingface.co/madroid/flux.1-dev-mflux-4bit)
+- For mflux >= v.0.6.0:
+  - [dhairyashil/FLUX.1-schnell-mflux-v0.6.2-4bit](https://huggingface.co/dhairyashil/FLUX.1-schnell-mflux-v0.6.2-4bit)
+  - [dhairyashil/FLUX.1-dev-mflux-4bit](https://huggingface.co/dhairyashil/FLUX.1-dev-mflux-4bit)
+
+<details>
+<summary>Using the community model support, the quantized weights can be also be automatically downloaded</summary>
+
+```sh
+mflux-generate \
+    --model "dhairyashil/FLUX.1-schnell-mflux-v0.6.2-4bit" \
+    --base-model schnell \
+    --steps 2 \
+    --seed 2 \
+    --prompt "Luxury food photograph"
+```
+
+</details>
 
 ### 💽 Running a non-quantized model directly from disk
 

--- a/src/mflux/dreambooth/lora_layers/lora_layers.py
+++ b/src/mflux/dreambooth/lora_layers/lora_layers.py
@@ -58,7 +58,7 @@ class LoRALayers:
             lora_layers = {**transformer_lora_layers, **single_transformer_lora_layers}
 
             weights = WeightHandler(
-                meta_data=MetaData(is_mflux=True),
+                meta_data=MetaData(mflux_version=GeneratedImage.get_version()),
                 transformer=mlx.utils.tree_unflatten(list(lora_layers.items()))['transformer'],
             )  # fmt:off
 

--- a/src/mflux/weights/model_saver.py
+++ b/src/mflux/weights/model_saver.py
@@ -5,6 +5,8 @@ from mlx import nn
 from mlx.utils import tree_flatten
 from transformers import CLIPTokenizer, T5Tokenizer
 
+from mflux.post_processing.generated_image import GeneratedImage
+
 
 class ModelSaver:
     @staticmethod
@@ -34,7 +36,10 @@ class ModelSaver:
             mx.save_safetensors(
                 str(path / f"{i}.safetensors"),
                 weight,
-                {"quantization_level": str(bits)},
+                {
+                    "quantization_level": str(bits),
+                    "mflux_version": GeneratedImage.get_version(),
+                },
             )
 
     @staticmethod

--- a/src/mflux/weights/weight_handler.py
+++ b/src/mflux/weights/weight_handler.py
@@ -14,7 +14,6 @@ class MetaData:
     quantization_level: int | None = None
     scale: float | None = None
     is_lora: bool = False
-    is_mflux: bool = False
     mflux_version: str | None = None
 
 

--- a/src/mflux/weights/weight_handler_lora.py
+++ b/src/mflux/weights/weight_handler_lora.py
@@ -38,7 +38,7 @@ class WeightHandlerLoRA:
                         quantization_level=None,
                         scale=lora_scale,
                         is_lora=True,
-                        is_mflux=True if mflux_version is not None else False,
+                        mflux_version=mflux_version,
                     ),
                 )
                 lora_weights.append(weights)

--- a/tests/model_saving/test_model_saving.py
+++ b/tests/model_saving/test_model_saving.py
@@ -1,9 +1,12 @@
 import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 
 from mflux import Config, Flux1, ModelConfig
+from mflux.post_processing.generated_image import GeneratedImage
+from mflux.weights.weight_handler import WeightHandler
 
 PATH = "tests/4bit/"
 
@@ -30,6 +33,11 @@ class TestModelSaving:
             )
             fluxA.save_model(PATH)
             del fluxA
+
+            # Verify that the mflux version is correctly saved in the model's metadata
+            _, quantization_level, mflux_version = WeightHandler._load_vae(root_path=Path(PATH))
+            assert mflux_version == GeneratedImage.get_version(), "mflux version not correctly saved in metadata"  # fmt: off
+            assert quantization_level == "4", "quantization level not correctly saved in metadata"  # fmt: off
 
             # when loading the quantized model (also without specifying bits)
             fluxB = Flux1(


### PR DESCRIPTION
When using `mfux-save` we now also save the mflux version in the weights metadata which can be useful to support future changes in weight handling between versions