### PR TITLE
Hot Fix: coldstart weight download (version 0.9.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ See `uv run tools/rename_images.py --help` for full CLI usage help.
 ### 💡Workflow Tips
 
 - To hide the model fetching status progress bars, `export HF_HUB_DISABLE_PROGRESS_BARS=1`
+- To opt-out of [HuggingFace telemetry](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/environment_variables#hfhubdisabletelemetry), `export HF_HUB_DISABLE_TELEMETRY=1`
 - Use config files to save complex job parameters in a file instead of passing many `--args`
 - Set up shell aliases for required args examples:
   - shortcut for dev model: `alias mflux-dev='mflux-generate --model dev'`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ source-exclude = [
 
 [project]
 name = "mflux"
-version = "0.9.2"
+version = "0.9.3"
 description = "A MLX port of FLUX based on the Huggingface Diffusers implementation."
 readme = "README.md"
 keywords = ["diffusers", "flux", "mlx"]

--- a/src/mflux/flux/flux_initializer.py
+++ b/src/mflux/flux/flux_initializer.py
@@ -36,7 +36,14 @@ class FluxInitializer:
         flux_model.prompt_cache = {}
         flux_model.model_config = model_config
 
-        # 1. Initialize tokenizers
+        # 1. Load the regular weights
+        weights = WeightHandler.load_regular_weights(
+            repo_id=model_config.model_name,
+            local_path=local_path,
+            transformer_repo_id=model_config.custom_transformer_model,
+        )
+
+        # 2. Initialize tokenizers
         tokenizers = TokenizerHandler(
             repo_id=model_config.model_name,
             max_t5_length=model_config.max_sequence_length,
@@ -48,13 +55,6 @@ class FluxInitializer:
         )
         flux_model.clip_tokenizer = TokenizerCLIP(
             tokenizer=tokenizers.clip,
-        )
-
-        # 2. Load the regular weights
-        weights = WeightHandler.load_regular_weights(
-            repo_id=model_config.model_name,
-            local_path=local_path,
-            transformer_repo_id=model_config.custom_transformer_model,
         )
 
         # 3. Initialize all models

--- a/src/mflux/weights/download.py
+++ b/src/mflux/weights/download.py
@@ -1,41 +1,13 @@
 """Download utilities for mflux weights with cache-first behavior."""
 
 from huggingface_hub import snapshot_download as hf_snapshot_download
-from huggingface_hub.utils import LocalEntryNotFoundError
 
 
 def snapshot_download(repo_id: str, **kwargs) -> str:
     """Download repo files with cache-first behavior.
 
-    This wrapper function attempts to use cached files first before downloading.
-    If local_files_only is explicitly set to True, it will not fall back to downloading.
-    Otherwise, it will try local cache first, then download if cache is not found.
+    This wrapper function is a wrapper for upstream hf_snapshot_download
 
-    Args:
-        repo_id: A user or an organization name and a repo name separated by a `/`.
-        **kwargs: Additional arguments passed to huggingface_hub.snapshot_download
-
-    Returns:
-        str: Path to the downloaded/cached repository
-
-    Docs: https://huggingface.co/docs/huggingface_hub/v0.33.1/en/package_reference/file_download#huggingface_hub.snapshot_download
-    """  # fmt: off
-    # Extract relevant kwargs for our logic
-    force_download = kwargs.get("force_download", False)
-    local_files_only = kwargs.get("local_files_only", False)
-
-    # If force_download or local_files_only is explicitly set, use original behavior
-    if force_download or local_files_only:
-        return hf_snapshot_download(repo_id=repo_id, **kwargs)
-
-    # Try to use cached files first
-    try:
-        # Override local_files_only to True for cache check
-        cache_kwargs = kwargs.copy()
-        cache_kwargs["local_files_only"] = True
-        return hf_snapshot_download(repo_id=repo_id, **cache_kwargs)
-    except LocalEntryNotFoundError:
-        # Cache doesn't exist, download from Hugging Face
-        download_kwargs = kwargs.copy()
-        download_kwargs["local_files_only"] = False
-        return hf_snapshot_download(repo_id=repo_id, **download_kwargs)
+    2025-07-08 HOT FIX: just pass the args through for now, see #235 discussion
+    """
+    return hf_snapshot_download(repo_id, **kwargs)


### PR DESCRIPTION
# Bug Fix/workaround

Reported by @awni in #234 🙏🏼

The origin of the original problem and the attempted fix + regression is in #216 and #226.

TL;DR - if the tokenizers download first, the parent directory is already created, which causes the HF `snapshot_download` call to return a valid path even when kwarg `local_files_only=True`. Apparently `local_files_only=True` qualifies if the parent/root directory exists??

For now, the quick fix attempt is to get the weights first, which I'm in the process of downloading the 20GB+ and allowing it to cache first.

- [x] Need to verify that after the download, image generation continues as expected
- [x] with my maintainer permissions I will attempt to merge to `main` and let the GitHub actions publish this `0.9.3` hot fix and prevent more users tripping on this
- [ ] TODO: create a plan to integration test this, perhaps by setting `HF_HUB_CACHE` to a temp dir during the test

```sh
$ mflux-generate -m schnell --prompt "beautiful sunset" --steps 4 --output /tmp/test.png
diffusion_pytorch_model.safetensors: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 168M/168M [01:45<00:00, 1.59MB/s]
model.safetensors: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 246M/246M [02:10<00:00, 1.88MB/s]
Fetching 7 files:  14%|████████████████████████████▊                                                                                                                                                                             | 1/7 [02:10<13:05, 130.89s/it]
model-00001-of-00002.safetensors:   7%|█████████████▎                                                                                                                                                                       | 367M/4.99G [03:29<42:58, 1.79MB/s]
(…)pytorch_model-00003-of-00003.safetensors:  10%|████████████████▌                                                                                                                                                         | 377M/3.87G [03:29<26:06, 2.23MB/s]
(…)pytorch_model-00001-of-00003.safetensors:   2%|███▋                                                                                                                                                                    | 220M/9.96G [02:08<1:47:28, 1.51MB/s]
(…)pytorch_model-00001-of-00003.safetensors:   4%|███████                                                                                                                                                                 | 419M/9.96G [03:30<1:00:08, 2.64MB/s]
(…)pytorch_model-00002-of-00003.safetensors:   4%|███████▍                                                                                                                                                                | 440M/9.95G [03:31<1:04:48, 2.45MB/s]
model-00002-of-00002.safetensors:   4%|███████▉                                                                                                                                                                             | 199M/4.53G [02:06<35:49, 2.02MB/s]
model-00002-of-00002.safetensors:   8%|██████████████▋                                                                                                                                                                      | 367M/4.53G [03:27<31:57, 2.17M
```

# Problem

This is the `tree` of the HF repo with tokenizers downloaded first:

```
.cache/huggingface/hub/models--black-forest-labs--FLUX.1-schnell-broken
├── blobs
│   ├── 17ade346a1042cbe0c1436f5bedcbd85c099d582
│   ├── 180a4e1be2a7d0b38a44108d6f24f585f35147b1
│   ├── 21ed409afa3df5a822caa0fd5da30d13941f90b5
│   ├── 469be27c5c010538f845f518c4f5e8574c78f7c8
│   ├── 76e821f1b6f0a9709293c3b6b51ed90980b3166b
│   ├── b336fa236135e6c87e246485e4d69e415cc57da0
│   ├── cf0682d6de72c1547f41b4f6d7c59f62deffef94
│   └── d60acb128cf7b7f2536e8f38a5b18a05535c9e14c7a355904270e15b0945ea86
├── refs
│   └── main
└── snapshots
    └── 741f7c3ce8b383c54771c7003378a50191e9efe9
        ├── tokenizer
        │   ├── merges.txt -> ../../../blobs/76e821f1b6f0a9709293c3b6b51ed90980b3166b
        │   ├── special_tokens_map.json -> ../../../blobs/cf0682d6de72c1547f41b4f6d7c59f62deffef94
        │   ├── tokenizer_config.json -> ../../../blobs/180a4e1be2a7d0b38a44108d6f24f585f35147b1
        │   └── vocab.json -> ../../../blobs/469be27c5c010538f845f518c4f5e8574c78f7c8
        └── tokenizer_2
            ├── special_tokens_map.json -> ../../../blobs/17ade346a1042cbe0c1436f5bedcbd85c099d582
            ├── spiece.model -> ../../../blobs/d60acb128cf7b7f2536e8f38a5b18a05535c9e14c7a355904270e15b0945ea86
            ├── tokenizer_config.json -> ../../../blobs/b336fa236135e6c87e246485e4d69e415cc57da0
            └── tokenizer.json -> ../../../blobs/21ed409afa3df5a822caa0fd5da30d13941f90b5
7 directories, 17 files
```

This is the `tree` of the HF repo that was previously fully downloaded:

```
/Users/anthonywu/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-schnell-backup
├── blobs
│   ├── 0bdb1b0ee10b0b31745d2654369613d432dc297a
│   ├── 17ade346a1042cbe0c1436f5bedcbd85c099d582
│   ├── 180a4e1be2a7d0b38a44108d6f24f585f35147b1
│   ├── 21ed409afa3df5a822caa0fd5da30d13941f90b5
│   ├── 469be27c5c010538f845f518c4f5e8574c78f7c8
│   ├── 58b4434078f0c2567ddc54e3b5cbf39626ab55fbd9d5c22956e183668f535dec
│   ├── 5ebd923ce51522c605f64ab3d26ea024672777b6
│   ├── 67e7b3526946734ed5f9014dc8fc2557714cce3e
│   ├── 76e821f1b6f0a9709293c3b6b51ed90980b3166b
│   ├── 893d67a23f4693ed42cdab4cbad7fe3e727cf59609c40da28a46b5470f9ed082
│   ├── 9b633dbe87316385c5b1c262bd4b5a01e3d955170661d63dcec8a01e89c0d820
│   ├── a5640855b301fcdbceddfa90ae8066cd9414aff020552a201a255ecf2059da00
│   ├── b00a8a6908682a2091f1194b81f220fd2b67c41c
│   ├── b336fa236135e6c87e246485e4d69e415cc57da0
│   ├── b43183d0f5f0274bccd8054cd0069fc1d5f64586
│   ├── bf1b236a5e90a3e5ffc62c916914d3696ad276e7
│   ├── c8728bc3dca59d2616a2a594cbac3ddb9eb77d5b
│   ├── cf0682d6de72c1547f41b4f6d7c59f62deffef94
│   ├── d60acb128cf7b7f2536e8f38a5b18a05535c9e14c7a355904270e15b0945ea86
│   ├── e2cbc25471ed5186e69a9b51098300cb2f612556453e38a372c851a220ed238d
│   ├── ec87bffd1923e8b2774a6d240c922a41f6143081d52cf83b8fe39e9d838c893e
│   ├── f2dcd899e03be059304cc980a87bb9389008ba2f
│   └── f5b59a26851551b67ae1fe58d32e76486e1e812def4696a4bea97f16604d40a3
├── refs
│   └── main
└── snapshots
    └── 741f7c3ce8b383c54771c7003378a50191e9efe9
        ├── model_index.json -> ../../blobs/f2dcd899e03be059304cc980a87bb9389008ba2f
        ├── scheduler
        │   └── scheduler_config.json -> ../../../blobs/0bdb1b0ee10b0b31745d2654369613d432dc297a
        ├── text_encoder
        │   ├── config.json -> ../../../blobs/5ebd923ce51522c605f64ab3d26ea024672777b6
        │   └── model.safetensors -> ../../../blobs/893d67a23f4693ed42cdab4cbad7fe3e727cf59609c40da28a46b5470f9ed082
        ├── text_encoder_2
        │   ├── config.json -> ../../../blobs/b00a8a6908682a2091f1194b81f220fd2b67c41c
        │   ├── model-00001-of-00002.safetensors -> ../../../blobs/ec87bffd1923e8b2774a6d240c922a41f6143081d52cf83b8fe39e9d838c893e
        │   ├── model-00002-of-00002.safetensors -> ../../../blobs/a5640855b301fcdbceddfa90ae8066cd9414aff020552a201a255ecf2059da00
        │   └── model.safetensors.index.json -> ../../../blobs/c8728bc3dca59d2616a2a594cbac3ddb9eb77d5b
        ├── tokenizer
        │   ├── merges.txt -> ../../../blobs/76e821f1b6f0a9709293c3b6b51ed90980b3166b
        │   ├── special_tokens_map.json -> ../../../blobs/cf0682d6de72c1547f41b4f6d7c59f62deffef94
        │   ├── tokenizer_config.json -> ../../../blobs/180a4e1be2a7d0b38a44108d6f24f585f35147b1
        │   └── vocab.json -> ../../../blobs/469be27c5c010538f845f518c4f5e8574c78f7c8
        ├── tokenizer_2
        │   ├── special_tokens_map.json -> ../../../blobs/17ade346a1042cbe0c1436f5bedcbd85c099d582
        │   ├── spiece.model -> ../../../blobs/d60acb128cf7b7f2536e8f38a5b18a05535c9e14c7a355904270e15b0945ea86
        │   ├── tokenizer_config.json -> ../../../blobs/b336fa236135e6c87e246485e4d69e415cc57da0
        │   └── tokenizer.json -> ../../../blobs/21ed409afa3df5a822caa0fd5da30d13941f90b5
        ├── transformer
        │   ├── config.json -> ../../../blobs/67e7b3526946734ed5f9014dc8fc2557714cce3e
        │   ├── diffusion_pytorch_model-00001-of-00003.safetensors -> ../../../blobs/9b633dbe87316385c5b1c262bd4b5a01e3d955170661d63dcec8a01e89c0d820
        │   ├── diffusion_pytorch_model-00002-of-00003.safetensors -> ../../../blobs/58b4434078f0c2567ddc54e3b5cbf39626ab55fbd9d5c22956e183668f535dec
        │   ├── diffusion_pytorch_model-00003-of-00003.safetensors -> ../../../blobs/e2cbc25471ed5186e69a9b51098300cb2f612556453e38a372c851a220ed238d
        │   └── diffusion_pytorch_model.safetensors.index.json -> ../../../blobs/bf1b236a5e90a3e5ffc62c916914d3696ad276e7
        └── vae
            ├── config.json -> ../../../blobs/b43183d0f5f0274bccd8054cd0069fc1d5f64586
            └── diffusion_pytorch_model.safetensors -> ../../../blobs/f5b59a26851551b67ae1fe58d32e76486e1e812def4696a4bea97f16604d40a3

12 directories, 47 files
```