### PR TITLE
🏗️ uv build backend update, trim 33MB from user pip install load

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,33 +14,32 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Validate confirmation
         run: |
           if [ "${{ github.event.inputs.confirm }}" != "publish" ]; then
             echo "❌ Must type 'publish' to confirm release"
             exit 1
           fi
-        
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-          
+          python-version: "3.10"
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install requests build twine toml
-          
+          python -m pip install --upgrade uv
+
       - name: Configure Git
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          
+
       - name: Run release script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,22 @@ test: ensure-pytest
 	$(PYTHON) -m pytest
 	# ✅ Tests completed
 
+
+# Run uv build and check dist sizes for optimized user installs
+.PHONE: build
+build:
+	rm -rf dist/mflux-*
+	# fresh build
+	uv build
+	# check the artifact sizes - we expect < 1MB
+	du -sh dist/*
+	# create a temp directory for extraction
+	# then find/list the largest 5 files - we should not see image artifacts
+	@TEMP_DIR=$$(mktemp -d -t mflux-dist) && \
+	mkdir -p "$$TEMP_DIR/this-build" && \
+	tar -xzf dist/mflux-*.tar.gz -C "$$TEMP_DIR/this-build" && \
+	find "$$TEMP_DIR/this-build" -type f -exec du -h {} \; | sort -rh | head -n 5
+
 # Clean up
 .PHONY: clean
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+default-excludes = true  # __pycache__, *.pyc, and *.pyo
+source-exclude = [
+    # documentation assets were 27MB on 2025-07-05
+    "**/assets/**",
+    # # dreambooth examples ~=5MB on 2025-07-05
+    "**/dreambooth/_example/images/**",
+    # loss pdf/tex does not need to be distributed
+    "**/optimization/_loss_derivation/**",
+]
 
 [project]
 name = "mflux"
@@ -74,9 +85,6 @@ mflux-upscale = "mflux.upscale:main"
 mflux-lora-library = "mflux.lora_library:main"
 mflux-completions = "mflux.completions.install:main"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-include = ["mflux*"]
 
 [tool.ruff]
 line-length = 120

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -175,12 +175,6 @@ class ReleaseManager:
         return result
 
     def build_package(self):
-        # Install build dependencies
-        self.run_command(
-            [sys.executable, "-m", "pip", "install", "--upgrade", "pip", "build", "twine"],
-            "Installing build dependencies",
-        )
-
         # Clean dist directory to ensure fresh build
         import shutil
 
@@ -190,7 +184,8 @@ class ReleaseManager:
             print("🧹 Cleaned dist/ directory")
 
         # Build the package
-        self.run_command([sys.executable, "-m", "build"], "Building package")
+        self.run_command([sys.executable, "-m", "uv", "--version"], "Verify 'uv build' version")
+        self.run_command([sys.executable, "-m", "uv", "build"], "Building package with 'uv build'")
 
     def verify_package(self):
         """Run *twine check* to verify that README / long_description renders on PyPI."""


### PR DESCRIPTION
- converge to the excellent universe of `uv`, `ruff`, `ty` by Astral
- opportunity: trim the examples/docs images from `pip install` distributable, saving users network load, disk space and wall time during `pip install`s
- optimistically update the GitHub Actions build step from `python -m build` to `uv build` (while keeping `twine`)

@filipstrand - if the GitHub Actions update has a mistake, you may have to bump a few nit changes