### PR TITLE
Fix: loading non-quantized saved models

### DIFF
--- a/src/mflux/weights/model_saver.py
+++ b/src/mflux/weights/model_saver.py
@@ -34,8 +34,12 @@ class ModelSaver:
         weights = ModelSaver._split_weights(base_path, dict(tree_flatten(model.parameters())))
         for i, weight in enumerate(weights):
             mx.save_safetensors(
+                # usage: save_safetensors(file: str, arrays: dict[str, array], metadata: Optional[dict[str, str]] = None)
                 str(path / f"{i}.safetensors"),
+                # arrays (dict(str, array)): The dictionary of names to arrays to be saved.
                 weight,
+                # [save_safetensors] Metadata must be a dictionary with string keys and values
+                # i.e. 'None' and other special values are string-ified and need to be parsed by readers
                 {
                     "quantization_level": str(bits),
                     "mflux_version": VersionUtil.get_mflux_version(),

--- a/src/mflux/weights/quantization_util.py
+++ b/src/mflux/weights/quantization_util.py
@@ -18,6 +18,14 @@ class QuantizationUtil:
         weights: "WeightHandler",
     ) -> None:
         q_level = weights.meta_data.quantization_level
+        breakpoint()
+
+        # mx.save_tensors saves metadata dict kv 'quantization_level': 'None' as a str: str mapping
+        # we coerce both configs to NoneType to help users use non-quantized saved model files
+        if q_level == "None":
+            q_level = None
+        if quantize == "None":
+            quantize = None
 
         if quantize is not None or q_level is not None:
             bits = int(q_level) if q_level is not None else quantize


### PR DESCRIPTION
# Fix for #260 

The reason @filipstrand did the `str(...)` casting was because of MLX interface type requirements:

Demo: 

```
>>> import mlx.core as mx
>>> x = mx.arange(3)
>>> mx.save_safetensors("/tmp/x.safetensors", {"data": x}, metadata = {"hi": None})
Traceback (most recent call last):
  File "<python-input-7>", line 1, in <module>
    mx.save_safetensors("/tmp/x.safetensors", {"data": x}, metadata = {"hi": None})
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: [save_safetensors] Metadata must be a dictionary with string keys and values
```

So if a model is saved with quantization at default value of `None`, then the value is stored as literal str `"None"`. The fix is just to coerce the value back.