### PR TITLE
Default inference steps to 4

### DIFF
--- a/src/mflux/config/config.py
+++ b/src/mflux/config/config.py
@@ -24,6 +24,9 @@ class Config:
             log.warning("Width and height should be multiples of 16. Rounding down.")
         self.width = 16 * (width // 16)
         self.height = 16 * (height // 16)
+        if not num_inference_steps:
+            log.warning("No number of inference steps specified. Defaulting to 4.")
+            num_inference_steps = 4
         self.num_inference_steps = num_inference_steps
         self.guidance = guidance
         self.image_path = image_path


### PR DESCRIPTION
Not passing in `--steps` on the command line would otherwise fail with "unsupported operand type(s) for /: 'int' and 'NoneType'" (as `args.steps` would be None).