### PR TITLE
Fix: Auto-download tokenizer files for FIBO-vlm when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2025-11-27
+
+### 🐛 Bug Fixes
+
+- **FIBO VLM Tokenizer Download**: Fixed an issue where the FIBO VLM tokenizer files would not download automatically when the model weights were cached but tokenizer files were missing. The initializer now properly checks for tokenizer file existence and downloads them if needed.
+
+---
+
 ## [0.12.0] - 2025-11-27
 
 # MFLUX v.0.12.0 Release Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ source-exclude = [
 
 [project]
 name = "mflux"
-version = "0.12.0"
+version = "0.12.1"
 description = "A MLX port of FLUX based on the Huggingface Diffusers implementation."
 readme = "README.md"
 keywords = ["diffusers", "flux", "mlx"]

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "mflux"
-version = "0.12.0.dev0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -813,7 +813,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.24.5,<1.0" },
     { name = "matplotlib", specifier = ">=3.9.2,<4.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">3.10,<4.0" },
-    { name = "mlx", specifier = ">=0.27.0,<0.30.0" },
+    { name = "mlx", specifier = ">=0.27.0,<0.31.0" },
     { name = "mlx", marker = "extra == 'dev'", specifier = "==0.29.2" },
     { name = "numpy", specifier = ">=2.0.1,<3.0" },
     { name = "opencv-python", specifier = ">=4.10.0,<5.0" },


### PR DESCRIPTION
The model weights could be cached from Qwen3VLForConditionalGeneration.from_pretrained() but the tokenizer files (vocab.json, merges.txt, etc.) were not downloaded with it.

This fix checks if tokenizer files exist after getting the cached path, and if they're missing, triggers a full download to fetch the complete model including tokenizer files.