### PR TITLE
Preview / Blocked by upstream: MLX on three clouds: Fal, Modal, Replicate

### DIFF
--- a/tools/cloud-fal/fal_run_mflux.py
+++ b/tools/cloud-fal/fal_run_mflux.py
@@ -15,6 +15,8 @@ class Input(BaseModel):
             "A charming Parisian street scene with its vibrant red awning and outdoor seating area, surrounded by quant shops and lush greenery under a bright blue sky."
         ],
     )
+    height: int = Field(description="Height in pixels", default=1024)
+    width: int = Field(description="Width in pixels", default=1024)
     guidance: float = Field(description="CFG Scale", default=3.5)
     steps: int = Field(description="Number of Inference Steps", default=20)
     seed: int = Field(description="Generation Seed", default=42)
@@ -74,7 +76,10 @@ class MFluxCudaModel(
         self.flux.generate_image(
             seed=random.randint(0, int(1e9)),
             prompt="Fluffy letters F A L in a cloud formation. Behind the clouds is a clear blue sky.",
-            config=Config(num_inference_steps=1, height=512, width=512, guidance=3.5),
+            num_inference_steps=1,
+            height=512,
+            width=512,
+            guidance=3.5,
         )
 
     @fal.endpoint("/")
@@ -87,7 +92,10 @@ class MFluxCudaModel(
         image = self.flux.generate_image(
             seed=input.seed,
             prompt=input.prompt,
-            config=Config(num_inference_steps=input.steps, height=512, width=512, guidance=input.guidance),
+            num_inference_steps=input.steps,
+            height=input.height,
+            width=input.width,
+            guidance=input.guidance,
         )
         output_dir = Path("/data/mflux-output")
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/cloud-fal/fal_run_mflux.py
+++ b/tools/cloud-fal/fal_run_mflux.py
@@ -1,0 +1,96 @@
+# run this file with: uvx --with fal==1.69.0 fal run
+import fal
+from fal.container import ContainerImage
+from fal.toolkit import (
+    File as FalFile,
+    Image as FalImage,
+)
+from pydantic import BaseModel, Field
+
+
+class Input(BaseModel):
+    prompt: str = Field(
+        description="The image prompt",
+        examples=[
+            "A charming Parisian street scene with its vibrant red awning and outdoor seating area, surrounded by quant shops and lush greenery under a bright blue sky."
+        ],
+    )
+    guidance: float = Field(description="CFG Scale", default=3.5)
+    steps: int = Field(description="Number of Inference Steps", default=20)
+    seed: int = Field(description="Generation Seed", default=42)
+
+
+class Output(BaseModel):
+    image: FalImage = Field(description="The mflux-generated image")
+
+
+DOCKERFILE_STR = """
+# this is python3.11 from 2025-08-19
+FROM nvcr.io/nvidia/cuda:13.1.1-runtime-ubuntu24.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1
+
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
+ENV HF_HUB_CACHE=/data/hf_cache
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
+ENV HF_XET_HIGH_PERFORMANCE=1
+ENV HF_XET_CHUNK_CACHE_SIZE_BYTES=1000000000000
+ENV HF_XET_NUM_CONCURRENT_RANGE_GETS=32
+
+
+ENV PATH=/mflux/bin:$PATH
+RUN apt update && \
+    apt install -y curl && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    . $HOME/.local/bin/env && \
+    uv python install 3.13 && \
+    uv venv -p 3.13 /mflux && \
+    . /mflux/bin/activate && \
+    uv pip install mlx[cuda13]>=0.30.3 mflux==0.15.5 hf_transfer && \
+    which python && \
+    /mflux/bin/python -c 'import mlx.core as mx; print(mx.default_device()); print(mx.ones([2,1]) * 2)' || true
+"""
+
+
+class MFluxCudaModel(
+    fal.App,
+    name="mflux-linux-cuda13",
+    image=ContainerImage.from_dockerfile_str(DOCKERFILE_STR),
+    kind="container",
+    keep_alive=300,
+    min_concurrency=0,  # Scale to zero when idle
+    max_concurrency=2,  # Limit concurrent requests
+):
+    machine_type = "GPU-B200"
+
+    def setup(self) -> None:
+        import random
+
+        from mflux.models.common.config import Config, ModelConfig
+        from mflux.models.flux.variants.txt2img.flux import Flux1
+
+        self.flux = Flux1(model_config=ModelConfig.from_name("schnell"))
+        print("Warming up model with first run")
+        self.flux.generate_image(
+            seed=random.randint(0, int(1e9)),
+            prompt="Fluffy letters F A L in a cloud formation. Behind the clouds is a clear blue sky.",
+            config=Config(num_inference_steps=1, height=512, width=512, guidance=3.5),
+        )
+
+    @fal.endpoint("/")
+    def image_to_video(self, input: Input) -> Output:
+        import time
+        from pathlib import Path
+
+        from mflux.config.config import Config
+
+        image = self.flux.generate_image(
+            seed=input.seed,
+            prompt=input.prompt,
+            config=Config(num_inference_steps=input.steps, height=512, width=512, guidance=input.guidance),
+        )
+        output_dir = Path("/data/mflux-output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"output-{int(time.time() * 1e6)}.png"
+        image.save(output_path)
+        return Output(image=FalFile.from_path(output_path))

--- a/tools/cloud-fal/fal_run_mflux.py
+++ b/tools/cloud-fal/fal_run_mflux.py
@@ -65,6 +65,8 @@ class MFluxCudaModel(
 ):
     machine_type = "GPU-B200"
 
+    warmup_generate_at_setup = False
+
     def setup(self) -> None:
         import random
 
@@ -72,15 +74,16 @@ class MFluxCudaModel(
         from mflux.models.flux.variants.txt2img.flux import Flux1
 
         self.flux = Flux1(model_config=ModelConfig.from_name("schnell"))
-        print("Warming up model with first run")
-        self.flux.generate_image(
-            seed=random.randint(0, int(1e9)),
-            prompt="Fluffy letters F A L in a cloud formation. Behind the clouds is a clear blue sky.",
-            num_inference_steps=1,
-            height=512,
-            width=512,
-            guidance=3.5,
-        )
+        if self.warmup_generate_at_setup:
+            print("Warming up model with first run")
+            self.flux.generate_image(
+                seed=random.randint(0, int(1e9)),
+                prompt="Fluffy letters F A L in a cloud formation. Behind the clouds is a clear blue sky.",
+                num_inference_steps=1,
+                height=512,
+                width=512,
+                guidance=3.5,
+            )
 
     @fal.endpoint("/")
     def image_to_video(self, input: Input) -> Output:

--- a/tools/cloud-fal/fal_run_mflux.py
+++ b/tools/cloud-fal/fal_run_mflux.py
@@ -87,8 +87,6 @@ class MFluxCudaModel(
         import time
         from pathlib import Path
 
-        from mflux.config.config import Config
-
         image = self.flux.generate_image(
             seed=input.seed,
             prompt=input.prompt,

--- a/tools/cloud-modal/generate_remote.py
+++ b/tools/cloud-modal/generate_remote.py
@@ -80,7 +80,10 @@ def generate_image():
     image = flux.generate_image(
         seed=random.randint(0, int(1e9)),
         prompt="Fluffy letters M L X in a cloud formation. Behind the clouds is a clear blue sky.",
-        config=Config(num_inference_steps=15, height=1024, width=1024, guidance=3.5),
+        num_inference_steps=15,
+        height=1024,
+        width=1024,
+        guidance=3.5,
     )
     image.save(output_path)
     print(output_path)

--- a/tools/cloud-modal/generate_remote.py
+++ b/tools/cloud-modal/generate_remote.py
@@ -1,0 +1,96 @@
+import modal
+
+app = modal.App("mflux-on-linux")
+
+"""
+Recommendation: do a one time warmup of model-store volume to store hf model caches, and another for your output artifacts:
+
+    - modal volume create output-data
+    - modal volume create model-store
+
+First, download one or more of the models onto the model-store volume and verify its integrity:
+
+    - modal shell --volume model-store --add-python 3.13
+    - export HF_HUB_ENABLE_HF_TRANSFER=1
+    - export HF_HUB_CACHE="/mnt/models-store/hf_hub"
+    - export HF_TOKEN=<your token>
+    - mkdir -p $HF_HUB_CACHE
+    - uvx --with hf_transfer,huggingface_hub hf download black-forest-labs/FLUX.1-schnell
+    - uvx hf cache verify black-forest-labs/FLUX.1-schnell
+    - uvx cache verify /mnt/models-store/hf_hub/models--black-forest-labs--FLUX.1-schnell
+
+    you should see something like:
+
+    ✅ Verified 28 file(s) for 'black-forest-labs/FLUX.1-schnell' (model) in /mnt/models-store/hf_hub/models--black-forest-labs--FLUX.1-schnell/snapshots/741f7c3ce8b383c54771c7003378a50191e9efe9
+      All checksums match.
+"""
+
+model_store_volume = modal.Volume.from_name("model-store")
+model_store_path = "/mnt/models-store"
+
+output_data_volume = modal.Volume.from_name("output-data")
+output_data_path = "/mnt/output-data"
+
+# MLX is supported on CUDA 13+ with mlx[cuda13]>=0.30.3
+mlx_on_cuda13 = modal.Image.from_registry(
+    "nvcr.io/nvidia/cuda:13.1.1-runtime-ubuntu24.04", add_python="3.13",
+).apt_install(
+    ["git"]
+).uv_pip_install(
+    "mlx[cuda13]>=0.30.3",
+    "mflux==0.15.5",
+).env({
+    "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    "HF_HUB_CACHE": "/mnt/models-store/hf_hub"
+})  # fmt: off
+
+
+@app.function(
+    # using Blackwell-class machine, because MLX Cuda support was initially tested on a DGX Spark
+    gpu="B200",
+    image=mlx_on_cuda13,
+    # init secret via: modal secret create my-huggingface-secret HF_TOKEN="hf_...value..."
+    secrets=[
+        modal.Secret.from_name("my-huggingface-secret")
+    ],
+    timeout=3600,
+    volumes={
+        model_store_path: model_store_volume,
+        output_data_path: output_data_volume
+    },
+)  # fmt: off
+def generate_image():
+    import os
+
+    # these are useful assertions when starting a new project
+    assert os.environ.get("HF_TOKEN", "").startswith("hf_")  # you set the secrets properly
+    assert os.environ["HF_HUB_CACHE"] == "/mnt/models-store/hf_hub"  # you defined ENV in docker build
+
+    import random
+    import time
+    from pathlib import Path
+
+    from mflux.models.common.config import Config, ModelConfig
+    from mflux.models.flux.variants.txt2img.flux import Flux1
+
+    flux = Flux1(model_config=ModelConfig.from_name("schnell"))
+
+    output_path = Path(f"/mnt/output-data/output-{int(time.time() * 1e6)}.png")
+
+    image = flux.generate_image(
+        seed=random.randint(0, int(1e9)),
+        prompt="Fluffy letters M L X in a cloud formation. Behind the clouds is a clear blue sky.",
+        config=Config(num_inference_steps=15, height=1024, width=1024, guidance=3.5),
+    )
+    image.save(output_path)
+    print(output_path)
+
+
+# run this script with:
+#   modal run
+# ✓ Initialized. View run at https://modal.com/apps/anthonywu/main/ap-pUXeO8seEe0gxUZ04PKLtM
+# Stopping app - uncaught exception raised locally: NotFoundError("Volume 'output-data' not found in environment 'main'").
+# Building image im-aLYBWnjqNWtJGEVDUnAv7n
+# => Step 0: FROM nvcr.io/nvidia/cuda:13.1.1-runtime-ubuntu24.04
+#
+# see https://modal.com/docs for advanced usage

--- a/tools/cloud-modal/modal_blockers.md
+++ b/tools/cloud-modal/modal_blockers.md
@@ -1,0 +1,35 @@
+This is the blocker with Modal B200 CUDA 13 mode:
+
+```
+==========
+== CUDA ==
+==========
+
+CUDA Version 13.1.1
+
+Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+By pulling and using the container, you accept the terms and conditions of this license:
+https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+
+A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+
+Traceback (most recent call last):
+  File "/pkg/modal/_runtime/container_io_manager.py", line 947, in handle_input_exception
+    yield
+  File "/pkg/modal/_container_entrypoint.py", line 172, in run_input_sync
+    values = io_context.call_function_sync()
+  File "/pkg/modal/_runtime/container_io_manager.py", line 225, in call_function_sync
+    expected_value_or_values = self.finalized_function.callable(*args, **kwargs)
+  File "/root/generate_remote.py", line 73, in generate_image
+    from mflux.models.common.config import Config, ModelConfig
+  File "/usr/local/lib/python3.13/site-packages/mflux/models/common/config/__init__.py", line 1, in <module>
+    from mflux.models.common.config.config import Config
+  File "/usr/local/lib/python3.13/site-packages/mflux/models/common/config/config.py", line 4, in <module>
+    import mlx.core as mx
+ImportError: cudaMemAdvise( data_, small_pool_size, cudaMemAdviseSetAccessedBy, loc) failed: invalid argument
+Stopping app - uncaught exception raised in remote container: ImportError('cudaMemAdvise( data_, small_pool_size, cudaMemAdviseSetAccessedBy, loc) failed: invalid argument').
+Exception ignored in atexit callback <nanobind.nb_func object at 0x2b2ded8517a0>:
+RuntimeError: cudaMemAdvise( data_, small_pool_size, cudaMemAdviseSetAccessedBy, loc) failed: invalid argument
+```

--- a/tools/cloud-replicate-cog/README.md
+++ b/tools/cloud-replicate-cog/README.md
@@ -1,0 +1,12 @@
+This is a quick demo of `mflux` running on Linux GPUs in Replicate's cloud using its `cog` framework
+
+# Development
+
+- install a Docker runtime on your machine for the `cog build` step
+- `cog login` if using for the first time
+- `cog build --tag mflux-linux-cuda13:test`  # produces image cog-cloud-replicate-cog
+- `cog predict  mflux-linux-cuda13:test --setup-timeout 3600 -i prompt=sunset -i steps=1 -i num_outputs=1 -i seed=$RANDOM`
+
+when running the first time, we may need to allow a longer setup timeout for initial model download:
+
+- `cog predict mflux-linux-cuda13:test --setup-timeout 3600 ...`

--- a/tools/cloud-replicate-cog/cog.yaml
+++ b/tools/cloud-replicate-cog/cog.yaml
@@ -1,0 +1,11 @@
+image: r8.im/anthonywu/mflux-linux-cuda13:test
+build:
+  cog_runtime: true
+  gpu: true
+  system_packages:
+    - "git"
+  python_version: "3.13"
+  python_requirements: requirements.txt
+  run:
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/latest/download/pget_$(uname -s)_$(uname -m)" && chmod +x /usr/local/bin/pget
+predict: "generate.py:TextToImage"

--- a/tools/cloud-replicate-cog/generate.py
+++ b/tools/cloud-replicate-cog/generate.py
@@ -1,0 +1,112 @@
+import os
+import subprocess
+import time
+from typing import List, Optional
+
+from cog import BasePredictor, Input, Path
+
+from mflux.models.common.config import Config, ModelConfig
+from mflux.models.flux.variants.txt2img.flux import Flux1
+
+MODEL_CACHE = "/data/FLUX.1-schnell"
+MODEL_URL = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-schnell/files.tar"
+
+ASPECT_RATIOS = {
+    "1:1": (1024, 1024),
+    "16:9": (1344, 768),
+    "21:9": (1536, 640),
+    "3:2": (1216, 832),
+    "2:3": (832, 1216),
+    "4:5": (896, 1088),
+    "5:4": (1088, 896),
+    "3:4": (896, 1152),
+    "4:3": (1152, 896),
+    "9:16": (768, 1344),
+    "9:21": (640, 1536),
+}
+
+
+def download_weights(url, dest):
+    start = time.time()
+    print("downloading url: ", url)
+    print("downloading to: ", dest)
+    subprocess.check_call(["pget", "-xf", url, dest], close_fds=False)
+    print("downloading took: ", time.time() - start)
+
+
+def find_transformers_parent(start_path: str) -> Optional[Path]:
+    """
+    Given a starting path, finds the parent directory that contains a 'transformers' directory.
+
+    Args:
+        start_path: The path to start the search from.
+
+    Returns:
+        The Path object of the parent directory containing 'transformers', or None if not found.
+    """
+    try:
+        # Resolve the path to handle '~' and make it absolute
+        p = Path(start_path).expanduser().resolve()
+
+        # Iterate through the path itself and its parents
+        for parent in [p] + list(p.parents):
+            if (parent / "transformers").is_dir():
+                return parent
+    except FileNotFoundError:
+        return None
+
+    return None
+
+
+class TextToImage(BasePredictor):
+    def setup(self) -> None:
+        """Load the model into memory to make running multiple predictions efficient"""
+        start = time.time()
+        print(f"Loading Flux model weights to {MODEL_CACHE}")
+        if not Path(MODEL_CACHE).exists():
+            download_weights(MODEL_URL, MODEL_CACHE)
+        model_path = find_transformers_parent(MODEL_CACHE)
+        print(f"model path found at: {model_path}")
+        self.flux = Flux1(path=model_path, model="schnell")
+        print("setup took: ", time.time() - start)
+
+    def predict(
+        self,
+        prompt: str = Input(description="Prompt for generated image"),
+        steps: int = Input(
+            description="Number of inference steps.",
+            ge=1,
+            le=20,
+            default=14,
+        ),
+        num_outputs: int = Input(
+            description="Number of images to output.",
+            ge=1,
+            le=4,
+            default=1,
+        ),
+        seed: Optional[int] = Input(description="Random seed. Set for reproducible generation", default=None),
+    ) -> List[Path]:
+        """Run a single prediction on the model"""
+        if seed is None:
+            seed = int.from_bytes(os.urandom(2), "big")
+        print(f"Using seed: {seed}")
+
+        guidance = 3.5
+        output_paths = []
+        for n in range(num_outputs):
+            image = self.flux.generate_image(
+                seed=seed,
+                prompt=prompt,
+                num_inference_steps=steps,
+                height=512,
+                width=512,
+                guidance=guidance,
+            )
+            output_dir = Path("/tmp/mflux-output")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_path = output_dir / f"output-{int(time.time() * 1e6)}.png"
+            image.save(output_path)
+            output_paths.append(output_path)
+
+        return output_paths

--- a/tools/cloud-replicate-cog/requirements.txt
+++ b/tools/cloud-replicate-cog/requirements.txt
@@ -1,0 +1,3 @@
+hf_transfer
+mflux==0.15.5
+mlx[cuda]>=0.30.3


### PR DESCRIPTION
# Update: Jan 31, 2026

All three cloud GPU service examples have been updated with the release from #321 

1. `modal run`: https://github.com/google/gvisor/pull/12436 unblocks the issue at the upstream `gvisor` project, but that runtime update has not been adopted by Modal yet (same error as August attempt)
2. `fal run fal_run_mflux.py` will start a remote app, and even a playground GUI, the generation apparently works if you observe only the log text content – tqdm progress bars complete, but the Result does not return to the playground GUI. Will investigate whether this is just my skill issue with Fal Apps.
3. **Replicate** `cog predict` - TBD

# Update: Aug 23, 2025

This is WIP to try out mflux on Linux (CPU for now) on Fal, Replicate Cog and Modal

When I get these to work, we can merge these as `tools/*` resources that isn't part of the official project but can be copy/pasteable to deployable application layers.