### PR TITLE
Add support for depth-guided training

### DIFF
--- a/src/mflux/dreambooth/_example/train.json
+++ b/src/mflux/dreambooth/_example/train.json
@@ -44,23 +44,28 @@
       "images": [
         {
           "image": "01.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": true
         },
         {
           "image": "02.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "03.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "04.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "05.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         }
       ]
   }

--- a/src/mflux/dreambooth/dataset/batch.py
+++ b/src/mflux/dreambooth/dataset/batch.py
@@ -13,6 +13,7 @@ class Example:
         encoded_image: mx.array,
         prompt_embeds: mx.array,
         pooled_prompt_embeds: mx.array,
+        depth_map: mx.array | None = None,
     ):
         self.example_id = example_id
         self.prompt = prompt
@@ -20,6 +21,7 @@ class Example:
         self.clean_latents = encoded_image
         self.prompt_embeds = prompt_embeds
         self.pooled_prompt_embeds = pooled_prompt_embeds
+        self.depth_map = depth_map
 
 
 class Batch:

--- a/src/mflux/dreambooth/state/training_spec.py
+++ b/src/mflux/dreambooth/state/training_spec.py
@@ -12,6 +12,7 @@ from mflux.dreambooth.state.zip_util import ZipUtil
 class ExampleSpec:
     image: Path
     prompt: str
+    use_depth: bool = False
 
     @classmethod
     def create(cls, param: dict[str, str], absolute_or_relative_path: str, base_path: Path) -> "ExampleSpec":
@@ -26,6 +27,7 @@ class ExampleSpec:
         return cls(
             image=image_path,
             prompt=param["prompt"],
+            use_depth=param.get("use_depth", False),
         )
 
 

--- a/tests/dreambooth/config/train.json
+++ b/tests/dreambooth/config/train.json
@@ -65,23 +65,28 @@
     "images": [
         {
           "image": "01.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": true
         },
         {
           "image": "02.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "03.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "04.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         },
         {
           "image": "05.jpeg",
-          "prompt": "photo of sks dog"
+          "prompt": "photo of sks dog",
+          "use_depth": false
         }
       ]
   }


### PR DESCRIPTION
Have not tried this yet so this will have to be evaluated before merged as a proper feature, but especially for subject-related LoRAs it feels like a lot of training could be wasted on modelling unnecessary details often present in the background. With DepthPro now natively supported, I thought scaling the loss according to the depth-map could potentially lead to faster convergence. 