### PR TITLE
Scheduler interface implementation. Implement pre-existing linear scheduler only.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # use temporary community build of py13 wheel, use until official project build
     # uv pip install https://github.com/anthonywu/sentencepiece/releases/download/0.2.1-py13dev/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl
     "sentencepiece>=0.2.0,<1.0; python_version<'3.13'",
-    "tokenizers>=0.20.3; python_version>='3.13'", # transformers -> tokenizers
+    "tokenizers>=0.20.3; python_version>='3.13'",       # transformers -> tokenizers
     "toml>=0.10.2,<1.0",
     "torch>=2.3.1,<3.0; python_version<'3.13'",
     # torch dev builds: pip install --pre --index-url https://download.pytorch.org/whl/nightly
@@ -61,6 +61,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "matplotlib>3.10,<4.0",
     "pytest>=8.3.0,<9.0",
     "pytest-timer>=1.0,<2.0",
     "mlx==0.27.1",  # Used ONLY during test runs to ensure deterministic test results
@@ -169,10 +170,10 @@ disable_error_code = [
     "union-attr",
     "return",
     "return-value",
-    "var-annotated"
+    "var-annotated",
 ]
 error_summary = true
 ignore_missing_imports = true
 implicit_optional = true
 # we should feel free to use new hinting features even if we back support to earlier versions
-python_version = 3.12
+python_version = "3.12"

--- a/src/mflux/config/config.py
+++ b/src/mflux/config/config.py
@@ -22,6 +22,7 @@ class Config:
         redux_image_strengths: list[float] | None = None,
         masked_image_path: Path | None = None,
         controlnet_strength: float | None = None,
+        scheduler: str = "linear",
     ):
         if width % 16 != 0 or height % 16 != 0:
             log.warning("Width and height should be multiples of 16. Rounding down.")
@@ -36,3 +37,4 @@ class Config:
         self.redux_image_strengths = redux_image_strengths
         self.masked_image_path = masked_image_path
         self.controlnet_strength = controlnet_strength
+        self.scheduler_str = scheduler

--- a/src/mflux/config/runtime_config.py
+++ b/src/mflux/config/runtime_config.py
@@ -2,10 +2,11 @@ import logging
 from pathlib import Path
 
 import mlx.core as mx
-import numpy as np
 
 from mflux.config.config import Config
 from mflux.config.model_config import ModelConfig
+from mflux.schedulers import try_import_external_scheduler
+from mflux.schedulers.linear_scheduler import LinearScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,6 @@ class RuntimeConfig:
     ):
         self.config = config
         self.model_config = model_config
-        self.sigmas = self._create_sigmas(config, model_config)
 
     @property
     def height(self) -> int:
@@ -96,27 +96,14 @@ class RuntimeConfig:
 
         return None
 
-    @staticmethod
-    def _create_sigmas(config: Config, model_config: ModelConfig) -> mx.array:
-        sigmas = RuntimeConfig._create_sigmas_values(config.num_inference_steps)
-        if model_config.requires_sigma_shift:
-            sigmas = RuntimeConfig._shift_sigmas(sigmas=sigmas, width=config.width, height=config.height)
-        return sigmas
-
-    @staticmethod
-    def _create_sigmas_values(num_inference_steps: int) -> mx.array:
-        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
-        sigmas = mx.array(sigmas).astype(mx.float32)
-        return mx.concatenate([sigmas, mx.zeros(1)])
-
-    @staticmethod
-    def _shift_sigmas(sigmas: mx.array, width: int, height: int) -> mx.array:
-        y1 = 0.5
-        x1 = 256
-        m = (1.15 - y1) / (4096 - x1)
-        b = y1 - m * x1
-        mu = m * width * height / 256 + b
-        mu = mx.array(mu)
-        shifted_sigmas = mx.exp(mu) / (mx.exp(mu) + (1 / sigmas - 1))
-        shifted_sigmas[-1] = 0
-        return shifted_sigmas
+    @property
+    def scheduler(self):
+        if self.config.scheduler_str == "linear":
+            scheduler = LinearScheduler(self)
+        elif "." in self.config.scheduler_str:
+            # this raises ValueError if scheduler is not importable
+            scheduler_cls = try_import_external_scheduler(self.config.scheduler_str)
+            scheduler = scheduler_cls(self)
+        else:
+            raise NotImplementedError(f"The scheduler {self.config.scheduler_str!r} is not implemented by mflux.")
+        return scheduler

--- a/src/mflux/generate.py
+++ b/src/mflux/generate.py
@@ -48,6 +48,7 @@ def main():
                     guidance=args.guidance,
                     image_path=args.image_path,
                     image_strength=args.image_strength,
+                    scheduler=args.scheduler,
                 ),
             )
             # 4. Save the image

--- a/src/mflux/generate_controlnet.py
+++ b/src/mflux/generate_controlnet.py
@@ -48,6 +48,7 @@ def main():
                     width=args.width,
                     guidance=args.guidance,
                     controlnet_strength=args.controlnet_strength,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_depth.py
+++ b/src/mflux/generate_depth.py
@@ -46,6 +46,7 @@ def main():
                     guidance=args.guidance,
                     image_path=args.image_path,
                     depth_image_path=args.depth_image_path,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_fill.py
+++ b/src/mflux/generate_fill.py
@@ -46,6 +46,7 @@ def main():
                     guidance=args.guidance,
                     image_path=args.image_path,
                     masked_image_path=args.masked_image_path,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_in_context_catvton.py
+++ b/src/mflux/generate_in_context_catvton.py
@@ -61,6 +61,7 @@ def main():
                     guidance=args.guidance,
                     image_path=args.person_image,
                     masked_image_path=args.person_mask,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_in_context_dev.py
+++ b/src/mflux/generate_in_context_dev.py
@@ -56,6 +56,7 @@ def main():
                     width=args.width,
                     guidance=args.guidance,
                     image_path=args.image_path,
+                    scheduler=args.scheduler,
                 ),
             )
             # 4. Save the image

--- a/src/mflux/generate_in_context_edit.py
+++ b/src/mflux/generate_in_context_edit.py
@@ -61,6 +61,7 @@ def main():
                     height=height,
                     width=width,
                     guidance=args.guidance,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_kontext.py
+++ b/src/mflux/generate_kontext.py
@@ -47,6 +47,7 @@ def main():
                     width=args.width,
                     guidance=args.guidance,
                     image_path=args.image_path,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/generate_redux.py
+++ b/src/mflux/generate_redux.py
@@ -56,6 +56,7 @@ def main():
                     guidance=args.guidance,
                     redux_image_paths=args.redux_image_paths,
                     redux_image_strengths=redux_image_strengths,
+                    scheduler=args.scheduler,
                 ),
             )
 

--- a/src/mflux/models/transformer/transformer.py
+++ b/src/mflux/models/transformer/transformer.py
@@ -156,7 +156,7 @@ class Transformer(nn.Module):
         time_text_embed: TimeTextEmbed,
         config: RuntimeConfig,
     ) -> mx.array:
-        time_step = config.sigmas[t] * config.num_train_steps
+        time_step = config.scheduler.sigmas[t] * config.num_train_steps
         time_step = mx.broadcast_to(time_step, (1,)).astype(config.precision)
         guidance = mx.broadcast_to(config.guidance * config.num_train_steps, (1,)).astype(config.precision)
         text_embeddings = time_text_embed(time_step, pooled_prompt_embeds, guidance)

--- a/src/mflux/schedulers/__init__.py
+++ b/src/mflux/schedulers/__init__.py
@@ -1,0 +1,37 @@
+from .linear_scheduler import LinearScheduler
+
+__all__ = [
+    "LinearScheduler",
+]
+
+
+class SchedulerModuleNotFound(ValueError): ...
+
+
+class SchedulerClassNotFound(ValueError): ...
+
+
+def try_import_external_scheduler(scheduler_object_path: str):
+    import importlib
+
+    try:
+        last_dot_index = scheduler_object_path.rfind(".")
+
+        if last_dot_index < 0:
+            raise ValueError("Expected format: some_library.some_package.maybe_sub_package.YourScheduler")
+
+        module_name_str = scheduler_object_path[:last_dot_index]
+        scheduler_class_name = scheduler_object_path[last_dot_index + 1 :]
+        module = importlib.import_module(module_name_str)
+        print(f"Successfully imported module: '{module_name_str}'")
+    except ImportError:
+        raise SchedulerModuleNotFound(scheduler_object_path)
+
+    try:
+        # Step 2: Get the object from the module using its string name
+        SchedulerClass = getattr(module, scheduler_class_name)
+        print(f"Successfully found Scheduler class: '{SchedulerClass}'")
+    except AttributeError:
+        raise SchedulerClassNotFound(scheduler_object_path)
+
+    return SchedulerClass

--- a/src/mflux/schedulers/base_scheduler.py
+++ b/src/mflux/schedulers/base_scheduler.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+
+import mlx.core as mx
+
+
+class BaseScheduler(ABC):
+    """
+    Abstract base class for all schedulers.
+    """
+
+    @property
+    @abstractmethod
+    def sigmas(self) -> mx.array:
+        """
+        The sigma schedule for the diffusion process.
+        """
+        raise NotImplementedError("Schedulers must implement sigmas")
+
+    def scale_model_input(self, latents: mx.array, t: int) -> mx.array:
+        """
+        Scale the denoising model input. By default, no scaling applied.
+        """
+        return latents

--- a/src/mflux/schedulers/linear_scheduler.py
+++ b/src/mflux/schedulers/linear_scheduler.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+
+if TYPE_CHECKING:
+    from mflux.config.runtime_config import RuntimeConfig
+
+from mflux.schedulers.base_scheduler import BaseScheduler
+
+
+class LinearScheduler(BaseScheduler):
+    """
+    Linear scheduler - the default/classic scheduler used in mflux.
+    Creates a linear schedule from 1.0 to 1/num_steps.
+    """
+
+    def __init__(self, runtime_config: "RuntimeConfig"):
+        self.runtime_config = runtime_config
+
+    @property
+    def sigmas(self) -> mx.array:
+        model_config = self.runtime_config.model_config
+        sigmas = mx.linspace(
+            1.0,
+            1.0 / self.runtime_config.num_inference_steps,
+            self.runtime_config.num_inference_steps,
+        )
+        sigmas = mx.array(sigmas).astype(mx.float32)
+        sigmas = mx.concatenate([sigmas, mx.zeros(1)])
+        if model_config.requires_sigma_shift:
+            y1 = 0.5
+            x1 = 256
+            m = (1.15 - y1) / (4096 - x1)
+            b = y1 - m * x1
+            mu = m * self.runtime_config.width * self.runtime_config.height / 256 + b
+            mu = mx.array(mu)
+            shifted_sigmas = mx.exp(mu) / (mx.exp(mu) + (1 / sigmas - 1))
+            shifted_sigmas[-1] = 0
+            return shifted_sigmas
+        else:
+            return sigmas

--- a/src/mflux/ui/cli/parsers.py
+++ b/src/mflux/ui/cli/parsers.py
@@ -107,6 +107,7 @@ class CommandLineParser(argparse.ArgumentParser):
         prompt_group.add_argument("--prompt-file", type=Path, help="Path to a file containing the prompt text. The file will be re-read before each generation, allowing you to edit the prompt between iterations when using multiple seeds without restarting the program.")
         self.add_argument("--seed", type=int, default=None, nargs='+', help="Specify 1+ Entropy Seeds (Default is 1 time-based random-seed)")
         self.add_argument("--auto-seeds", type=int, default=-1, help="Auto generate N Entropy Seeds (random ints between 0 and 1 billion")
+        self.add_argument("--scheduler", type=str, default="linear", help="Choose from implemented schedulers. Or ")
         self._add_image_generator_common_arguments(supports_dimension_scale_factor=supports_dimension_scale_factor)
         if supports_metadata_config:
             self.add_metadata_config()

--- a/tests/schedulers/test_base_scheduler.py
+++ b/tests/schedulers/test_base_scheduler.py
@@ -1,0 +1,43 @@
+import mlx.core as mx
+import pytest
+
+from mflux.schedulers.base_scheduler import BaseScheduler
+
+
+def test_base_scheduler_is_abstract():
+    """
+    Test that BaseScheduler cannot be instantiated directly.
+    """
+    with pytest.raises(TypeError):
+        BaseScheduler()
+
+
+def test_sigmas_must_be_implemented():
+    """
+    Test that subclasses of BaseScheduler must implement the sigmas property.
+    """
+
+    class IncompleteScheduler(BaseScheduler):
+        def scale_model_input(self, latents: mx.array) -> mx.array:
+            return latents
+
+    with pytest.raises(NotImplementedError):
+        IncompleteScheduler().sigmas
+
+
+def test_scale_model_input_default_behavior():
+    """
+    Test the default behavior of scale_model_input.
+    """
+
+    class CompleteScheduler(BaseScheduler):
+        @property
+        def sigmas(self) -> mx.array:
+            return mx.array([1.0, 0.5, 0.0])
+
+        def scale_model_input(self, latents: mx.array) -> mx.array:
+            return latents
+
+    scheduler = CompleteScheduler()
+    test_input = mx.array([1, 2, 3])
+    assert mx.array_equal(scheduler.scale_model_input(test_input), test_input)

--- a/tests/schedulers/test_linear_scheduler.py
+++ b/tests/schedulers/test_linear_scheduler.py
@@ -1,0 +1,79 @@
+import io
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+from mflux.config.runtime_config import RuntimeConfig
+from mflux.schedulers import try_import_external_scheduler
+from mflux.schedulers.linear_scheduler import LinearScheduler
+
+
+def test_linear_scheduler_import_by_name():
+    assert try_import_external_scheduler("mflux.schedulers.linear_scheduler.LinearScheduler") == LinearScheduler
+
+
+@pytest.fixture
+def test_runtime_config():
+    return RuntimeConfig(
+        Config(
+            # these are the only attributes relevant to schedulers
+            num_inference_steps=14,
+            width=1024,
+            height=1024,
+            scheduler_type="linear",
+        ),
+        ModelConfig.dev(),  # requires_sigma_shift=True
+    )
+
+
+def test_linear_scheduler_initialization(test_runtime_config):
+    """
+    Test the initialization of the LinearScheduler.
+    """
+    scheduler = LinearScheduler(runtime_config=test_runtime_config)
+    assert scheduler.sigmas is not None
+    assert isinstance(scheduler.sigmas, mx.array)
+    assert len(scheduler.sigmas) > 0
+
+
+def test_linear_scheduler_sigmas_property_no_shift(test_runtime_config):
+    """
+    Test the sigmas property of the LinearScheduler without sigma shift.
+    """
+    scheduler = LinearScheduler(runtime_config=test_runtime_config)
+    expected_sigmas_from_mflux_0_9_0 = mx.array(
+        np.load(
+            io.BytesIO(
+                bytes.fromhex(
+                    # see: https://gist.github.com/anthonywu/2832147ff5f5f50c81df4d13152d2bed
+                    "934e554d505901003e007b276465736372273a20273c6634272c2027666f727472616e5f6f72646572273a20547275652c20277368617065273a202831352c20297d20202020200a0000803fb7e9793fd92a733f7aa66b3fab38633f30b4593f59df4e3f4f6f423f4b01343f1b10233fc3e30e3f5cedec3e0a90b03e4025483e00000000"
+                )
+            )
+        )
+    )
+
+    assert mx.allclose(scheduler.sigmas, expected_sigmas_from_mflux_0_9_0)
+    assert scheduler.sigmas.shape == (test_runtime_config.num_inference_steps + 1,)
+
+
+def test_linear_scheduler_sigmas_property_with_shift(test_runtime_config):
+    """
+    Test the sigmas property of the LinearScheduler with sigma shift.
+    """
+    test_runtime_config.model_config = ModelConfig.schnell()  # requires_sigma_shift=True
+    scheduler = LinearScheduler(runtime_config=test_runtime_config)
+    expected_sigmas_from_mflux_0_9_0 = mx.array(
+        np.load(
+            io.BytesIO(
+                bytes.fromhex(
+                    # see: https://gist.github.com/anthonywu/2832147ff5f5f50c81df4d13152d2bed
+                    "934e554d505901003e007b276465736372273a20273c6634272c2027666f727472616e5f6f72646572273a20547275652c20277368617065273a202831352c20297d20202020200a0000803fdbb66d3fb76d5b3f9224493f6edb363f4992243f2549123f0000003fb76ddb3e6edbb63e2549923eb76d5b3e2549123e2549923d00000000"
+                )
+            )
+        )
+    )
+    assert mx.allclose(scheduler.sigmas, expected_sigmas_from_mflux_0_9_0)
+    assert scheduler.sigmas.shape == (test_runtime_config.num_inference_steps + 1,)


### PR DESCRIPTION
This is a _by hand, 🌱 100% organic_ subset of the PR plucked from my self review and edit of #243.

This smaller, tastefully constructed PR simply migrates the old `RuntimeConfig.sigmas` implementation to the schedulers interface, and opens the door to any third party library implementation of compatible scheduler interfaces (unlock: `mflux` official repo do not have to implement every desired community scheduler, you can _Bring Your Own Scheduler_ - which we enable for now but should not publicize until a few more examples)

After this PR:

- [ ] #243 will rebase and follow this implementation

Testing:

- unit test with mflux 0.9.0 output as frozen-in-time comparison, showing work here: https://gist.github.com/anthonywu/2832147ff5f5f50c81df4d13152d2bed