### PR TITLE
Add Z-Image-Turbo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2025-11-30
+
+# MFLUX v.0.13.0 Release Notes
+
+### 🎨 New Model Support
+
+- **Z-Image-Turbo Support**: Added support for [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo), a 6B parameter text-to-image model from Tongyi MAI (Alibaba)
+- **S3-DiT Architecture**: Single-stream diffusion transformer (S3-DiT) that concatenates text and image tokens into a unified sequence
+- **Qwen3-4B Text Encoder**: Native support for Qwen3-4B text encoder with 36 layers and grouped-query attention
+- **Fast Inference**: 8-9 step generation with CFG baked into distilled weights
+- **New commands**:
+  - `mflux-generate-zimage` - Generate images from text prompts
+  - `mflux-save-zimage` - Save quantized Z-Image-Turbo models to disk
+- **Full quantization support**: 3, 4, 5, 6, and 8-bit quantization for reduced memory usage
+- **Image-to-image support**: Transform existing images with text guidance
+
+### 🔧 Technical Details
+
+- **3D RoPE**: Rotary position embeddings for time, height, and width dimensions
+- **Context Refiner**: 2-layer attention module for caption feature refinement
+- **AdaLN Modulation**: Adaptive layer normalization with timestep conditioning
+- **Reuses FLUX VAE**: Compatible with existing FLUX VAE decoder
+
+
+---
+
 ## [0.12.1] - 2025-11-27
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "filelock>=3.18.0",
     "huggingface-hub>=0.24.5,<1.0",
     "matplotlib>=3.9.2,<4.0",
-    "mlx>=0.27.0,<0.31.0",
+    "mlx>=0.30.0,<0.31.0",
     "numpy>=2.0.1,<3.0",
     "opencv-python>=4.10.0,<5.0",
     "piexif>=1.1.3,<2.0",
@@ -68,7 +68,7 @@ dev = [
     "matplotlib>3.10,<4.0",
     "pytest>=8.3.0,<9.0",
     "pytest-timer>=1.0,<2.0",
-    "mlx==0.29.2",  # Used ONLY during test runs to ensure deterministic test results
+    "mlx==0.30.0",  # Used ONLY during test runs to ensure deterministic test results
 ]
 
 [project.urls]
@@ -87,12 +87,14 @@ mflux-generate-kontext = "mflux.generate_kontext:main"
 mflux-generate-qwen = "mflux.generate_qwen:main"
 mflux-generate-qwen-edit = "mflux.generate_qwen_edit:main"
 mflux-generate-fibo = "mflux.generate_fibo:main"
+mflux-generate-zimage = "mflux.generate_zimage:main"
 mflux-refine-fibo = "mflux.refine_fibo:main"
 mflux-inspire-fibo = "mflux.inspire_fibo:main"
 mflux-concept = "mflux.concept:main"
 mflux-concept-from-image = "mflux.concept_from_image:main"
 mflux-save = "mflux.save:main"
 mflux-save-depth = "mflux.save_depth:main"
+mflux-save-zimage = "mflux.save_zimage:main"
 mflux-train = "mflux.train:main"
 mflux-upscale = "mflux.upscale:main"
 mflux-lora-library = "mflux.lora_library:main"

--- a/src/mflux/config/model_config.py
+++ b/src/mflux/config/model_config.py
@@ -99,6 +99,11 @@ class ModelConfig:
     def fibo() -> "ModelConfig":
         return AVAILABLE_MODELS["fibo"]
 
+    @staticmethod
+    @lru_cache
+    def zimage_turbo() -> "ModelConfig":
+        return AVAILABLE_MODELS["zimage-turbo"]
+
     def x_embedder_input_dim(self) -> int:
         if "Fill" in self.model_name:
             return 384
@@ -335,5 +340,17 @@ AVAILABLE_MODELS = {
         supports_guidance=True,
         requires_sigma_shift=False,
         priority=13,
+    ),
+    "zimage-turbo": ModelConfig(
+        aliases=["zimage-turbo", "turbo"],
+        model_name="Tongyi-MAI/Z-Image-Turbo",
+        base_model=None,
+        controlnet_model=None,
+        custom_transformer_model=None,
+        num_train_steps=1000,
+        max_sequence_length=512,
+        supports_guidance=False,  # CFG baked into distilled weights
+        requires_sigma_shift=False,
+        priority=14,
     ),
 }

--- a/src/mflux/config/runtime_config.py
+++ b/src/mflux/config/runtime_config.py
@@ -85,8 +85,11 @@ class RuntimeConfig:
             # 1. Clamp strength to [0, 1]
             strength = max(0.0, min(1.0, self.config.image_strength))  # type: ignore
 
-            # 2. Return start time in [1, floor(num_steps * strength)]
-            return max(1, int(self.num_inference_steps * strength))  # type: ignore
+            # 2. Higher strength = more influence from init image = skip more steps
+            # strength=1.0 → init_time_step=num_steps (preserve original)
+            # strength=0.0 → init_time_step=0 (full regeneration)
+            # Note: mflux convention is OPPOSITE of diffusers
+            return max(1, int(self.num_inference_steps * strength))  # type: ignore[operator]
         else:
             return 0
 

--- a/src/mflux/generate_zimage.py
+++ b/src/mflux/generate_zimage.py
@@ -1,0 +1,78 @@
+"""CLI entry point for mflux-generate-zimage command."""
+
+import gc
+
+import mlx.core as mx
+
+from mflux.callbacks.callback_manager import CallbackManager
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+from mflux.ui.cli.parsers import CommandLineParser
+from mflux.ui.prompt_utils import PromptUtils
+from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationException
+from mflux.zimage import ZImage
+
+
+def main():
+    # Parse command line arguments (using shared infrastructure)
+    parser = CommandLineParser(description="Generate images with Z-Image-Turbo")
+    parser.add_general_arguments()
+    parser.add_model_arguments(require_model_arg=False)
+    parser.set_defaults(model="zimage-turbo")  # Default for validation
+    parser.add_image_generator_arguments(supports_metadata_config=True)
+    parser.add_image_to_image_arguments()  # Add img2img support
+    parser.add_output_arguments()
+    args = parser.parse_args()
+
+    # Z-Image Turbo has CFG baked in - force guidance to 0
+    args.guidance = 0.0
+
+    # Default steps for Turbo (if not specified)
+    if args.steps is None:
+        args.steps = 9
+
+    # Load model
+    zimage = ZImage(
+        model_config=ModelConfig.zimage_turbo(),
+        quantize=args.quantize,
+        local_path=args.path,
+    )
+
+    # Register callbacks
+    memory_saver = CallbackManager.register_callbacks(args=args, model=zimage)
+
+    try:
+        for seed in args.seed:
+            image = zimage.generate_image(
+                seed=seed,
+                prompt=PromptUtils.get_effective_prompt(args),
+                config=Config(
+                    num_inference_steps=args.steps,
+                    height=args.height,
+                    width=args.width,
+                    guidance=args.guidance,
+                    image_path=args.image_path,
+                    image_strength=args.image_strength,
+                ),
+            )
+            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
+
+            # Clean up image reference to prevent retention during exit
+            del image
+    except (StopImageGenerationException, PromptFileReadError) as exc:
+        print(exc)
+    finally:
+        if memory_saver:
+            print(memory_saver.memory_stats())
+
+        # Clean up model reference to release all weights
+        del zimage
+
+        # Force garbage collection and clear MLX cache before exit
+        # This prevents the ~32GB memory spike that occurs during Python cleanup
+        gc.collect()
+        mx.clear_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mflux/models/common/latent_creator/latent_creator.py
+++ b/src/mflux/models/common/latent_creator/latent_creator.py
@@ -10,13 +10,17 @@ if TYPE_CHECKING:
     from mflux.models.fibo.latent_creator.fibo_latent_creator import FiboLatentCreator
     from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
     from mflux.models.qwen.latent_creator.qwen_latent_creator import QwenLatentCreator
+    from mflux.models.zimage.latent_creator.zimage_latent_creator import ZImageLatentCreator
 
 
 class Img2Img:
     def __init__(
         self,
         vae: nn.Module,
-        latent_creator: type["FiboLatentCreator"] | type["FluxLatentCreator"] | type["QwenLatentCreator"],
+        latent_creator: type["FiboLatentCreator"]
+        | type["FluxLatentCreator"]
+        | type["QwenLatentCreator"]
+        | type["ZImageLatentCreator"],
         sigmas: mx.array,
         init_time_step: int,
         image_path: str | Path | None,

--- a/src/mflux/models/common/lora/download/lora_huggingface_downloader.py
+++ b/src/mflux/models/common/lora/download/lora_huggingface_downloader.py
@@ -6,7 +6,6 @@ from mflux.utils.download import snapshot_download
 
 
 class LoRAHuggingFaceDownloader:
-
     @staticmethod
     def download_loras(
         lora_names: list[str] | None = None,

--- a/src/mflux/models/common/lora/mapping/lora_mapping.py
+++ b/src/mflux/models/common/lora/mapping/lora_mapping.py
@@ -11,7 +11,6 @@ class LoRATarget:
 
 
 class LoRAMapping(Protocol):
-
     @staticmethod
     def get_mapping() -> List[LoRATarget]:
         return

--- a/src/mflux/models/flux/flux_initializer.py
+++ b/src/mflux/models/flux/flux_initializer.py
@@ -1,4 +1,5 @@
 from mflux.config.model_config import ModelConfig
+from mflux.models.common.lora.download.lora_huggingface_downloader import LoRAHuggingFaceDownloader
 from mflux.models.depth_pro.depth_pro import DepthPro
 from mflux.models.flux.model.flux_text_encoder.clip_encoder.clip_encoder import CLIPEncoder
 from mflux.models.flux.model.flux_text_encoder.t5_encoder.t5_encoder import T5Encoder
@@ -12,7 +13,6 @@ from mflux.models.flux.tokenizer.tokenizer_handler import TokenizerHandler
 from mflux.models.flux.variants.controlnet.transformer_controlnet import TransformerControlnet
 from mflux.models.flux.variants.controlnet.weight_handler_controlnet import WeightHandlerControlnet
 from mflux.models.flux.variants.redux.weight_handler_redux import WeightHandlerRedux
-from mflux.models.common.lora.download.lora_huggingface_downloader import LoRAHuggingFaceDownloader
 from mflux.models.flux.weights.weight_handler import WeightHandler
 from mflux.models.flux.weights.weight_handler_lora import WeightHandlerLoRA
 from mflux.models.flux.weights.weight_util import WeightUtil

--- a/src/mflux/models/flux/model/flux_vae/common/resnet_block_2d.py
+++ b/src/mflux/models/flux/model/flux_vae/common/resnet_block_2d.py
@@ -63,10 +63,12 @@ class ResnetBlock2D(nn.Module):
         hidden_states = self.norm1(input_array.astype(mx.float32)).astype(Config.precision)
         hidden_states = nn.silu(hidden_states)
         hidden_states = self.conv1(hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion after first conv
         hidden_states = self.norm2(hidden_states.astype(mx.float32)).astype(Config.precision)
         hidden_states = nn.silu(hidden_states)
         hidden_states = self.conv2(hidden_states)
         if self.conv_shortcut is not None:
             input_array = self.conv_shortcut(input_array)
         output_tensor = input_array + hidden_states
+        mx.eval(output_tensor)  # Prevent graph explosion after residual add
         return mx.transpose(output_tensor, (0, 3, 1, 2))

--- a/src/mflux/models/flux/model/flux_vae/common/unet_mid_block.py
+++ b/src/mflux/models/flux/model/flux_vae/common/unet_mid_block.py
@@ -16,6 +16,9 @@ class UnetMidBlock(nn.Module):
 
     def __call__(self, input_array: mx.array) -> mx.array:
         hidden_states = self.resnets[0](input_array)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.attentions[0](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[1](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         return hidden_states

--- a/src/mflux/models/flux/model/flux_vae/decoder/up_block_1_or_2.py
+++ b/src/mflux/models/flux/model/flux_vae/decoder/up_block_1_or_2.py
@@ -17,10 +17,14 @@ class UpBlock1Or2(nn.Module):
 
     def __call__(self, input_array: mx.array) -> mx.array:
         hidden_states = self.resnets[0](input_array)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[1](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[2](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
 
         if self.upsamplers is not None:
             hidden_states = self.upsamplers[0](hidden_states)
+            mx.eval(hidden_states)  # Prevent graph explosion
 
         return hidden_states

--- a/src/mflux/models/flux/model/flux_vae/decoder/up_block_3.py
+++ b/src/mflux/models/flux/model/flux_vae/decoder/up_block_3.py
@@ -17,10 +17,14 @@ class UpBlock3(nn.Module):
 
     def __call__(self, input_array: mx.array) -> mx.array:
         hidden_states = self.resnets[0](input_array)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[1](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[2](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
 
         if self.upsamplers is not None:
             hidden_states = self.upsamplers[0](hidden_states)
+            mx.eval(hidden_states)  # Prevent graph explosion
 
         return hidden_states

--- a/src/mflux/models/flux/model/flux_vae/decoder/up_block_4.py
+++ b/src/mflux/models/flux/model/flux_vae/decoder/up_block_4.py
@@ -15,6 +15,9 @@ class UpBlock4(nn.Module):
 
     def __call__(self, input_array: mx.array) -> mx.array:
         hidden_states = self.resnets[0](input_array)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[1](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         hidden_states = self.resnets[2](hidden_states)
+        mx.eval(hidden_states)  # Prevent graph explosion
         return hidden_states

--- a/src/mflux/models/flux/model/flux_vae/decoder/up_sampler.py
+++ b/src/mflux/models/flux/model/flux_vae/decoder/up_sampler.py
@@ -16,7 +16,9 @@ class UpSampler(nn.Module):
     def __call__(self, input_array: mx.array) -> mx.array:
         input_array = mx.transpose(input_array, (0, 2, 3, 1))
         hidden_states = UpSampler.up_sample_nearest(input_array)
+        mx.eval(hidden_states)  # Prevent graph explosion after upsampling
         hidden_state = self.conv(hidden_states)
+        mx.eval(hidden_state)  # Prevent graph explosion after conv
         return mx.transpose(hidden_state, (0, 3, 1, 2))
 
     @staticmethod

--- a/src/mflux/models/flux/variants/in_context/utils/in_context_loras.py
+++ b/src/mflux/models/flux/variants/in_context/utils/in_context_loras.py
@@ -1,4 +1,5 @@
 """Configuration for In-Context LoRAs from Hugging Face."""
+
 from mflux.models.common.lora.download.lora_huggingface_downloader import LoRAHuggingFaceDownloader
 
 # Default Hugging Face repository for In-Context LoRAs

--- a/src/mflux/models/zimage/__init__.py
+++ b/src/mflux/models/zimage/__init__.py
@@ -1,0 +1,39 @@
+# Z-Image models
+from mflux.models.zimage.embeddings import CaptionEmbed, PatchEmbed, RoPE3D, TimestepEmbed
+from mflux.models.zimage.text_encoder import Qwen3Attention, Qwen3DecoderLayer, Qwen3Encoder, Qwen3MLP, Qwen3Tokenizer
+from mflux.models.zimage.transformer import (
+    AdaLayerNorm,
+    Attention,
+    ContextRefinerBlock,
+    FinalLayer,
+    S3DiT,
+    S3DiTBlock,
+    SwiGLUFeedForward,
+)
+from mflux.models.zimage.weights import ZImageComponents, ZImageWeightHandler, ZImageWeightMapping
+
+__all__ = [
+    # Embeddings
+    "CaptionEmbed",
+    "PatchEmbed",
+    "RoPE3D",
+    "TimestepEmbed",
+    # Text encoder
+    "Qwen3Attention",
+    "Qwen3DecoderLayer",
+    "Qwen3Encoder",
+    "Qwen3MLP",
+    "Qwen3Tokenizer",
+    # Transformer
+    "AdaLayerNorm",
+    "Attention",
+    "ContextRefinerBlock",
+    "FinalLayer",
+    "S3DiT",
+    "S3DiTBlock",
+    "SwiGLUFeedForward",
+    # Weights
+    "ZImageComponents",
+    "ZImageWeightHandler",
+    "ZImageWeightMapping",
+]

--- a/src/mflux/models/zimage/embeddings/__init__.py
+++ b/src/mflux/models/zimage/embeddings/__init__.py
@@ -1,0 +1,12 @@
+from mflux.models.zimage.embeddings.caption_embed import CaptionEmbed
+from mflux.models.zimage.embeddings.patch_embed import PatchEmbed
+from mflux.models.zimage.embeddings.rope_3d import RoPE3D, apply_rope
+from mflux.models.zimage.embeddings.timestep_embed import TimestepEmbed
+
+__all__ = [
+    "CaptionEmbed",
+    "PatchEmbed",
+    "RoPE3D",
+    "TimestepEmbed",
+    "apply_rope",
+]

--- a/src/mflux/models/zimage/embeddings/caption_embed.py
+++ b/src/mflux/models/zimage/embeddings/caption_embed.py
@@ -1,0 +1,34 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class CaptionEmbed(nn.Module):
+    """Project Qwen3 text embeddings to transformer dimension.
+
+    RMSNorm followed by linear projection from text encoder hidden dim to S3-DiT dim.
+    HF structure: cap_embedder.0 = RMSNorm(2560), cap_embedder.1 = Linear(2560, 3840)
+    """
+
+    CAP_FEAT_DIM = 2560  # Qwen3-4B hidden size
+    HIDDEN_DIM = 3840  # S3-DiT dimension
+    NORM_EPS = 1e-5
+
+    def __init__(self):
+        super().__init__()
+        # Layer 0: RMSNorm (weight only, maps to cap_embedder.0.weight)
+        self.linear1 = nn.RMSNorm(self.CAP_FEAT_DIM, eps=self.NORM_EPS)
+        # Layer 1: Linear projection (maps to cap_embedder.1.weight/bias)
+        self.linear2 = nn.Linear(self.CAP_FEAT_DIM, self.HIDDEN_DIM, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Project text embeddings to transformer dimension.
+
+        Args:
+            x: Text embeddings [B, seq_len, cap_feat_dim] from Qwen3
+
+        Returns:
+            Projected embeddings [B, seq_len, hidden_dim]
+        """
+        x = self.linear1(x)  # Normalize
+        x = self.linear2(x)  # Project to hidden_dim
+        return x

--- a/src/mflux/models/zimage/embeddings/patch_embed.py
+++ b/src/mflux/models/zimage/embeddings/patch_embed.py
@@ -1,0 +1,47 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class PatchEmbed(nn.Module):
+    """Patchify VAE latents into transformer tokens.
+
+    Converts [B, C, H, W] latents into [B, N_patches, dim] sequence.
+    Uses 2x2 patches on 16-channel VAE latents.
+    """
+
+    # Hardcoded architecture (mflux pattern)
+    IN_CHANNELS = 16
+    PATCH_SIZE = 2
+    EMBED_DIM = 3840
+
+    def __init__(self):
+        super().__init__()
+        # Input dimension: in_channels * patch_size^2 = 16 * 4 = 64
+        in_dim = self.IN_CHANNELS * self.PATCH_SIZE * self.PATCH_SIZE
+        self.proj = nn.Linear(in_dim, self.EMBED_DIM)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Convert latents to patch tokens.
+
+        Args:
+            x: VAE latents [B, C, H, W] where C=16
+
+        Returns:
+            Patch tokens [B, N_patches, embed_dim] where N_patches = (H/2) * (W/2)
+        """
+        batch_size, channels, height, width = x.shape
+
+        # Reshape into patches: [B, C, H/P, P, W/P, P]
+        h_patches = height // self.PATCH_SIZE
+        w_patches = width // self.PATCH_SIZE
+
+        # Rearrange to [B, H/P, W/P, P*P*C] matching diffusers order (spatial first, then channel)
+        # Diffusers: "c f pf h ph w pw -> (f h w) (pf ph pw c)"
+        x = x.reshape(batch_size, channels, h_patches, self.PATCH_SIZE, w_patches, self.PATCH_SIZE)
+        x = x.transpose(0, 2, 4, 3, 5, 1)  # [B, H/P, W/P, P_h, P_w, C]
+        x = x.reshape(batch_size, h_patches * w_patches, -1)  # [B, N_patches, P*P*C]
+
+        # Project to embedding dimension
+        x = self.proj(x)
+
+        return x

--- a/src/mflux/models/zimage/embeddings/rope_3d.py
+++ b/src/mflux/models/zimage/embeddings/rope_3d.py
@@ -1,0 +1,219 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def apply_rope_complex(x: mx.array, freqs_cis: mx.array) -> mx.array:
+    """Apply rotary embeddings using complex number representation.
+
+    This matches the diffusers implementation which uses interleaved pairing
+    of adjacent elements as complex numbers.
+
+    Args:
+        x: Input tensor [B, S, n_heads, head_dim]
+        freqs_cis: Complex frequencies [S, head_dim//2, 2] where last dim is [cos, sin]
+
+    Returns:
+        Rotated tensor with same shape as input
+    """
+    # Reshape x to pair adjacent elements: [B, S, n_heads, head_dim//2, 2]
+    x_reshaped = x.reshape(*x.shape[:-1], -1, 2)
+
+    # Extract real and imaginary parts (adjacent pairs)
+    x_real = x_reshaped[..., 0]  # [B, S, n_heads, head_dim//2]
+    x_imag = x_reshaped[..., 1]  # [B, S, n_heads, head_dim//2]
+
+    # Extract cos and sin from freqs_cis: [S, head_dim//2]
+    # Broadcast to [1, S, 1, head_dim//2]
+    freqs_cos = freqs_cis[..., 0][None, :, None, :]
+    freqs_sin = freqs_cis[..., 1][None, :, None, :]
+
+    # Complex multiplication: (a + bi) * (cos + i*sin) = (a*cos - b*sin) + i*(a*sin + b*cos)
+    out_real = x_real * freqs_cos - x_imag * freqs_sin
+    out_imag = x_real * freqs_sin + x_imag * freqs_cos
+
+    # Interleave back: [B, S, n_heads, head_dim//2, 2] -> [B, S, n_heads, head_dim]
+    out = mx.stack([out_real, out_imag], axis=-1)
+    return out.reshape(*x.shape)
+
+
+def apply_rope(q: mx.array, k: mx.array, freqs_cos: mx.array, freqs_sin: mx.array) -> tuple[mx.array, mx.array]:
+    """Apply rotary position embeddings to Q and K.
+
+    Args:
+        q: Query tensor [B, S, n_heads, head_dim]
+        k: Key tensor [B, S, n_kv_heads, head_dim]
+        freqs_cos: Cosine frequencies [S, head_dim//2]
+        freqs_sin: Sine frequencies [S, head_dim//2]
+
+    Returns:
+        Rotated Q and K tensors
+    """
+    # Stack cos and sin into [S, head_dim//2, 2] format for complex multiplication
+    freqs_cis = mx.stack([freqs_cos, freqs_sin], axis=-1)
+
+    q_rotated = apply_rope_complex(q, freqs_cis)
+    k_rotated = apply_rope_complex(k, freqs_cis)
+
+    return q_rotated, k_rotated
+
+
+class RoPE3D(nn.Module):
+    """3D Rotary Position Embeddings for (time, height, width).
+
+    Z-Image uses 3-axis RoPE with specific frequency configurations:
+    - axes_dims: (32, 48, 48) - frequency dimensions per axis
+    - axes_lens: (1024, 512, 512) - maximum sequence lengths
+    - theta: 256.0 - base frequency
+
+    Position encoding scheme:
+    - Caption tokens: time=1,2,3,...,cap_len, h=0, w=0
+    - Image tokens: time=cap_len+1 (fixed), h=0..H-1, w=0..W-1
+    """
+
+    AXES_DIMS = (32, 48, 48)  # Dims for time, height, width (total 128 = head_dim)
+    AXES_LENS = (1024, 512, 512)  # Max lengths per axis
+    THETA = 256.0  # Base frequency
+    HEAD_DIM = 128  # Matches S3DiT head dimension
+
+    def __init__(self):
+        super().__init__()
+        # Precompute frequencies for each axis (will be looked up by position)
+        self._freqs_cache = {}
+        self._combined_cache = {}  # Cache for combined image + caption frequencies
+        self._precompute_freqs()
+
+    def _precompute_freqs(self):
+        """Precompute frequency tables for each axis."""
+        for axis_idx, (dim, max_len) in enumerate(zip(self.AXES_DIMS, self.AXES_LENS)):
+            # Compute base frequencies: 1 / theta^(2i/d) for i=0..dim//2-1
+            half_dim = dim // 2
+            base_freqs = 1.0 / (self.THETA ** (mx.arange(0, half_dim, dtype=mx.float32) / half_dim))
+
+            # Compute angles for all positions: [max_len, dim//2]
+            positions = mx.arange(max_len, dtype=mx.float32)[:, None]
+            angles = positions * base_freqs[None, :]
+
+            # Store as cos and sin
+            self._freqs_cache[axis_idx] = (mx.cos(angles), mx.sin(angles))
+
+    def get_freqs_for_positions(self, pos_ids: mx.array) -> tuple[mx.array, mx.array]:
+        """Look up frequencies for given position IDs.
+
+        Args:
+            pos_ids: Position indices [N, 3] where columns are (time, height, width)
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) each [N, head_dim//2]
+        """
+        # Vectorized version: Extract all axis positions at once
+        axis_positions = [pos_ids[:, axis_idx].astype(mx.int32) for axis_idx in range(3)]
+
+        # Look up frequencies for all axes in parallel
+        axis_cos_list = [self._freqs_cache[axis_idx][0][axis_positions[axis_idx]] for axis_idx in range(3)]
+        axis_sin_list = [self._freqs_cache[axis_idx][1][axis_positions[axis_idx]] for axis_idx in range(3)]
+
+        # Concatenate along last dimension: [N, head_dim//2]
+        freqs_cos = mx.concatenate(axis_cos_list, axis=-1)
+        freqs_sin = mx.concatenate(axis_sin_list, axis=-1)
+
+        return freqs_cos, freqs_sin
+
+    def get_image_freqs(self, h_patches: int, w_patches: int, time_offset: int = 1) -> tuple[mx.array, mx.array]:
+        """Generate RoPE frequencies for image patches.
+
+        Args:
+            h_patches: Number of patches in height
+            w_patches: Number of patches in width
+            time_offset: Time position for all image tokens (typically cap_len + 1)
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) each [N_patches, head_dim//2]
+        """
+        n_patches = h_patches * w_patches
+
+        # Create position IDs: [N_patches, 3]
+        h_pos, w_pos = self._get_2d_positions(h_patches, w_patches)
+        t_pos = mx.full((n_patches,), time_offset, dtype=mx.int32)
+
+        pos_ids = mx.stack([t_pos, h_pos, w_pos], axis=-1)
+        return self.get_freqs_for_positions(pos_ids)
+
+    def get_caption_freqs(self, cap_len: int) -> tuple[mx.array, mx.array]:
+        """Generate RoPE frequencies for caption tokens.
+
+        Args:
+            cap_len: Number of caption tokens
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) each [cap_len, head_dim//2]
+        """
+        # Caption positions: time=1,2,3,...,cap_len, h=0, w=0
+        t_pos = mx.arange(1, cap_len + 1, dtype=mx.int32)
+        h_pos = mx.zeros((cap_len,), dtype=mx.int32)
+        w_pos = mx.zeros((cap_len,), dtype=mx.int32)
+
+        pos_ids = mx.stack([t_pos, h_pos, w_pos], axis=-1)
+        return self.get_freqs_for_positions(pos_ids)
+
+    def get_combined_freqs(
+        self, h_patches: int, w_patches: int, cap_len: int, padded_cap_len: int
+    ) -> tuple[mx.array, mx.array]:
+        """Get cached combined frequencies for image + caption.
+
+        This is the main optimization: since image dimensions and caption length
+        are typically fixed for a generation run, we can precompute and cache
+        the combined frequencies instead of computing them separately each time.
+
+        Args:
+            h_patches: Number of patches in height
+            w_patches: Number of patches in width
+            cap_len: Number of caption tokens
+            padded_cap_len: Padded caption length (for time offset calculation)
+
+        Returns:
+            Tuple of (combined_freqs_cos, combined_freqs_sin) each [N_img + cap_len, head_dim//2]
+        """
+        key = (h_patches, w_patches, cap_len, padded_cap_len)
+        if key not in self._combined_cache:
+            # Compute image frequencies with proper time offset
+            img_freqs_cos, img_freqs_sin = self.get_image_freqs(h_patches, w_patches, time_offset=padded_cap_len + 1)
+
+            # Compute caption frequencies
+            cap_freqs_cos, cap_freqs_sin = self.get_caption_freqs(cap_len)
+
+            # Concatenate: image first, then caption (matches S3DiT order)
+            combined_cos = mx.concatenate([img_freqs_cos, cap_freqs_cos], axis=0)
+            combined_sin = mx.concatenate([img_freqs_sin, cap_freqs_sin], axis=0)
+
+            self._combined_cache[key] = (combined_cos, combined_sin)
+
+        return self._combined_cache[key]
+
+    def __call__(self, height: int, width: int) -> tuple[mx.array, mx.array]:
+        """Generate RoPE frequencies for image dimensions (legacy interface).
+
+        Args:
+            height: Image height in pixels
+            width: Image width in pixels
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) each [N_patches, head_dim//2]
+        """
+        h_patches = height // 16
+        w_patches = width // 16
+        return self.get_image_freqs(h_patches, w_patches, time_offset=1)
+
+    def _get_2d_positions(self, h_patches: int, w_patches: int) -> tuple[mx.array, mx.array]:
+        """Generate 2D position indices for image patches.
+
+        Returns:
+            h_pos, w_pos: Position arrays flattened to [N]
+        """
+        h_pos = mx.arange(h_patches, dtype=mx.int32)
+        w_pos = mx.arange(w_patches, dtype=mx.int32)
+
+        # Create meshgrid and flatten
+        h_grid = mx.repeat(h_pos[:, None], w_patches, axis=1)  # [H, W]
+        w_grid = mx.repeat(w_pos[None, :], h_patches, axis=0)  # [H, W]
+
+        return h_grid.flatten(), w_grid.flatten()

--- a/src/mflux/models/zimage/embeddings/timestep_embed.py
+++ b/src/mflux/models/zimage/embeddings/timestep_embed.py
@@ -1,0 +1,54 @@
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class TimestepEmbed(nn.Module):
+    """Sinusoidal timestep embedding with MLP projection.
+
+    Converts scalar timestep to [B, embed_dim] embedding for AdaLN conditioning.
+    HF structure: sinusoidal(256) -> Linear(256, 1024) -> SiLU -> Linear(1024, 256)
+    """
+
+    EMBED_DIM = 256  # Timestep embedding dimension (from HF weights)
+    MLP_HIDDEN = 1024  # MLP hidden dimension
+    T_SCALE = 1000.0  # From Z-Image config
+
+    def __init__(self):
+        super().__init__()
+        # MLP: Linear -> SiLU -> Linear
+        # Maps to t_embedder.mlp.{0,2}.weight
+        self.mlp = nn.Sequential(
+            nn.Linear(self.EMBED_DIM, self.MLP_HIDDEN),
+            nn.SiLU(),
+            nn.Linear(self.MLP_HIDDEN, self.EMBED_DIM),
+        )
+
+    def __call__(self, t: mx.array) -> mx.array:
+        """Generate timestep embedding.
+
+        Args:
+            t: Timestep values [B] in [0, 1]
+
+        Returns:
+            Timestep embeddings [B, embed_dim=256]
+        """
+        # Scale timestep
+        t = t * self.T_SCALE
+
+        # Sinusoidal embedding
+        half_dim = self.EMBED_DIM // 2
+        freqs = mx.exp(-math.log(10000.0) * mx.arange(0, half_dim) / half_dim)
+
+        # Ensure t has correct shape for broadcasting
+        if t.ndim == 0:
+            t = t.reshape(1)
+        if t.ndim == 1:
+            t = t[:, None]  # [B, 1]
+
+        args = t * freqs[None, :]  # [B, half_dim]
+        embedding = mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)  # [B, embed_dim]
+
+        # MLP projection
+        return self.mlp(embedding)

--- a/src/mflux/models/zimage/latent_creator/__init__.py
+++ b/src/mflux/models/zimage/latent_creator/__init__.py
@@ -1,0 +1,3 @@
+from mflux.models.zimage.latent_creator.zimage_latent_creator import ZImageLatentCreator
+
+__all__ = ["ZImageLatentCreator"]

--- a/src/mflux/models/zimage/latent_creator/zimage_latent_creator.py
+++ b/src/mflux/models/zimage/latent_creator/zimage_latent_creator.py
@@ -1,0 +1,37 @@
+import mlx.core as mx
+
+
+class ZImageLatentCreator:
+    @staticmethod
+    def create_noise(seed: int, height: int, width: int) -> mx.array:
+        """Create random noise for Z-Image latent space.
+
+        Args:
+            seed: Random seed
+            height: Image height in pixels
+            width: Image width in pixels
+
+        Returns:
+            Random noise tensor [1, 16, H/8, W/8]
+        """
+        return mx.random.normal(
+            shape=[1, 16, height // 8, width // 8],
+            key=mx.random.key(seed),
+        )
+
+    @staticmethod
+    def pack_latents(latents: mx.array, height: int, width: int) -> mx.array:
+        """Pack latents for Z-Image (identity operation).
+
+        Z-Image uses unpacked latents in BCHW format [1, 16, H/8, W/8],
+        unlike FLUX which uses packed format. So this is just an identity.
+
+        Args:
+            latents: Encoded latents from VAE [1, 16, H/8, W/8]
+            height: Image height in pixels
+            width: Image width in pixels
+
+        Returns:
+            Same latents unchanged
+        """
+        return latents

--- a/src/mflux/models/zimage/scheduler.py
+++ b/src/mflux/models/zimage/scheduler.py
@@ -1,0 +1,78 @@
+"""Z-Image scheduler with shift=3.0.
+
+This scheduler uses the formula from diffusers FlowMatchEulerDiscreteScheduler
+with use_dynamic_shifting=False and shift=3.0.
+"""
+
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+
+if TYPE_CHECKING:
+    from mflux.config.runtime_config import RuntimeConfig
+
+
+class ZImageScheduler:
+    """Flow matching Euler scheduler for Z-Image with shift=3.0.
+
+    Formula: sigma_shifted = shift * sigma / (1 + (shift - 1) * sigma)
+    """
+
+    SHIFT = 3.0  # Z-Image uses shift=3.0
+    NUM_TRAIN_TIMESTEPS = 1000
+
+    def __init__(self, runtime_config: "RuntimeConfig"):
+        self.runtime_config = runtime_config
+        self.num_inference_steps = runtime_config.num_inference_steps
+        self._sigmas, self._timesteps = self._compute_timesteps_and_sigmas()
+
+    @property
+    def sigmas(self) -> mx.array:
+        return self._sigmas
+
+    @property
+    def timesteps(self) -> mx.array:
+        return self._timesteps
+
+    def _compute_timesteps_and_sigmas(self) -> tuple[mx.array, mx.array]:
+        """Compute sigmas and timesteps with shift=3.0."""
+        num_steps = self.num_inference_steps
+
+        # Linear spacing from 1.0 to 1/num_steps
+        sigmas_linear = [1.0 - i / num_steps for i in range(num_steps + 1)]
+
+        # Apply shift: sigma_shifted = shift * sigma / (1 + (shift - 1) * sigma)
+        sigmas_shifted = []
+        for s in sigmas_linear:
+            if s > 0:
+                shifted = self.SHIFT * s / (1 + (self.SHIFT - 1) * s)
+            else:
+                shifted = 0.0
+            sigmas_shifted.append(shifted)
+
+        # Convert to timesteps (sigma * num_train_timesteps)
+        timesteps = [s * self.NUM_TRAIN_TIMESTEPS for s in sigmas_shifted[:-1]]
+
+        sigmas_arr = mx.array(sigmas_shifted, dtype=mx.float32)
+        timesteps_arr = mx.array(timesteps, dtype=mx.float32)
+
+        return sigmas_arr, timesteps_arr
+
+    def step(self, model_output: mx.array, timestep_idx: int, sample: mx.array) -> mx.array:
+        """Euler step: x_next = x + dt * velocity.
+
+        Args:
+            model_output: Velocity prediction from transformer
+            timestep_idx: Index into timesteps array
+            sample: Current sample
+
+        Returns:
+            Updated sample
+        """
+        dt = self._sigmas[timestep_idx + 1] - self._sigmas[timestep_idx]
+        prev_sample = sample + dt * model_output
+        return prev_sample
+
+    def scale_model_input(self, latents: mx.array, t: int) -> mx.array:
+        """Scale model input (identity for flow matching)."""
+        return latents

--- a/src/mflux/models/zimage/text_encoder/__init__.py
+++ b/src/mflux/models/zimage/text_encoder/__init__.py
@@ -1,0 +1,13 @@
+from mflux.models.zimage.text_encoder.qwen3_attention import Qwen3Attention
+from mflux.models.zimage.text_encoder.qwen3_encoder import Qwen3Encoder
+from mflux.models.zimage.text_encoder.qwen3_layer import Qwen3DecoderLayer
+from mflux.models.zimage.text_encoder.qwen3_mlp import Qwen3MLP
+from mflux.models.zimage.text_encoder.qwen3_tokenizer import Qwen3Tokenizer
+
+__all__ = [
+    "Qwen3Attention",
+    "Qwen3DecoderLayer",
+    "Qwen3Encoder",
+    "Qwen3MLP",
+    "Qwen3Tokenizer",
+]

--- a/src/mflux/models/zimage/text_encoder/qwen3_attention.py
+++ b/src/mflux/models/zimage/text_encoder/qwen3_attention.py
@@ -1,0 +1,135 @@
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.core.fast import scaled_dot_product_attention
+
+
+class Qwen3Attention(nn.Module):
+    """Qwen3 attention with Grouped Query Attention.
+
+    Key differences from S3DiT attention:
+    - Uses GQA: 32 query heads, 8 KV heads (4:1 ratio)
+    - Different RoPE configuration (theta=1000000)
+    - Has QK norms (q_norm, k_norm)
+    """
+
+    # Qwen3-4B architecture (from HF weights)
+    HIDDEN_SIZE = 2560
+    NUM_HEADS = 32  # Q heads
+    NUM_KV_HEADS = 8  # KV heads (4:1 GQA ratio)
+    HEAD_DIM = 128  # From q_norm.weight shape
+    ROPE_THETA = 1000000.0
+    NORM_EPS = 1e-6
+
+    def __init__(self):
+        super().__init__()
+
+        # Projections
+        self.q_proj = nn.Linear(self.HIDDEN_SIZE, self.NUM_HEADS * self.HEAD_DIM, bias=False)
+        self.k_proj = nn.Linear(self.HIDDEN_SIZE, self.NUM_KV_HEADS * self.HEAD_DIM, bias=False)
+        self.v_proj = nn.Linear(self.HIDDEN_SIZE, self.NUM_KV_HEADS * self.HEAD_DIM, bias=False)
+        self.o_proj = nn.Linear(self.NUM_HEADS * self.HEAD_DIM, self.HIDDEN_SIZE, bias=False)
+
+        # QK norms (per head_dim)
+        self.q_norm = nn.RMSNorm(self.HEAD_DIM, eps=self.NORM_EPS)
+        self.k_norm = nn.RMSNorm(self.HEAD_DIM, eps=self.NORM_EPS)
+
+        # RoPE cache for text positions
+        self._rope_cache: dict[int, tuple[mx.array, mx.array]] = {}
+
+    def _get_rope(self, seq_len: int) -> tuple[mx.array, mx.array]:
+        """Get or compute RoPE for given sequence length."""
+        if seq_len not in self._rope_cache:
+            freqs = 1.0 / (self.ROPE_THETA ** (mx.arange(0, self.HEAD_DIM, 2) / self.HEAD_DIM))
+            positions = mx.arange(seq_len)
+            angles = positions[:, None] * freqs[None, :]
+            cos = mx.cos(angles)
+            sin = mx.sin(angles)
+            self._rope_cache[seq_len] = (cos, sin)
+        return self._rope_cache[seq_len]
+
+    def __call__(self, x: mx.array, mask: mx.array | None = None) -> mx.array:
+        """Forward pass with optional attention mask.
+
+        Args:
+            x: Input tensor [B, S, HIDDEN_SIZE]
+            mask: Optional attention mask [S, S] or [B, 1, S, S]
+
+        Returns:
+            Output tensor [B, S, HIDDEN_SIZE]
+        """
+        B, S, _ = x.shape
+
+        # Project to Q, K, V
+        q = self.q_proj(x).reshape(B, S, self.NUM_HEADS, self.HEAD_DIM)
+        k = self.k_proj(x).reshape(B, S, self.NUM_KV_HEADS, self.HEAD_DIM)
+        v = self.v_proj(x).reshape(B, S, self.NUM_KV_HEADS, self.HEAD_DIM)
+
+        # Apply QK norms (per head)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+
+        # Apply RoPE
+        cos, sin = self._get_rope(S)
+        q, k = self._apply_rope(q, k, cos, sin)
+
+        # Expand KV heads for GQA
+        heads_per_kv = self.NUM_HEADS // self.NUM_KV_HEADS  # 4
+        k = mx.repeat(k, heads_per_kv, axis=2)
+        v = mx.repeat(v, heads_per_kv, axis=2)
+
+        # Transpose: [B, heads, S, head_dim]
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        # Scaled dot-product attention (fused kernel)
+        scale = self.HEAD_DIM**-0.5
+        out = scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+        # Reshape and project
+        out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
+        return self.o_proj(out)
+
+    def _apply_rope(self, q: mx.array, k: mx.array, cos: mx.array, sin: mx.array) -> tuple[mx.array, mx.array]:
+        """Apply rotary position embeddings.
+
+        Args:
+            q: Query tensor [B, S, heads, head_dim]
+            k: Key tensor [B, S, kv_heads, head_dim]
+            cos: Cosine frequencies [S, head_dim/2]
+            sin: Sine frequencies [S, head_dim/2]
+
+        Returns:
+            Rotated Q and K tensors
+        """
+        q_embed = self._rotate(q, cos, sin)
+        k_embed = self._rotate(k, cos, sin)
+        return q_embed, k_embed
+
+    def _rotate(self, x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+        """Rotate tensor with RoPE.
+
+        Args:
+            x: Input tensor [B, S, heads, head_dim]
+            cos: Cosine frequencies [S, head_dim/2]
+            sin: Sine frequencies [S, head_dim/2]
+
+        Returns:
+            Rotated tensor
+        """
+        # Split into halves
+        x1 = x[..., : self.HEAD_DIM // 2]
+        x2 = x[..., self.HEAD_DIM // 2 :]
+
+        # Rotate: [-x2, x1]
+        rotated = mx.concatenate([-x2, x1], axis=-1)
+
+        # Broadcast cos/sin: [S, head_dim/2] -> [1, S, 1, head_dim/2]
+        cos = cos[None, :, None, :]
+        sin = sin[None, :, None, :]
+
+        # Duplicate cos/sin to match full head_dim
+        cos = mx.concatenate([cos, cos], axis=-1)
+        sin = mx.concatenate([sin, sin], axis=-1)
+
+        return x * cos + rotated * sin

--- a/src/mflux/models/zimage/text_encoder/qwen3_encoder.py
+++ b/src/mflux/models/zimage/text_encoder/qwen3_encoder.py
@@ -1,0 +1,95 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mflux.models.zimage.text_encoder.qwen3_layer import Qwen3DecoderLayer
+
+
+class Qwen3Encoder(nn.Module):
+    """Qwen3-4B text encoder for Z-Image.
+
+    Full 36-layer decoder-only transformer used as text encoder.
+    Uses last hidden states (not logits) as text embeddings.
+    """
+
+    # Qwen3-4B architecture
+    HIDDEN_SIZE = 2560
+    NUM_LAYERS = 36
+    VOCAB_SIZE = 151936
+    RMS_NORM_EPS = 1e-6
+    MAX_SEQ_LEN = 2048
+
+    def __init__(self):
+        super().__init__()
+
+        # Token embeddings
+        self.embed_tokens = nn.Embedding(self.VOCAB_SIZE, self.HIDDEN_SIZE)
+
+        # Decoder layers
+        self.layers = [Qwen3DecoderLayer() for _ in range(self.NUM_LAYERS)]
+
+        # Final layer norm
+        self.norm = nn.RMSNorm(self.HIDDEN_SIZE, eps=self.RMS_NORM_EPS)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+        return_layer: int = -2,
+    ) -> mx.array:
+        """Forward pass to get text embeddings.
+
+        Args:
+            input_ids: Token IDs [B, seq_len]
+            attention_mask: Optional attention mask [B, seq_len], 1=attend, 0=mask
+            return_layer: Which layer's output to return (default -2 matches diffusers)
+                          -1 = final normed output, -2 = output before final layer
+
+        Returns:
+            Hidden states [B, seq_len, 2560]
+        """
+        # Embed tokens
+        hidden_states = self.embed_tokens(input_ids)
+
+        # Create causal mask
+        seq_len = input_ids.shape[1]
+        causal_mask = mx.triu(mx.full((seq_len, seq_len), -1e9), k=1)
+
+        # Apply attention mask if provided
+        if attention_mask is not None:
+            # Convert 1D mask to 2D attention mask
+            # attention_mask: [B, seq_len], 1=attend, 0=mask
+            # Need: [B, 1, 1, seq_len] for broadcasting with attention scores
+            mask_2d = (1 - attention_mask[:, None, None, :]) * -1e9
+            # Broadcast causal mask to batch dimension and add padding mask
+            causal_mask = causal_mask[None, None, :, :] + mask_2d
+        else:
+            # Just broadcast causal mask for batch compatibility
+            causal_mask = causal_mask[None, None, :, :]
+
+        # Process through layers, collecting hidden states
+        # hidden_states list: [embeddings, layer_0_out, layer_1_out, ..., layer_35_out]
+        all_hidden_states = [hidden_states]
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, mask=causal_mask)
+            all_hidden_states.append(hidden_states)
+
+        # Return the requested layer's output
+        if return_layer == -1:
+            # Final normed output (original behavior)
+            return self.norm(hidden_states)
+        else:
+            # Diffusers uses hidden_states[-2] which is output of layer 34 (second-to-last)
+            # Our list: [embed, l0, l1, ..., l34, l35]  (len=37)
+            # -2 index = l34 output
+            return all_hidden_states[return_layer]
+
+    def encode(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        """Convenience method that returns text embeddings.
+
+        Same as __call__ but with clearer semantics.
+        """
+        return self(input_ids, attention_mask)

--- a/src/mflux/models/zimage/text_encoder/qwen3_layer.py
+++ b/src/mflux/models/zimage/text_encoder/qwen3_layer.py
@@ -1,0 +1,47 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mflux.models.zimage.text_encoder.qwen3_attention import Qwen3Attention
+from mflux.models.zimage.text_encoder.qwen3_mlp import Qwen3MLP
+
+
+class Qwen3DecoderLayer(nn.Module):
+    """Single Qwen3 decoder layer.
+
+    Pre-norm architecture with RMSNorm.
+    """
+
+    HIDDEN_SIZE = 2560
+    RMS_NORM_EPS = 1e-6
+
+    def __init__(self):
+        super().__init__()
+
+        self.input_layernorm = nn.RMSNorm(self.HIDDEN_SIZE, eps=self.RMS_NORM_EPS)
+        self.self_attn = Qwen3Attention()
+        self.post_attention_layernorm = nn.RMSNorm(self.HIDDEN_SIZE, eps=self.RMS_NORM_EPS)
+        self.mlp = Qwen3MLP()
+
+    def __call__(self, x: mx.array, mask: mx.array | None = None) -> mx.array:
+        """Forward pass with pre-norm and residual connections.
+
+        Args:
+            x: Input tensor [B, S, HIDDEN_SIZE]
+            mask: Optional attention mask
+
+        Returns:
+            Output tensor [B, S, HIDDEN_SIZE]
+        """
+        # Pre-norm attention
+        residual = x
+        x = self.input_layernorm(x)
+        x = self.self_attn(x, mask=mask)
+        x = residual + x
+
+        # Pre-norm MLP
+        residual = x
+        x = self.post_attention_layernorm(x)
+        x = self.mlp(x)
+        x = residual + x
+
+        return x

--- a/src/mflux/models/zimage/text_encoder/qwen3_mlp.py
+++ b/src/mflux/models/zimage/text_encoder/qwen3_mlp.py
@@ -1,0 +1,34 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class Qwen3MLP(nn.Module):
+    """Qwen3 MLP with SwiGLU activation.
+
+    gate_proj and up_proj have same output dimension.
+    SwiGLU: swish(gate) * up, then down projection.
+    """
+
+    HIDDEN_SIZE = 2560
+    INTERMEDIATE_SIZE = 9728  # From Qwen3-4B config
+
+    def __init__(self):
+        super().__init__()
+
+        self.gate_proj = nn.Linear(self.HIDDEN_SIZE, self.INTERMEDIATE_SIZE, bias=False)
+        self.up_proj = nn.Linear(self.HIDDEN_SIZE, self.INTERMEDIATE_SIZE, bias=False)
+        self.down_proj = nn.Linear(self.INTERMEDIATE_SIZE, self.HIDDEN_SIZE, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Forward pass with SwiGLU activation.
+
+        Args:
+            x: Input tensor [B, S, HIDDEN_SIZE]
+
+        Returns:
+            Output tensor [B, S, HIDDEN_SIZE]
+        """
+        # SwiGLU: swish(gate) * up
+        gate = nn.silu(self.gate_proj(x))
+        up = self.up_proj(x)
+        return self.down_proj(gate * up)

--- a/src/mflux/models/zimage/text_encoder/qwen3_tokenizer.py
+++ b/src/mflux/models/zimage/text_encoder/qwen3_tokenizer.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import mlx.core as mx
+from transformers import AutoTokenizer
+
+
+class Qwen3Tokenizer:
+    """Tokenizer wrapper for Qwen3-4B.
+
+    Uses HuggingFace tokenizers for compatibility with existing mflux patterns.
+    """
+
+    MAX_LENGTH = 256  # Default max tokens for prompts
+    PAD_TOKEN_ID = 0
+
+    def __init__(self, tokenizer_path: str | Path | None = None):
+        """Initialize tokenizer.
+
+        Args:
+            tokenizer_path: Path to tokenizer files or HF model ID.
+                           If None, uses default Z-Image model.
+        """
+        if tokenizer_path is None:
+            # Default to HuggingFace model
+            tokenizer_path = "Tongyi-MAI/Z-Image-Turbo"
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path,
+            subfolder="tokenizer",
+            trust_remote_code=True,
+        )
+
+        # Set padding side
+        self.tokenizer.padding_side = "right"
+
+    def __call__(
+        self,
+        text: str | list[str],
+        max_length: int | None = None,
+        padding: bool = True,
+        truncation: bool = True,
+        apply_chat_template: bool = True,
+    ) -> dict[str, mx.array]:
+        """Tokenize text input.
+
+        Args:
+            text: Single string or list of strings
+            max_length: Maximum sequence length (default: MAX_LENGTH)
+            padding: Whether to pad to max_length
+            truncation: Whether to truncate to max_length
+            apply_chat_template: Whether to apply Qwen3 chat template (like diffusers)
+
+        Returns:
+            Dict with 'input_ids' and 'attention_mask' as mx.arrays
+        """
+        max_length = max_length or self.MAX_LENGTH
+
+        # Handle single string
+        if isinstance(text, str):
+            text = [text]
+
+        # Apply chat template if requested (matches diffusers behavior)
+        if apply_chat_template:
+            formatted_text = []
+            for prompt_item in text:
+                messages = [{"role": "user", "content": prompt_item}]
+                formatted = self.tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    enable_thinking=False,
+                )
+                formatted_text.append(formatted)
+            text = formatted_text
+
+        # Tokenize
+        encoded = self.tokenizer(
+            text,
+            max_length=max_length,
+            padding="max_length" if padding else False,
+            truncation=truncation,
+            return_tensors="np",
+        )
+
+        # Convert to MLX arrays
+        return {
+            "input_ids": mx.array(encoded["input_ids"]),
+            "attention_mask": mx.array(encoded["attention_mask"]),
+        }
+
+    def decode(self, token_ids: mx.array | list) -> str:
+        """Decode token IDs back to text.
+
+        Args:
+            token_ids: Token IDs to decode
+
+        Returns:
+            Decoded text string
+        """
+        if hasattr(token_ids, "tolist"):
+            token_ids = token_ids.tolist()
+        return self.tokenizer.decode(token_ids, skip_special_tokens=True)
+
+    @property
+    def vocab_size(self) -> int:
+        """Get vocabulary size."""
+        return len(self.tokenizer)
+
+    @property
+    def pad_token_id(self) -> int:
+        """Get padding token ID."""
+        return self.tokenizer.pad_token_id or self.PAD_TOKEN_ID
+
+    @property
+    def eos_token_id(self) -> int:
+        """Get end-of-sequence token ID."""
+        return self.tokenizer.eos_token_id

--- a/src/mflux/models/zimage/transformer/__init__.py
+++ b/src/mflux/models/zimage/transformer/__init__.py
@@ -1,0 +1,17 @@
+from mflux.models.zimage.transformer.adaln import AdaLayerNorm
+from mflux.models.zimage.transformer.attention import Attention
+from mflux.models.zimage.transformer.context_refiner import ContextRefinerBlock
+from mflux.models.zimage.transformer.feedforward import SwiGLUFeedForward
+from mflux.models.zimage.transformer.final_layer import FinalLayer
+from mflux.models.zimage.transformer.s3_dit import S3DiT
+from mflux.models.zimage.transformer.transformer_block import S3DiTBlock
+
+__all__ = [
+    "AdaLayerNorm",
+    "Attention",
+    "ContextRefinerBlock",
+    "FinalLayer",
+    "S3DiT",
+    "S3DiTBlock",
+    "SwiGLUFeedForward",
+]

--- a/src/mflux/models/zimage/transformer/adaln.py
+++ b/src/mflux/models/zimage/transformer/adaln.py
@@ -1,0 +1,44 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class AdaLayerNorm(nn.Module):
+    """Adaptive Layer Normalization with timestep conditioning.
+
+    Produces 6 modulation parameters from timestep embedding:
+    - shift_msa, scale_msa, gate_msa (for attention)
+    - shift_mlp, scale_mlp, gate_mlp (for FFN)
+    """
+
+    DIM = 3840
+    NORM_EPS = 1e-5
+
+    def __init__(self):
+        super().__init__()
+        # Project timestep embedding to 6 modulation parameters
+        self.linear = nn.Linear(self.DIM, self.DIM * 6, bias=True)
+
+    def __call__(self, x: mx.array, temb: mx.array) -> tuple[mx.array, ...]:
+        """Get modulation parameters from timestep embedding.
+
+        Args:
+            x: Input tensor [B, S, dim] (unused, for shape reference)
+            temb: Timestep embedding [B, dim]
+
+        Returns:
+            Tuple of 6 modulation tensors:
+            (shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+            Each has shape [B, 1, dim]
+        """
+        # Get modulation parameters from timestep
+        mods = self.linear(nn.silu(temb))
+        mods = mods.reshape(temb.shape[0], 1, 6, self.DIM)
+
+        shift_msa = mods[:, :, 0, :]
+        scale_msa = mods[:, :, 1, :]
+        gate_msa = mods[:, :, 2, :]
+        shift_mlp = mods[:, :, 3, :]
+        scale_mlp = mods[:, :, 4, :]
+        gate_mlp = mods[:, :, 5, :]
+
+        return shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp

--- a/src/mflux/models/zimage/transformer/attention.py
+++ b/src/mflux/models/zimage/transformer/attention.py
@@ -1,0 +1,73 @@
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.core.fast import scaled_dot_product_attention
+
+from mflux.models.zimage.embeddings.rope_3d import apply_rope
+
+
+class Attention(nn.Module):
+    """Self-attention with QK normalization and RoPE support.
+
+    Key differences from standard attention:
+    - RMSNorm applied to Q and K before attention (qk_norm=True)
+    - RoPE applied after normalization
+    - No GQA in Z-Image (n_heads == n_kv_heads == 30)
+    """
+
+    # Hardcoded for S3-DiT
+    DIM = 3840
+    N_HEADS = 30
+    N_KV_HEADS = 30  # No GQA
+    HEAD_DIM = 128
+    SCALE = HEAD_DIM**-0.5
+
+    def __init__(self):
+        super().__init__()
+
+        # Projections
+        self.to_q = nn.Linear(self.DIM, self.N_HEADS * self.HEAD_DIM, bias=False)
+        self.to_k = nn.Linear(self.DIM, self.N_KV_HEADS * self.HEAD_DIM, bias=False)
+        self.to_v = nn.Linear(self.DIM, self.N_KV_HEADS * self.HEAD_DIM, bias=False)
+        self.to_out = nn.Linear(self.N_HEADS * self.HEAD_DIM, self.DIM, bias=False)
+
+        # QK Normalization (critical for training stability)
+        self.norm_q = nn.RMSNorm(self.HEAD_DIM)
+        self.norm_k = nn.RMSNorm(self.HEAD_DIM)
+
+    def __call__(self, x: mx.array, rope: tuple[mx.array, mx.array] | None = None) -> mx.array:
+        """Forward pass with optional RoPE.
+
+        Args:
+            x: Input tensor [B, S, DIM]
+            rope: Optional tuple of (freqs_cos, freqs_sin) from RoPE3D
+
+        Returns:
+            Output tensor [B, S, DIM]
+        """
+        B, S, _ = x.shape
+
+        # Project
+        q = self.to_q(x).reshape(B, S, self.N_HEADS, self.HEAD_DIM)
+        k = self.to_k(x).reshape(B, S, self.N_KV_HEADS, self.HEAD_DIM)
+        v = self.to_v(x).reshape(B, S, self.N_KV_HEADS, self.HEAD_DIM)
+
+        # QK Normalization
+        q = self.norm_q(q)
+        k = self.norm_k(k)
+
+        # Apply RoPE
+        if rope is not None:
+            freqs_cos, freqs_sin = rope
+            q, k = apply_rope(q, k, freqs_cos, freqs_sin)
+
+        # Transpose for attention: [B, heads, S, head_dim]
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        # Scaled dot-product attention (fused kernel)
+        out = scaled_dot_product_attention(q, k, v, scale=self.SCALE, mask=None)
+
+        # Reshape and project
+        out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
+        return self.to_out(out)

--- a/src/mflux/models/zimage/transformer/context_refiner.py
+++ b/src/mflux/models/zimage/transformer/context_refiner.py
@@ -1,0 +1,61 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mflux.models.zimage.transformer.attention import Attention
+from mflux.models.zimage.transformer.feedforward import SwiGLUFeedForward
+
+
+class ContextRefinerBlock(nn.Module):
+    """Context refiner block for caption embeddings.
+
+    Simpler than S3DiTBlock - no AdaLN conditioning.
+    Uses pre/post RMSNorm pattern with SwiGLU FFN.
+    """
+
+    DIM = 3840
+    N_HEADS = 30
+    HEAD_DIM = 128
+    NORM_EPS = 1e-5
+
+    def __init__(self):
+        super().__init__()
+
+        # Attention norms
+        self.attention_norm1 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+        self.attention_norm2 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+
+        # Attention
+        self.attn = Attention()
+
+        # FFN norms
+        self.ffn_norm1 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+        self.ffn_norm2 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+
+        # SwiGLU FFN (context refiner uses SwiGLU, not GEGLU)
+        self.ff = SwiGLUFeedForward()
+
+    def __call__(
+        self,
+        x: mx.array,
+        rope: tuple[mx.array, mx.array] | None = None,
+    ) -> mx.array:
+        """Forward pass to refine caption embeddings.
+
+        Args:
+            x: Caption embeddings [B, seq_len, dim]
+            rope: Optional tuple of (freqs_cos, freqs_sin) from RoPE3D
+
+        Returns:
+            Refined caption embeddings [B, seq_len, dim]
+        """
+        # Pre-norm attention with optional RoPE
+        x_norm = self.attention_norm1(x)
+        attn_out = self.attn(x_norm, rope=rope)
+        x = x + self.attention_norm2(attn_out)
+
+        # Pre-norm FFN
+        x_norm = self.ffn_norm1(x)
+        ff_out = self.ff(x_norm)
+        x = x + self.ffn_norm2(ff_out)
+
+        return x

--- a/src/mflux/models/zimage/transformer/feedforward.py
+++ b/src/mflux/models/zimage/transformer/feedforward.py
@@ -1,0 +1,43 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class SwiGLUFeedForward(nn.Module):
+    """SwiGLU feedforward network.
+
+    SwiGLU: out = (Swish(W1 * x) * W3 * x) @ W2
+
+    Key difference from GEGLU:
+    - Uses Swish (SiLU) instead of GELU
+    - Three-weight design: gate (W1), up (W3), down (W2)
+
+    Used by both ContextRefiner and main transformer blocks.
+    """
+
+    DIM = 3840
+    HIDDEN_DIM = 10240  # From HuggingFace weights
+
+    def __init__(self):
+        super().__init__()
+        hidden_dim = self.HIDDEN_DIM
+
+        # W1: gate projection
+        self.w1 = nn.Linear(self.DIM, hidden_dim, bias=False)
+        # W2: down projection
+        self.w2 = nn.Linear(hidden_dim, self.DIM, bias=False)
+        # W3: up projection
+        self.w3 = nn.Linear(self.DIM, hidden_dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Forward pass with SwiGLU activation.
+
+        Args:
+            x: Input tensor [B, S, DIM]
+
+        Returns:
+            Output tensor [B, S, DIM]
+        """
+        # SwiGLU: swish(gate) * up, then down
+        gate = nn.silu(self.w1(x))  # Swish activation
+        up = self.w3(x)
+        return self.w2(gate * up)

--- a/src/mflux/models/zimage/transformer/final_layer.py
+++ b/src/mflux/models/zimage/transformer/final_layer.py
@@ -1,0 +1,48 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class FinalLayer(nn.Module):
+    """Final output layer for S3-DiT.
+
+    Projects transformer output back to latent space with AdaLN modulation.
+    """
+
+    DIM = 3840
+    TEMB_DIM = 256  # Timestep embedding dimension (matches t_embedder output)
+    PATCH_SIZE = 2
+    IN_CHANNELS = 16  # VAE latent channels
+
+    def __init__(self):
+        super().__init__()
+
+        # AdaLN modulation: takes 256-dim timestep embedding, outputs DIM for scale only
+        # Maps to all_final_layer.2-1.adaLN_modulation.1.weight (SiLU applied before linear)
+        # HF weight shape: (3840, 256) - only scale, no shift
+        self.adaLN = nn.Linear(self.TEMB_DIM, self.DIM, bias=True)
+
+        # Output projection (dim → patch_size² × in_channels)
+        out_dim = self.PATCH_SIZE**2 * self.IN_CHANNELS  # 4 * 16 = 64
+        self.linear = nn.Linear(self.DIM, out_dim, bias=True)
+
+        # Layer norm WITHOUT learnable parameters (elementwise_affine=False in PyTorch)
+        # Diffusers: nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.norm = nn.LayerNorm(self.DIM, eps=1e-6, affine=False)
+
+    def __call__(self, x: mx.array, temb: mx.array) -> mx.array:
+        """Project image tokens to patch outputs.
+
+        Args:
+            x: Image tokens [B, N_patches, dim]
+            temb: Timestep embedding [B, temb_dim=256]
+
+        Returns:
+            Patch predictions [B, N_patches, patch_size² × in_channels]
+        """
+        # Get scale modulation (no shift in final layer)
+        scale = self.adaLN(nn.silu(temb))  # [B, dim]
+        scale = scale[:, None, :]  # [B, 1, dim]
+
+        # Apply scale modulation and project
+        x = self.norm(x) * (1 + scale)
+        return self.linear(x)

--- a/src/mflux/models/zimage/transformer/s3_dit.py
+++ b/src/mflux/models/zimage/transformer/s3_dit.py
@@ -1,0 +1,261 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mflux.models.zimage.embeddings import CaptionEmbed, PatchEmbed, RoPE3D, TimestepEmbed
+from mflux.models.zimage.transformer.context_refiner import ContextRefinerBlock
+from mflux.models.zimage.transformer.final_layer import FinalLayer
+from mflux.models.zimage.transformer.transformer_block import S3DiTBlock
+
+
+class S3DiT(nn.Module):
+    """Scalable Single-Stream Diffusion Transformer.
+
+    Full Z-Image transformer architecture:
+    1. Embed inputs (patches, captions, timestep)
+    2. Refine image patches with noise_refiner (WITH adaLN)
+    3. Refine captions with context_refiner (WITHOUT adaLN)
+    4. Concatenate refined captions + images into single stream
+    5. 30 transformer blocks with AdaLN
+    6. Extract and unpatchify image tokens
+    """
+
+    # Hardcoded architecture
+    DIM = 3840
+    N_LAYERS = 30
+    N_REFINER_LAYERS = 2
+    VAE_SCALE_FACTOR = 8  # VAE spatial downsampling factor (latent = pixel / 8)
+    SEQ_MULTI_OF = 32  # Sequence padding multiple for caption alignment
+
+    def __init__(self):
+        super().__init__()
+
+        # Input embeddings (from Phase 1)
+        self.x_embedder = PatchEmbed()
+        self.cap_embedder = CaptionEmbed()
+        self.t_embedder = TimestepEmbed()
+
+        # RoPE
+        self.rope = RoPE3D()
+
+        # Noise refiner (2 layers) - processes IMAGE patches WITH adaLN
+        self.noise_refiner = [S3DiTBlock() for _ in range(self.N_REFINER_LAYERS)]
+
+        # Context refiner (2 layers) - processes CAPTIONS WITHOUT adaLN
+        self.context_refiner = [ContextRefinerBlock() for _ in range(self.N_REFINER_LAYERS)]
+
+        # Main transformer blocks (30 layers)
+        self.transformer_blocks = [S3DiTBlock() for _ in range(self.N_LAYERS)]
+
+        # Output projection
+        self.final_layer = FinalLayer()
+
+        # Compiled forward implementation (lazy initialization)
+        self._compiled_forward = None
+
+        # Lazy cache for quantization check
+        self._quantized_cached = None
+
+    # Hardcoded patch size constant
+    PATCH_SIZE = 2  # From PatchEmbed
+
+    def _pad_to_multiple(self, length: int) -> int:
+        """Pad length to next multiple of SEQ_MULTI_OF."""
+        return length + ((-length) % self.SEQ_MULTI_OF)
+
+    def precompute_rope(self, height: int, width: int, caption_len: int) -> tuple[mx.array, mx.array]:
+        """Precompute RoPE frequencies for given dimensions.
+
+        Call once before denoising loop, then pass result to __call__.
+
+        Args:
+            height: Latent height (pixels / VAE_SCALE_FACTOR)
+            width: Latent width (pixels / VAE_SCALE_FACTOR)
+            caption_len: Number of caption tokens
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) for the combined image + caption sequence
+        """
+        h_patches = height // self.PATCH_SIZE
+        w_patches = width // self.PATCH_SIZE
+
+        # Compute padded caption length (matches _forward_impl logic)
+        padded_cap_len = self._pad_to_multiple(caption_len)
+
+        # Get image frequencies with time offset
+        img_freqs_cos, img_freqs_sin = self.rope.get_image_freqs(h_patches, w_patches, time_offset=padded_cap_len + 1)
+
+        # Get caption frequencies
+        cap_freqs_cos, cap_freqs_sin = self.rope.get_caption_freqs(caption_len)
+
+        # Concatenate: image first, then caption (matches S3DiT order)
+        freqs_cos = mx.concatenate([img_freqs_cos, cap_freqs_cos], axis=0)
+        freqs_sin = mx.concatenate([img_freqs_sin, cap_freqs_sin], axis=0)
+
+        return freqs_cos, freqs_sin
+
+    def precompute_timestep_embeddings(self, scheduler, num_steps: int) -> mx.array:
+        """Precompute all timestep embeddings for the denoising loop.
+
+        Args:
+            scheduler: ZImageScheduler with timesteps
+            num_steps: Number of inference steps
+
+        Returns:
+            Tensor of shape [num_steps, embed_dim] with all timestep embeddings
+        """
+        # Normalize timesteps as done in zimage.py
+        all_t = mx.stack([(1000.0 - scheduler.timesteps[i]) / 1000.0 for i in range(num_steps)])
+        return self.t_embedder(all_t)
+
+    def __call__(
+        self,
+        latents: mx.array,  # [B, C, H, W] VAE latents
+        text_embeddings: mx.array,  # [B, S, cap_feat_dim] from Qwen
+        timestep: mx.array | None = None,  # [B] timestep values (optional if temb provided)
+        rope: tuple[mx.array, mx.array] | None = None,  # Optional precomputed RoPE
+        temb: mx.array | None = None,  # Optional precomputed timestep embedding
+    ) -> mx.array:
+        """Forward pass through S3-DiT with compilation.
+
+        Note: Compilation is skipped for quantized models to avoid memory spike.
+        mx.compile() traces through the function and captures quantized weights
+        as dequantized fp16 constants, causing ~25GB memory increase.
+
+        Args:
+            latents: VAE latent representations [B, 16, H, W]
+            text_embeddings: Caption embeddings from Qwen3 [B, S, 2560]
+            timestep: Timestep values [B] (optional if temb provided)
+            rope: Optional precomputed RoPE frequencies (freqs_cos, freqs_sin)
+            temb: Optional precomputed timestep embedding [B, 256]
+
+        Returns:
+            Patch predictions [B, N_patches, 64]
+        """
+        # Skip compilation for quantized models to avoid memory spike
+        # (compilation captures dequantized weights as constants)
+        if self._is_quantized():
+            return self._forward_impl(latents, text_embeddings, timestep, rope, temb)
+
+        # Lazy compilation: compile on first call (fp16 models only)
+        if self._compiled_forward is None:
+            self._compiled_forward = mx.compile(self._forward_impl)
+
+        return self._compiled_forward(latents, text_embeddings, timestep, rope, temb)
+
+    def _is_quantized(self) -> bool:
+        """Check if model contains quantized layers (cached after first check).
+
+        Returns:
+            True if any layer is quantized, False otherwise
+        """
+        if self._quantized_cached is None:
+            self._quantized_cached = any(isinstance(m, nn.QuantizedLinear) for m in self.modules())
+        return self._quantized_cached
+
+    def _forward_impl(
+        self,
+        latents: mx.array,  # [B, C, H, W] VAE latents
+        text_embeddings: mx.array,  # [B, S, cap_feat_dim] from Qwen
+        timestep: mx.array | None = None,  # [B] timestep values (optional if temb provided)
+        rope: tuple[mx.array, mx.array] | None = None,  # Optional precomputed RoPE
+        temb: mx.array | None = None,  # Optional precomputed timestep embedding
+    ) -> mx.array:
+        """Internal forward implementation (compiled).
+
+        Args:
+            latents: VAE latent representations [B, 16, H, W]
+            text_embeddings: Caption embeddings from Qwen3 [B, S, 2560]
+            timestep: Timestep values [B] (optional if temb provided)
+            rope: Optional precomputed RoPE frequencies (freqs_cos, freqs_sin)
+            temb: Optional precomputed timestep embedding [B, 256]
+
+        Returns:
+            Patch predictions [B, N_patches, 64]
+        """
+        height, width = latents.shape[2], latents.shape[3]
+
+        # 1. Embed inputs
+        x = self.x_embedder(latents)  # [B, N_patches, dim]
+        cap = self.cap_embedder(text_embeddings)  # [B, S, dim]
+
+        # Use precomputed timestep embedding if provided, otherwise compute from timestep
+        if temb is None:
+            temb = self.t_embedder(timestep)  # [B, temb_dim=256]
+
+        n_cap_tokens = cap.shape[1]
+        n_img_tokens = x.shape[1]
+
+        # Compute patch dimensions
+        h_patches = height // self.x_embedder.PATCH_SIZE
+        w_patches = width // self.x_embedder.PATCH_SIZE
+
+        # 2. Get RoPE frequencies - use precomputed if available, otherwise compute
+        if rope is not None:
+            # Use precomputed RoPE frequencies (optimization for denoising loop)
+            full_freqs_cos, full_freqs_sin = rope
+
+            # Split into image and caption parts
+            n_img_patches = h_patches * w_patches
+            img_freqs_cos = full_freqs_cos[:n_img_patches]
+            img_freqs_sin = full_freqs_sin[:n_img_patches]
+            cap_freqs_cos = full_freqs_cos[n_img_patches:]
+            cap_freqs_sin = full_freqs_sin[n_img_patches:]
+        else:
+            # Compute RoPE frequencies (backwards compatibility)
+            # Diffusers pads caption length to multiple of 32 for position computation
+            padded_cap_len = self._pad_to_multiple(n_cap_tokens)
+            img_freqs_cos, img_freqs_sin = self.rope.get_image_freqs(
+                h_patches, w_patches, time_offset=padded_cap_len + 1
+            )
+            cap_freqs_cos, cap_freqs_sin = self.rope.get_caption_freqs(n_cap_tokens)
+
+            # Concatenate for full sequence
+            full_freqs_cos = mx.concatenate([img_freqs_cos, cap_freqs_cos], axis=0)
+            full_freqs_sin = mx.concatenate([img_freqs_sin, cap_freqs_sin], axis=0)
+
+        img_rope = (img_freqs_cos, img_freqs_sin)
+        cap_rope = (cap_freqs_cos, cap_freqs_sin)
+        full_rope = (full_freqs_cos, full_freqs_sin)
+
+        # 3. Refine image patches with noise_refiner (WITH adaLN)
+        for refiner in self.noise_refiner:
+            x = refiner(x, temb, rope=img_rope)
+
+        # 4. Refine captions with context_refiner (WITHOUT adaLN, but WITH RoPE)
+        for refiner in self.context_refiner:
+            cap = refiner(cap, rope=cap_rope)
+
+        # 5. SINGLE-STREAM: Concatenate images + captions (IMAGE FIRST per diffusers)
+        hidden_states = mx.concatenate([x, cap], axis=1)
+
+        # 6. Apply main transformer blocks
+        for block in self.transformer_blocks:
+            hidden_states = block(hidden_states, temb, rope=full_rope)
+
+        # 7. Extract image tokens (at the beginning) and project to output
+        img_tokens = hidden_states[:, :n_img_tokens, :]
+        out = self.final_layer(img_tokens, temb)
+
+        return out
+
+    def unpatchify(self, x: mx.array, height: int, width: int) -> mx.array:
+        """Convert patches back to spatial layout.
+
+        Args:
+            x: Patch tensor [B, N_patches, patch_size² × C]
+            height: Latent height
+            width: Latent width
+
+        Returns:
+            Spatial tensor [B, C, H, W]
+        """
+        patch_size = self.x_embedder.PATCH_SIZE
+        in_channels = self.x_embedder.IN_CHANNELS
+
+        h_patches = height // patch_size
+        w_patches = width // patch_size
+
+        x = x.reshape(x.shape[0], h_patches, w_patches, patch_size, patch_size, in_channels)
+        x = x.transpose(0, 5, 1, 3, 2, 4)
+        x = x.reshape(x.shape[0], in_channels, height, width)
+        return x

--- a/src/mflux/models/zimage/transformer/transformer_block.py
+++ b/src/mflux/models/zimage/transformer/transformer_block.py
@@ -1,0 +1,85 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mflux.models.zimage.transformer.attention import Attention
+from mflux.models.zimage.transformer.feedforward import SwiGLUFeedForward
+
+
+class S3DiTBlock(nn.Module):
+    """Single S3-DiT transformer block with AdaLN conditioning.
+
+    Structure matches HuggingFace Z-Image-Turbo weights:
+    1. AdaLN modulation from 256-dim timestep embedding
+    2. Attention with pre/post RMSNorm and gated residual
+    3. FFN with pre/post RMSNorm and gated residual
+    """
+
+    DIM = 3840
+    TEMB_DIM = 256  # Timestep embedding dimension
+    N_HEADS = 30
+    N_KV_HEADS = 30
+    HEAD_DIM = 128
+    NORM_EPS = 1e-5
+
+    def __init__(self):
+        super().__init__()
+
+        # AdaLN modulation: 256-dim timestep -> 4*dim modulation params
+        # Output: [scale_attn, shift_attn, scale_ffn, shift_ffn] (4 vectors of dim 3840)
+        self.adaLN = nn.Linear(self.TEMB_DIM, 4 * self.DIM, bias=True)
+
+        # Attention norms (pre/post)
+        self.attention_norm1 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+        self.attention_norm2 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+
+        # Self-attention
+        self.attn = Attention()
+
+        # FFN norms (pre/post)
+        self.ffn_norm1 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+        self.ffn_norm2 = nn.RMSNorm(self.DIM, eps=self.NORM_EPS)
+
+        # FFN (SwiGLU with hidden_dim=10240)
+        self.ff = SwiGLUFeedForward()
+
+    def __call__(
+        self,
+        x: mx.array,
+        temb: mx.array,
+        rope: tuple[mx.array, mx.array] | None = None,
+    ) -> mx.array:
+        """Forward pass with timestep conditioning.
+
+        Args:
+            x: Hidden states [B, S, dim]
+            temb: Timestep embedding [B, temb_dim=256]
+            rope: Optional tuple of (freqs_cos, freqs_sin) from RoPE3D
+
+        Returns:
+            Updated hidden states [B, S, dim]
+        """
+        # Get AdaLN modulation parameters (4 vectors)
+        # Order from HuggingFace: scale_msa, gate_msa, scale_mlp, gate_mlp
+        modulation = self.adaLN(temb)  # [B, 4*dim]
+        scale_msa, gate_msa, scale_mlp, gate_mlp = mx.split(modulation[:, None, :], 4, axis=-1)  # Each [B, 1, dim]
+
+        # Apply tanh to gates, add 1.0 to scales (matches diffusers)
+        gate_msa = mx.tanh(gate_msa)
+        gate_mlp = mx.tanh(gate_mlp)
+        scale_msa = 1.0 + scale_msa
+        scale_mlp = 1.0 + scale_mlp
+
+        # Attention block: scale input, gate output
+        attn_out = self.attn(
+            self.attention_norm1(x) * scale_msa,
+            rope=rope,
+        )
+        x = x + gate_msa * self.attention_norm2(attn_out)
+
+        # FFN block: scale input, gate output
+        ffn_out = self.ff(
+            self.ffn_norm1(x) * scale_mlp,
+        )
+        x = x + gate_mlp * self.ffn_norm2(ffn_out)
+
+        return x

--- a/src/mflux/models/zimage/weights/__init__.py
+++ b/src/mflux/models/zimage/weights/__init__.py
@@ -1,0 +1,11 @@
+from mflux.models.zimage.weights.zimage_weight_handler import (
+    ZImageComponents,
+    ZImageWeightHandler,
+)
+from mflux.models.zimage.weights.zimage_weight_mapping import ZImageWeightMapping
+
+__all__ = [
+    "ZImageComponents",
+    "ZImageWeightHandler",
+    "ZImageWeightMapping",
+]

--- a/src/mflux/models/zimage/weights/zimage_weight_handler.py
+++ b/src/mflux/models/zimage/weights/zimage_weight_handler.py
@@ -1,0 +1,464 @@
+"""
+Z-Image weight handler for loading S3-DiT transformer, Qwen3 text encoder, and VAE weights.
+
+Supports:
+- Loading from HuggingFace Hub or local path
+- Sharded safetensors files
+- Pre-quantized weights (metadata detection)
+- Runtime quantization (3/4/5/6/8-bit)
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+import mlx.nn as nn
+import torch
+from mlx.utils import tree_unflatten
+from safetensors.torch import load_file as torch_load_file
+
+from mflux.models.common.weights.mapping.weight_mapper import WeightMapper
+from mflux.models.flux.weights.weight_handler import MetaData
+from mflux.models.zimage.weights.zimage_weight_mapping import ZImageWeightMapping
+from mflux.utils.download import snapshot_download
+
+if TYPE_CHECKING:
+    from mflux.models.zimage.text_encoder import Qwen3Encoder, Qwen3Tokenizer
+    from mflux.models.zimage.transformer import S3DiT
+
+
+@dataclass
+class ZImageComponents:
+    """Container for all Z-Image model components."""
+
+    transformer: "S3DiT"
+    text_encoder: "Qwen3Encoder"
+    tokenizer: "Qwen3Tokenizer"
+    vae: nn.Module  # AutoencoderKL from FLUX
+
+
+class ZImageWeightHandler:
+    """Load Z-Image weights from HuggingFace or local path."""
+
+    # HuggingFace repo mapping
+    REPO_MAP = {
+        "zimage-turbo": "Tongyi-MAI/Z-Image-Turbo",
+    }
+
+    # Architecture constants
+    N_TRANSFORMER_BLOCKS = 30
+    N_REFINER_LAYERS = 2
+    N_TEXT_ENCODER_LAYERS = 36
+
+    # Quantization support
+    VALID_QUANTIZE_BITS = [3, 4, 5, 6, 8]
+    DEFAULT_GROUP_SIZE = 64  # mflux standard
+
+    # Expected memory sizes in GB
+    EXPECTED_SIZES = {
+        # (transformer_gb, text_encoder_gb, total_gb)
+        None: (24.6, 8.0, 32.8),  # fp16
+        16: (24.6, 8.0, 32.8),  # bf16/fp16
+        8: (12.3, 4.0, 16.5),  # 8-bit
+        6: (9.2, 3.0, 12.4),  # 6-bit
+        4: (6.2, 2.0, 8.4),  # 4-bit
+        3: (4.6, 1.5, 6.3),  # 3-bit
+    }
+
+    def __init__(
+        self,
+        meta_data: MetaData,
+        transformer: dict | None = None,
+        text_encoder: dict | None = None,
+        vae: dict | None = None,
+    ):
+        self.meta_data = meta_data
+        self.transformer = transformer
+        self.text_encoder = text_encoder
+        self.vae = vae
+
+    @staticmethod
+    def load_regular_weights(
+        repo_id: str | None = None,
+        local_path: str | None = None,
+    ) -> "ZImageWeightHandler":
+        """Load Z-Image weights from HuggingFace or local path.
+
+        Args:
+            repo_id: HuggingFace repo ID or alias ("zimage-turbo")
+            local_path: Optional local path override
+
+        Returns:
+            ZImageWeightHandler with loaded weights
+        """
+        root_path: Path | None = None
+        if local_path:
+            root_path = Path(local_path)
+        elif repo_id:
+            # Resolve alias to repo ID
+            actual_repo_id = ZImageWeightHandler.REPO_MAP.get(repo_id, repo_id)
+            root_path = ZImageWeightHandler._download_weights(actual_repo_id)
+
+        if root_path is None:
+            raise ValueError("Either repo_id or local_path must be provided")
+
+        # Try to load pre-saved mflux format first
+        transformer_weights, quantization_level, mflux_version = ZImageWeightHandler._try_load_saved_component(
+            root_path, "transformer"
+        )
+        text_encoder_weights, _, _ = ZImageWeightHandler._try_load_saved_component(root_path, "text_encoder")
+        vae_weights, _, _ = ZImageWeightHandler._try_load_saved_component(root_path, "vae")
+
+        # Fall back to HuggingFace format if not found
+        if transformer_weights is None:
+            transformer_weights = ZImageWeightHandler._load_transformer_weights(root_path)
+            quantization_level = None
+            mflux_version = None
+
+        if text_encoder_weights is None:
+            text_encoder_weights = ZImageWeightHandler._load_text_encoder_weights(root_path)
+
+        if vae_weights is None:
+            vae_weights = ZImageWeightHandler._load_vae_weights(root_path)
+
+        return ZImageWeightHandler(
+            meta_data=MetaData(
+                quantization_level=quantization_level,
+                scale=None,
+                is_lora=False,
+                mflux_version=mflux_version,
+            ),
+            transformer=transformer_weights,
+            text_encoder=text_encoder_weights,
+            vae=vae_weights,
+        )
+
+    @staticmethod
+    def _download_weights(repo_id: str) -> Path:
+        """Download weights from HuggingFace Hub."""
+        return Path(
+            snapshot_download(
+                repo_id=repo_id,
+                allow_patterns=[
+                    "transformer/*.safetensors",
+                    "transformer/*.json",
+                    "text_encoder/*.safetensors",
+                    "text_encoder/*.json",
+                    "tokenizer/*",
+                    "vae/*.safetensors",
+                    "vae/*.json",
+                ],
+            )
+        )
+
+    @staticmethod
+    def _load_safetensors_shards(path: Path) -> dict[str, mx.array]:
+        """Load all safetensor shards from a directory.
+
+        Handles:
+        - Sharded files (model-00001-of-00003.safetensors)
+        - Single files (model.safetensors)
+        - bfloat16 to float16 conversion
+        """
+        shard_files = sorted(f for f in path.glob("*.safetensors") if not f.name.startswith("._"))
+        if not shard_files:
+            raise FileNotFoundError(f"No safetensors files found in {path}")
+
+        all_weights: dict[str, mx.array] = {}
+        for shard in shard_files:
+            # Use torch loader for bfloat16 support
+            torch_weights = torch_load_file(str(shard))
+            for key, tensor in torch_weights.items():
+                if tensor.dtype == torch.bfloat16:
+                    tensor = tensor.to(torch.float16)
+                all_weights[key] = mx.array(tensor.numpy())
+
+        return all_weights
+
+    @staticmethod
+    def _load_transformer_weights(root_path: Path) -> dict:
+        """Load and map transformer weights."""
+        transformer_path = root_path / "transformer"
+        if transformer_path.exists() and list(transformer_path.glob("*.safetensors")):
+            raw_weights = ZImageWeightHandler._load_safetensors_shards(transformer_path)
+        else:
+            raw_weights = ZImageWeightHandler._load_safetensors_shards(root_path)
+
+        mapping = ZImageWeightMapping.get_transformer_mapping()
+        return WeightMapper.apply_mapping(
+            raw_weights,
+            mapping,
+            num_blocks=ZImageWeightHandler.N_TRANSFORMER_BLOCKS,
+        )
+
+    @staticmethod
+    def _load_text_encoder_weights(root_path: Path) -> dict:
+        """Load and map text encoder weights."""
+        text_encoder_path = root_path / "text_encoder"
+        raw_weights = ZImageWeightHandler._load_safetensors_shards(text_encoder_path)
+
+        mapping = ZImageWeightMapping.get_text_encoder_mapping()
+        return WeightMapper.apply_mapping(
+            raw_weights,
+            mapping,
+            num_layers=ZImageWeightHandler.N_TEXT_ENCODER_LAYERS,
+        )
+
+    @staticmethod
+    def _load_vae_weights(root_path: Path) -> dict:
+        """Load VAE weights.
+
+        Z-Image uses the same VAE as FLUX. Weights need:
+        1. Conv weight transposition from PyTorch OIHW to MLX OHWI format
+        2. Restructuring to match FLUX VAE model structure
+        """
+        from mflux.config.config import Config
+
+        vae_path = root_path / "vae"
+        raw_weights = ZImageWeightHandler._load_safetensors_shards(vae_path)
+
+        # Transpose conv weights from PyTorch OIHW to MLX OHWI and cast to precision
+        processed_weights = []
+        for key, value in raw_weights.items():
+            if len(value.shape) == 4:
+                value = value.transpose(0, 2, 3, 1)  # OIHW -> OHWI
+            value = value.reshape(-1).reshape(value.shape).astype(Config.precision)
+            processed_weights.append((key, value))
+
+        weights = tree_unflatten(processed_weights)
+
+        # Restructure to match FLUX VAE model structure
+        weights["decoder"]["conv_in"] = {"conv2d": weights["decoder"]["conv_in"]}
+        weights["decoder"]["conv_out"] = {"conv2d": weights["decoder"]["conv_out"]}
+        weights["decoder"]["conv_norm_out"] = {"norm": weights["decoder"]["conv_norm_out"]}
+        weights["encoder"]["conv_in"] = {"conv2d": weights["encoder"]["conv_in"]}
+        weights["encoder"]["conv_out"] = {"conv2d": weights["encoder"]["conv_out"]}
+        weights["encoder"]["conv_norm_out"] = {"norm": weights["encoder"]["conv_norm_out"]}
+
+        return weights
+
+    @staticmethod
+    def _try_load_saved_component(
+        root_path: Path,
+        component_name: str,
+    ) -> tuple[dict | None, int | None, str | None]:
+        """Try to load a pre-saved mflux component.
+
+        Returns:
+            (weights, quantization_level, mflux_version) or (None, None, None)
+        """
+        component_path = root_path / component_name
+        if not component_path.exists():
+            return None, None, None
+
+        shard_files = sorted(f for f in component_path.glob("*.safetensors") if not f.name.startswith("._"))
+        if not shard_files:
+            return None, None, None
+
+        all_weights: dict[str, mx.array] = {}
+        quantization_level: int | None = None
+        mflux_version: str | None = None
+
+        for idx, shard in enumerate(shard_files):
+            data = mx.load(str(shard), return_metadata=True)
+            weights_dict = data[0]
+            all_weights.update(dict(weights_dict.items()))
+
+            if idx == 0 and len(data) > 1:
+                quantization_level = data[1].get("quantization_level")
+                mflux_version = data[1].get("mflux_version")
+
+        if quantization_level is None and mflux_version is None:
+            return None, None, None
+
+        unflattened = tree_unflatten(list(all_weights.items()))
+        return unflattened, quantization_level, mflux_version
+
+    @classmethod
+    def estimate_memory(cls, quantize: int | None = None) -> dict:
+        """Estimate memory requirements for given quantization level.
+
+        Args:
+            quantize: Quantization bits (3, 4, 5, 6, 8) or None for fp16
+
+        Returns:
+            Dict with memory estimates in GB
+        """
+        trans, text, total = cls.EXPECTED_SIZES.get(quantize, cls.EXPECTED_SIZES[None])
+        return {
+            "transformer_gb": trans,
+            "text_encoder_gb": text,
+            "total_gb": total,
+            "quantize": quantize or 16,
+        }
+
+    @classmethod
+    def recommend_quantization(cls, available_memory_gb: float) -> int | None:
+        """Recommend quantization level based on available memory.
+
+        Args:
+            available_memory_gb: Available GPU memory in GB
+
+        Returns:
+            Recommended quantization bits, or None for fp16
+        """
+        # Add 2GB headroom for inference
+        required = available_memory_gb - 2.0
+
+        for bits in [None, 8, 6, 4, 3]:
+            _, _, total = cls.EXPECTED_SIZES[bits]
+            if total <= required:
+                return bits
+
+        # If even 3-bit doesn't fit, return 3-bit anyway
+        return 3
+
+    def num_transformer_blocks(self) -> int:
+        """Get number of transformer blocks from weights."""
+        return self.N_TRANSFORMER_BLOCKS
+
+    def num_refiner_layers(self) -> int:
+        """Get number of context refiner layers from weights."""
+        return self.N_REFINER_LAYERS
+
+    def load_all(
+        self,
+        root_path: Path,
+        quantize: int | None = None,
+    ) -> ZImageComponents:
+        """Create and load all Z-Image model components.
+
+        Args:
+            root_path: Path to model directory (for tokenizer)
+            quantize: Optional quantization bits (3, 4, 5, 6, 8)
+
+        Returns:
+            ZImageComponents with all loaded models
+        """
+        # Import models here to avoid circular imports
+        from mflux.models.flux.model.flux_vae.vae import VAE
+        from mflux.models.zimage.text_encoder import Qwen3Encoder, Qwen3Tokenizer
+        from mflux.models.zimage.transformer import S3DiT
+
+        # Create model instances
+        transformer = S3DiT()
+        text_encoder = Qwen3Encoder()
+        vae = VAE()
+        # Qwen3Tokenizer expects root path - it uses subfolder="tokenizer" internally
+        tokenizer = Qwen3Tokenizer(tokenizer_path=str(root_path))
+
+        # Apply weights
+        self._apply_weights(
+            transformer=transformer,
+            text_encoder=text_encoder,
+            vae=vae,
+            quantize=quantize,
+        )
+
+        return ZImageComponents(
+            transformer=transformer,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            vae=vae,
+        )
+
+    def _apply_weights(
+        self,
+        transformer: nn.Module,
+        text_encoder: nn.Module,
+        vae: nn.Module,
+        quantize: int | None = None,
+    ) -> int | None:
+        """Apply loaded weights to model instances.
+
+        Args:
+            transformer: S3DiT model instance
+            text_encoder: Qwen3Encoder model instance
+            vae: VAE model instance
+            quantize: Optional quantization bits
+
+        Returns:
+            Actual quantization level used (from metadata or argument)
+        """
+        # Determine quantization level (metadata stores as string)
+        q_level = self.meta_data.quantization_level
+        if q_level is not None:
+            q_level = int(q_level)
+            # Pre-quantized weights - quantize models first, then load
+            self._quantize_model(transformer, q_level)
+            self._quantize_model(text_encoder, q_level)
+            # VAE is not quantized - needs precision
+            self._set_weights(transformer, text_encoder, vae)
+            return q_level
+        elif quantize is not None:
+            # Runtime quantization - load weights, then quantize
+            self._set_weights(transformer, text_encoder, vae)
+            self._quantize_model(transformer, quantize)
+            self._quantize_model(text_encoder, quantize)
+            # VAE is not quantized - needs precision
+            return quantize
+        else:
+            # No quantization - just load fp16 weights
+            self._set_weights(transformer, text_encoder, vae)
+            return None
+
+    def _set_weights(
+        self,
+        transformer: nn.Module,
+        text_encoder: nn.Module,
+        vae: nn.Module,
+    ) -> None:
+        """Set weights on model instances."""
+        if self.transformer is not None:
+            transformer.update(self.transformer, strict=False)
+        if self.text_encoder is not None:
+            text_encoder.update(self.text_encoder, strict=False)
+        if self.vae is not None:
+            vae.update(self.vae, strict=False)
+
+    def _quantize_model(self, model: nn.Module, bits: int) -> None:
+        """Apply MLX quantization to a model.
+
+        Args:
+            model: nn.Module to quantize
+            bits: Quantization bits (3, 4, 5, 6, 8)
+
+        Raises:
+            ValueError: If bits is not a valid quantization level
+        """
+        if bits not in self.VALID_QUANTIZE_BITS:
+            raise ValueError(f"Invalid quantization bits: {bits}. Valid options: {self.VALID_QUANTIZE_BITS}")
+
+        # MLX quantization with mflux standard group size
+        nn.quantize(model, bits=bits, group_size=self.DEFAULT_GROUP_SIZE)
+
+    @classmethod
+    def load_model(
+        cls,
+        alias: str = "zimage-turbo",
+        quantize: int | None = None,
+        local_path: str | None = None,
+    ) -> ZImageComponents:
+        """Convenience method to load complete model.
+
+        Args:
+            alias: Model alias ("zimage-turbo") or HuggingFace repo ID
+            quantize: Optional quantization bits (3, 4, 5, 6, 8)
+            local_path: Optional local path override
+
+        Returns:
+            ZImageComponents with all loaded models
+        """
+        # Determine root path
+        if local_path:
+            root_path = Path(local_path)
+        else:
+            actual_repo_id = cls.REPO_MAP.get(alias, alias)
+            root_path = cls._download_weights(actual_repo_id)
+
+        # Load weights
+        handler = cls.load_regular_weights(repo_id=alias, local_path=local_path)
+
+        # Create and load models
+        return handler.load_all(root_path, quantize=quantize)

--- a/src/mflux/models/zimage/weights/zimage_weight_mapping.py
+++ b/src/mflux/models/zimage/weights/zimage_weight_mapping.py
@@ -1,0 +1,383 @@
+"""
+Declarative weight mapping for Z-Image S3-DiT transformer and Qwen3 text encoder.
+
+Maps HuggingFace weight names to MLX model structure paths.
+"""
+
+from typing import List
+
+from mflux.models.common.weights.mapping.weight_mapping import WeightMapping, WeightTarget
+
+
+class ZImageWeightMapping(WeightMapping):
+    """Weight mappings for Z-Image model components."""
+
+    @staticmethod
+    def get_transformer_mapping() -> List[WeightTarget]:
+        """Get transformer weight mappings (S3-DiT)."""
+        return [
+            # ========== Input Embeddings ==========
+            # Patch embedder: all_x_embedder.2-1 → x_embedder.proj
+            WeightTarget(
+                mlx_path="x_embedder.proj.weight",
+                hf_patterns=["all_x_embedder.2-1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="x_embedder.proj.bias",
+                hf_patterns=["all_x_embedder.2-1.bias"],
+            ),
+            # Caption embedder: cap_embedder.0 → cap_embedder.linear1, cap_embedder.1 → cap_embedder.linear2
+            WeightTarget(
+                mlx_path="cap_embedder.linear1.weight",
+                hf_patterns=["cap_embedder.0.weight"],
+            ),
+            WeightTarget(
+                mlx_path="cap_embedder.linear2.weight",
+                hf_patterns=["cap_embedder.1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="cap_embedder.linear2.bias",
+                hf_patterns=["cap_embedder.1.bias"],
+            ),
+            # Timestep embedder MLP (nn.Sequential with Linear, SiLU, Linear)
+            # HF: t_embedder.mlp.0 → layers.0, t_embedder.mlp.2 → layers.2
+            WeightTarget(
+                mlx_path="t_embedder.mlp.layers.0.weight",
+                hf_patterns=["t_embedder.mlp.0.weight"],
+            ),
+            WeightTarget(
+                mlx_path="t_embedder.mlp.layers.0.bias",
+                hf_patterns=["t_embedder.mlp.0.bias"],
+            ),
+            WeightTarget(
+                mlx_path="t_embedder.mlp.layers.2.weight",
+                hf_patterns=["t_embedder.mlp.2.weight"],
+            ),
+            WeightTarget(
+                mlx_path="t_embedder.mlp.layers.2.bias",
+                hf_patterns=["t_embedder.mlp.2.bias"],
+            ),
+            # ========== Context Refiner (2 layers) ==========
+            # Attention norms
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attention_norm1.weight",
+                hf_patterns=["context_refiner.{block}.attention_norm1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attention_norm2.weight",
+                hf_patterns=["context_refiner.{block}.attention_norm2.weight"],
+                max_blocks=2,
+            ),
+            # FFN norms
+            WeightTarget(
+                mlx_path="context_refiner.{block}.ffn_norm1.weight",
+                hf_patterns=["context_refiner.{block}.ffn_norm1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.ffn_norm2.weight",
+                hf_patterns=["context_refiner.{block}.ffn_norm2.weight"],
+                max_blocks=2,
+            ),
+            # Attention QKV projections
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.to_q.weight",
+                hf_patterns=["context_refiner.{block}.attention.to_q.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.to_k.weight",
+                hf_patterns=["context_refiner.{block}.attention.to_k.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.to_v.weight",
+                hf_patterns=["context_refiner.{block}.attention.to_v.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.to_out.weight",
+                hf_patterns=["context_refiner.{block}.attention.to_out.0.weight"],
+                max_blocks=2,
+            ),
+            # Attention QK norms
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.norm_q.weight",
+                hf_patterns=["context_refiner.{block}.attention.norm_q.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.attn.norm_k.weight",
+                hf_patterns=["context_refiner.{block}.attention.norm_k.weight"],
+                max_blocks=2,
+            ),
+            # SwiGLU FFN (w1=gate, w2=down, w3=up)
+            WeightTarget(
+                mlx_path="context_refiner.{block}.ff.w1.weight",
+                hf_patterns=["context_refiner.{block}.feed_forward.w1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.ff.w2.weight",
+                hf_patterns=["context_refiner.{block}.feed_forward.w2.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="context_refiner.{block}.ff.w3.weight",
+                hf_patterns=["context_refiner.{block}.feed_forward.w3.weight"],
+                max_blocks=2,
+            ),
+            # ========== Noise Refiner (2 layers) ==========
+            # Uses S3DiTBlock structure (same as main transformer blocks)
+            # AdaLN modulation
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.adaLN.weight",
+                hf_patterns=["noise_refiner.{block}.adaLN_modulation.0.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.adaLN.bias",
+                hf_patterns=["noise_refiner.{block}.adaLN_modulation.0.bias"],
+                max_blocks=2,
+            ),
+            # Attention layer norms
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attention_norm1.weight",
+                hf_patterns=["noise_refiner.{block}.attention_norm1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attention_norm2.weight",
+                hf_patterns=["noise_refiner.{block}.attention_norm2.weight"],
+                max_blocks=2,
+            ),
+            # Attention QKV projections
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.to_q.weight",
+                hf_patterns=["noise_refiner.{block}.attention.to_q.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.to_k.weight",
+                hf_patterns=["noise_refiner.{block}.attention.to_k.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.to_v.weight",
+                hf_patterns=["noise_refiner.{block}.attention.to_v.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.to_out.weight",
+                hf_patterns=["noise_refiner.{block}.attention.to_out.0.weight"],
+                max_blocks=2,
+            ),
+            # QK norms
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.norm_q.weight",
+                hf_patterns=["noise_refiner.{block}.attention.norm_q.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.attn.norm_k.weight",
+                hf_patterns=["noise_refiner.{block}.attention.norm_k.weight"],
+                max_blocks=2,
+            ),
+            # FFN layer norms
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.ffn_norm1.weight",
+                hf_patterns=["noise_refiner.{block}.ffn_norm1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.ffn_norm2.weight",
+                hf_patterns=["noise_refiner.{block}.ffn_norm2.weight"],
+                max_blocks=2,
+            ),
+            # SwiGLU FFN
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.ff.w1.weight",
+                hf_patterns=["noise_refiner.{block}.feed_forward.w1.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.ff.w2.weight",
+                hf_patterns=["noise_refiner.{block}.feed_forward.w2.weight"],
+                max_blocks=2,
+            ),
+            WeightTarget(
+                mlx_path="noise_refiner.{block}.ff.w3.weight",
+                hf_patterns=["noise_refiner.{block}.feed_forward.w3.weight"],
+                max_blocks=2,
+            ),
+            # ========== Main Transformer Blocks (30 layers) ==========
+            # HF uses "layers.{block}", model uses "transformer_blocks.{block}"
+            # AdaLN modulation (nn.Linear, not nested)
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.adaLN.weight",
+                hf_patterns=["layers.{block}.adaLN_modulation.0.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.adaLN.bias",
+                hf_patterns=["layers.{block}.adaLN_modulation.0.bias"],
+            ),
+            # Attention layer norms
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attention_norm1.weight",
+                hf_patterns=["layers.{block}.attention_norm1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attention_norm2.weight",
+                hf_patterns=["layers.{block}.attention_norm2.weight"],
+            ),
+            # Attention QKV projections
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.to_q.weight",
+                hf_patterns=["layers.{block}.attention.to_q.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.to_k.weight",
+                hf_patterns=["layers.{block}.attention.to_k.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.to_v.weight",
+                hf_patterns=["layers.{block}.attention.to_v.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.to_out.weight",
+                hf_patterns=["layers.{block}.attention.to_out.0.weight"],
+            ),
+            # QK norms
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.norm_q.weight",
+                hf_patterns=["layers.{block}.attention.norm_q.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.attn.norm_k.weight",
+                hf_patterns=["layers.{block}.attention.norm_k.weight"],
+            ),
+            # FFN layer norms
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.ffn_norm1.weight",
+                hf_patterns=["layers.{block}.ffn_norm1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.ffn_norm2.weight",
+                hf_patterns=["layers.{block}.ffn_norm2.weight"],
+            ),
+            # SwiGLU FFN (w1=gate, w2=down, w3=up)
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.ff.w1.weight",
+                hf_patterns=["layers.{block}.feed_forward.w1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.ff.w2.weight",
+                hf_patterns=["layers.{block}.feed_forward.w2.weight"],
+            ),
+            WeightTarget(
+                mlx_path="transformer_blocks.{block}.ff.w3.weight",
+                hf_patterns=["layers.{block}.feed_forward.w3.weight"],
+            ),
+            # ========== Final Layer ==========
+            # AdaLN modulation
+            WeightTarget(
+                mlx_path="final_layer.adaLN.weight",
+                hf_patterns=["all_final_layer.2-1.adaLN_modulation.1.weight"],
+            ),
+            WeightTarget(
+                mlx_path="final_layer.adaLN.bias",
+                hf_patterns=["all_final_layer.2-1.adaLN_modulation.1.bias"],
+            ),
+            # LayerNorm
+            WeightTarget(
+                mlx_path="final_layer.norm.weight",
+                hf_patterns=["all_final_layer.2-1.norm.weight"],
+                required=False,  # May not exist in all checkpoints
+            ),
+            # Output linear
+            WeightTarget(
+                mlx_path="final_layer.linear.weight",
+                hf_patterns=["all_final_layer.2-1.linear.weight"],
+            ),
+            WeightTarget(
+                mlx_path="final_layer.linear.bias",
+                hf_patterns=["all_final_layer.2-1.linear.bias"],
+            ),
+        ]
+
+    @staticmethod
+    def get_text_encoder_mapping() -> List[WeightTarget]:
+        """Get text encoder weight mappings (Qwen3-4B)."""
+        return [
+            # Token embeddings
+            WeightTarget(
+                mlx_path="embed_tokens.weight",
+                hf_patterns=["model.embed_tokens.weight"],
+            ),
+            # Decoder layers (36 layers)
+            # Self-attention projections
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.q_proj.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.q_proj.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.k_proj.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.k_proj.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.v_proj.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.v_proj.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.o_proj.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.o_proj.weight"],
+            ),
+            # QK norms
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.q_norm.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.q_norm.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.self_attn.k_norm.weight",
+                hf_patterns=["model.layers.{layer}.self_attn.k_norm.weight"],
+            ),
+            # MLP projections
+            WeightTarget(
+                mlx_path="layers.{layer}.mlp.gate_proj.weight",
+                hf_patterns=["model.layers.{layer}.mlp.gate_proj.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.mlp.up_proj.weight",
+                hf_patterns=["model.layers.{layer}.mlp.up_proj.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.mlp.down_proj.weight",
+                hf_patterns=["model.layers.{layer}.mlp.down_proj.weight"],
+            ),
+            # Layer norms
+            WeightTarget(
+                mlx_path="layers.{layer}.input_layernorm.weight",
+                hf_patterns=["model.layers.{layer}.input_layernorm.weight"],
+            ),
+            WeightTarget(
+                mlx_path="layers.{layer}.post_attention_layernorm.weight",
+                hf_patterns=["model.layers.{layer}.post_attention_layernorm.weight"],
+            ),
+            # Final norm
+            WeightTarget(
+                mlx_path="norm.weight",
+                hf_patterns=["model.norm.weight"],
+            ),
+        ]
+
+    @staticmethod
+    def get_vae_mapping() -> List[WeightTarget]:
+        """Get VAE weight mappings.
+
+        Z-Image uses the same VAE as FLUX, so we can reuse FLUX VAE weights directly.
+        The VAE structure matches, so this returns an empty list (direct mapping).
+        """
+        # VAE weights can be loaded directly without remapping
+        # They match FLUX VAE structure
+        return []

--- a/src/mflux/save.py
+++ b/src/mflux/save.py
@@ -3,6 +3,7 @@ from mflux.models.fibo.variants.txt2img.fibo import FIBO
 from mflux.models.flux.variants.txt2img.flux import Flux1
 from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
 from mflux.ui.cli.parsers import CommandLineParser
+from mflux.zimage import ZImage
 
 
 def main():
@@ -18,6 +19,8 @@ def main():
         model_class = QwenImage
     elif "fibo" in model_name_lower:
         model_class = FIBO
+    elif "zimage" in model_name_lower or model_name_lower == "turbo":
+        model_class = ZImage
     else:
         model_class = Flux1
 
@@ -26,7 +29,8 @@ def main():
         "model_config": ModelConfig.from_name(args.model, base_model=args.base_model),
         "quantize": args.quantize,
     }
-    if args.lora_paths and model_class != FIBO:
+    # LoRA support (not available for FIBO or ZImage)
+    if args.lora_paths and model_class not in (FIBO, ZImage):
         model_kwargs["lora_paths"] = args.lora_paths
         model_kwargs["lora_scales"] = args.lora_scales
 

--- a/src/mflux/save_zimage.py
+++ b/src/mflux/save_zimage.py
@@ -1,0 +1,50 @@
+"""CLI entry point for mflux-save-zimage command.
+
+Saves a quantized version of Z-Image-Turbo to disk for efficient loading.
+"""
+
+import argparse
+
+from mflux.config.model_config import ModelConfig
+from mflux.zimage import ZImage
+
+
+def main():
+    # Simple argument parser for Z-Image save
+    parser = argparse.ArgumentParser(description="Save a quantized version of Z-Image-Turbo to disk.")
+    parser.add_argument(
+        "--path",
+        type=str,
+        required=True,
+        help="Directory to save the quantized model",
+    )
+    parser.add_argument(
+        "--quantize",
+        "-q",
+        type=int,
+        choices=[3, 4, 5, 6, 8],
+        default=None,
+        help="Quantization bits (3, 4, 5, 6, 8). Default: None (fp16)",
+    )
+    args = parser.parse_args()
+
+    # Status message
+    if args.quantize is None:
+        print("Saving Z-Image-Turbo (fp16, no quantization)...")
+    else:
+        print(f"Saving Z-Image-Turbo ({args.quantize}-bit quantization)...")
+
+    # Load and quantize model
+    zimage = ZImage(
+        model_config=ModelConfig.zimage_turbo(),
+        quantize=args.quantize,
+    )
+
+    # Save to disk
+    print(f"Saving model to {args.path}...")
+    zimage.save_model(args.path)
+    print(f"Model saved successfully to {args.path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mflux/zimage/__init__.py
+++ b/src/mflux/zimage/__init__.py
@@ -1,0 +1,4 @@
+# Z-Image module
+from mflux.zimage.zimage import ZImage
+
+__all__ = ["ZImage"]

--- a/src/mflux/zimage/zimage.py
+++ b/src/mflux/zimage/zimage.py
@@ -1,0 +1,394 @@
+"""Z-Image-Turbo model for text-to-image generation.
+
+Main entry point for generating images using Z-Image-Turbo.
+Handles model loading, text encoding, diffusion, and VAE decoding.
+"""
+
+import logging
+
+import mlx.core as mx
+from mlx import nn
+from tqdm import tqdm
+
+from mflux.callbacks.callbacks import Callbacks
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+from mflux.config.runtime_config import RuntimeConfig
+from mflux.models.common.latent_creator.latent_creator import Img2Img, LatentCreator
+from mflux.models.common.weights.model_saver import ModelSaver
+from mflux.models.flux.model.flux_vae.vae import VAE
+from mflux.models.zimage.latent_creator.zimage_latent_creator import ZImageLatentCreator
+from mflux.models.zimage.scheduler import ZImageScheduler
+from mflux.models.zimage.text_encoder import Qwen3Encoder, Qwen3Tokenizer
+from mflux.models.zimage.transformer import S3DiT
+from mflux.models.zimage.weights import ZImageWeightHandler
+from mflux.utils.exceptions import StopImageGenerationException
+from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.image_util import ImageUtil
+
+log = logging.getLogger(__name__)
+
+
+class ZImage(nn.Module):
+    """Z-Image-Turbo model for text-to-image generation.
+
+    Main entry point for generating images using Z-Image-Turbo.
+    Handles model loading, text encoding, diffusion, and VAE decoding.
+    """
+
+    # Architecture constants
+    VAE_SCALE_FACTOR = 8  # VAE spatial downsampling factor
+    LATENT_CHANNELS = 16  # VAE latent channels
+
+    # Default inference settings (from research)
+    DEFAULT_STEPS = 9  # Turbo uses 9 steps (8 + 1)
+    DEFAULT_GUIDANCE_SCALE = 0.0  # CFG baked into distilled weights
+
+    # Supported model variants
+    VARIANTS = {
+        "turbo": "Tongyi-MAI/Z-Image-Turbo",
+    }
+
+    vae: VAE
+    transformer: S3DiT
+    text_encoder: Qwen3Encoder
+    tokenizer: Qwen3Tokenizer
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        quantize: int | None = None,
+        local_path: str | None = None,
+    ):
+        """Initialize ZImage model.
+
+        Args:
+            model_config: Model configuration
+            quantize: Quantization bits (3, 4, 5, 6, 8) or None for fp16
+            local_path: Optional local path to model weights
+        """
+        super().__init__()
+        self.model_config = model_config
+        self.bits = quantize
+        self.local_path = local_path
+
+        # Load all components
+        self._init_components(quantize, local_path)
+
+    def _init_components(
+        self,
+        quantize: int | None,
+        local_path: str | None,
+    ) -> None:
+        """Initialize all model components.
+
+        Args:
+            quantize: Quantization bits
+            local_path: Optional local path
+        """
+        # Load weights and create models
+        components = ZImageWeightHandler.load_model(
+            alias=self.model_config.aliases[0],
+            quantize=quantize,
+            local_path=local_path,
+        )
+
+        self.transformer = components.transformer
+        self.text_encoder = components.text_encoder
+        self.tokenizer = components.tokenizer
+        self.vae = components.vae
+
+        # Fix self.bits for pre-quantized models loaded via local_path
+        # When loading from local_path, self.bits is None even though model IS quantized
+        if self.bits is None:
+            self.bits = self._detect_quantization_bits()
+
+    def _detect_quantization_bits(self) -> int | None:
+        """Detect quantization bits from loaded model layers.
+
+        Returns:
+            Quantization bits (3, 4, 5, 6, 8) or None if not quantized
+        """
+        for module in self.transformer.modules():
+            if isinstance(module, nn.QuantizedLinear):
+                return module.bits
+        return None
+
+    def generate_image(
+        self,
+        seed: int,
+        prompt: str,
+        config: Config | None = None,
+    ) -> GeneratedImage:
+        """Generate image from text prompt (txt2img or img2img).
+
+        Args:
+            seed: Random seed for reproducibility
+            prompt: Text description of desired image
+            config: Generation config (steps, height, width, image_path, image_strength)
+
+        Returns:
+            GeneratedImage with PIL Image and metadata
+        """
+        # Use default config if not provided
+        if config is None:
+            config = Config(
+                num_inference_steps=self.DEFAULT_STEPS,
+                height=1024,
+                width=1024,
+                guidance=self.DEFAULT_GUIDANCE_SCALE,
+            )
+
+        # Create runtime config
+        runtime_config = RuntimeConfig(config, self.model_config)
+
+        # Calculate start step based on img2img strength
+        init_time_step = runtime_config.init_time_step
+        time_steps = tqdm(range(init_time_step, runtime_config.num_inference_steps))
+
+        # Memory tracking - start of generation
+        log.debug(f"Memory at generation start: {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # 1. Create scheduler with shift=3.0 for Z-Image
+        scheduler = ZImageScheduler(runtime_config)
+
+        # 2. Encode text prompt
+        text_embeddings = self._encode_prompt(prompt)
+
+        # Memory tracking - after text encoding
+        log.debug(f"Memory after text encoding: {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # 3. Create initial latents (txt2img or img2img)
+        latents = LatentCreator.create_for_txt2img_or_img2img(
+            seed=seed,
+            height=runtime_config.height,
+            width=runtime_config.width,
+            img2img=Img2Img(
+                vae=self.vae,
+                latent_creator=ZImageLatentCreator,
+                image_path=runtime_config.image_path,
+                sigmas=scheduler.sigmas,
+                init_time_step=init_time_step,
+            ),
+        )
+
+        # (Optional) Call subscribers for beginning of loop
+        Callbacks.before_loop(
+            seed=seed,
+            prompt=prompt,
+            latents=latents,
+            config=runtime_config,
+        )
+
+        # Precompute RoPE frequencies (constant for all steps)
+        rope = self.transformer.precompute_rope(
+            runtime_config.height // self.VAE_SCALE_FACTOR,
+            runtime_config.width // self.VAE_SCALE_FACTOR,
+            text_embeddings.shape[1],
+        )
+        mx.eval(rope[0], rope[1])  # Force evaluation
+
+        # Precompute timestep embeddings (constant for all steps)
+        all_temb = self.transformer.precompute_timestep_embeddings(scheduler, runtime_config.num_inference_steps)
+        mx.eval(all_temb)
+
+        # 4. Denoising loop (starts at init_time_step for img2img, 0 for txt2img)
+        for t_idx in time_steps:
+            try:
+                # Get velocity prediction from transformer
+                velocity = self.transformer(
+                    latents=latents,
+                    text_embeddings=text_embeddings,
+                    timestep=None,  # Not needed when temb provided
+                    rope=rope,  # Pass precomputed RoPE frequencies
+                    temb=all_temb[t_idx : t_idx + 1],  # Select embedding for current step
+                )
+
+                # Unpatchify to spatial format for Euler step
+                velocity = self.transformer.unpatchify(
+                    velocity,
+                    height=runtime_config.height // self.VAE_SCALE_FACTOR,
+                    width=runtime_config.width // self.VAE_SCALE_FACTOR,
+                )
+
+                # CRITICAL: Negate velocity (diffusers pipeline_z_image.py line 560)
+                # The transformer predicts velocity in the opposite direction
+                velocity = -velocity
+
+                # Euler step using scheduler
+                latents = scheduler.step(velocity, t_idx, latents)
+
+                # (Optional) Call subscribers in-loop
+                Callbacks.in_loop(
+                    t=t_idx,
+                    seed=seed,
+                    prompt=prompt,
+                    latents=latents,
+                    config=runtime_config,
+                    time_steps=time_steps,
+                )
+
+                # Evaluate to enable progress tracking
+                mx.eval(latents)
+
+            except KeyboardInterrupt:  # noqa: PERF203
+                Callbacks.interruption(
+                    t=t_idx,
+                    seed=seed,
+                    prompt=prompt,
+                    latents=latents,
+                    config=runtime_config,
+                    time_steps=time_steps,
+                )
+                raise StopImageGenerationException(
+                    f"Stopping image generation at step {t_idx + 1}/{runtime_config.num_inference_steps}"
+                )
+
+        # (Optional) Call subscribers after loop
+        Callbacks.after_loop(
+            seed=seed,
+            prompt=prompt,
+            latents=latents,
+            config=runtime_config,
+        )
+
+        # Clean up precomputed tensors that are no longer needed
+        # This prevents them from being held in memory during VAE decode
+        del rope
+        del all_temb
+
+        # Memory tracking - after diffusion loop
+        log.debug(f"Memory after diffusion loop: {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # 5. Decode latents with VAE
+        decoded = self.vae.decode(latents)
+
+        # Memory tracking - after VAE decode (before eval)
+        log.debug(f"Memory after VAE decode (unevaluated): {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # CRITICAL: Evaluate decoded latents to prevent graph explosion
+        # Without this, the computation graph grows to 30+GB during image conversion
+        mx.eval(decoded)
+
+        # Memory tracking - after VAE decode eval
+        log.debug(f"Memory after VAE decode (evaluated): {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # 6. Convert to GeneratedImage
+        result = ImageUtil.to_image(
+            decoded_latents=decoded,
+            config=runtime_config,
+            seed=seed,
+            prompt=prompt,
+            quantization=self.bits,
+            generation_time=time_steps.format_dict["elapsed"],
+            lora_paths=None,
+            lora_scales=None,
+            image_path=runtime_config.image_path,
+            image_strength=runtime_config.image_strength,
+        )
+
+        # Memory tracking - after image conversion
+        log.debug(f"Memory after image conversion: {mx.get_active_memory() / 1e9:.2f} GB")
+
+        # Clean up intermediate tensors to prevent graph retention during exit
+        # The decoded tensor is no longer needed after image conversion
+        del decoded
+        del latents
+        del text_embeddings
+
+        # Clear MLX cache to release unused memory before returning
+        mx.clear_cache()
+
+        return result
+
+    def _encode_prompt(self, prompt: str, max_sequence_length: int = 512) -> mx.array:
+        """Encode text prompt to embeddings.
+
+        Matches diffusers ZImagePipeline.encode_prompt behavior:
+        - Applies chat template before tokenization
+        - Uses hidden_states[-2] from text encoder
+        - Extracts only non-padding tokens
+
+        Args:
+            prompt: Text prompt
+            max_sequence_length: Maximum sequence length (default 512 like diffusers)
+
+        Returns:
+            Text embeddings [1, seq_len, 2560] (batch dim kept for transformer)
+        """
+        # Tokenize (with chat template applied)
+        tokens = self.tokenizer(prompt, max_length=max_sequence_length)
+        input_ids = tokens["input_ids"]
+        attention_mask = tokens["attention_mask"]
+
+        # Encode with Qwen3 (returns hidden_states[-2] by default)
+        embeddings = self.text_encoder(input_ids, attention_mask)
+
+        # Extract only non-padding tokens (like diffusers)
+        # attention_mask: [B, seq_len], 1=valid, 0=pad
+        # embeddings: [B, seq_len, 2560]
+        # Extract first batch item
+        emb = embeddings[0]  # [seq_len, 2560]
+        mask = attention_mask[0]  # [seq_len]
+
+        # MLX doesn't support boolean indexing, so we count valid tokens and slice
+        # NOTE: .item() here is acceptable - this is called ONCE per generation (not in hot path)
+        # and we need the actual integer value for slicing. Impact: <1ms vs 9+ calls in loop.
+        valid_len = int(mx.sum(mask).item())
+        emb = emb[:valid_len, :]  # [valid_len, 2560]
+
+        # Add batch dimension back for transformer
+        emb = emb[None, :, :]  # [1, valid_len, 2560]
+
+        return emb
+
+    def _init_latents(
+        self,
+        seed: int,
+        height: int,
+        width: int,
+    ) -> mx.array:
+        """Initialize random latents for diffusion.
+
+        Args:
+            seed: Random seed
+            height: Image height (pixels)
+            width: Image width (pixels)
+
+        Returns:
+            Random latents [1, C, H/8, W/8]
+        """
+        mx.random.seed(seed)
+
+        # VAE produces 8x downsampled latents
+        latent_h = height // self.VAE_SCALE_FACTOR
+        latent_w = width // self.VAE_SCALE_FACTOR
+
+        # 16 channels for VAE latents, BCHW format
+        latents = mx.random.normal((1, self.LATENT_CHANNELS, latent_h, latent_w))
+
+        return latents
+
+    def save_model(self, base_path: str) -> None:
+        """Save model weights and tokenizer to disk.
+
+        Saves pre-quantized weights that can be loaded without peak memory spike.
+        Following Qwen pattern: only transformer is quantized, text encoder stays fp16
+        to avoid semantic degradation.
+
+        Args:
+            base_path: Directory to save model files
+        """
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            tokenizers=[
+                ("tokenizer.tokenizer", "tokenizer"),
+            ],
+            components=[
+                ("vae", "vae"),
+                ("transformer", "transformer"),
+                ("text_encoder", "text_encoder"),
+            ],
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Pytest fixtures for Z-Image tests with basic memory management.
+
+This module provides cleanup fixtures to prevent memory accumulation
+across test classes when testing large models like S3DiT and Qwen3Encoder.
+Make no mistake, though: this will hammer systems with less than 48GB RAM!
+"""
+
+import gc
+
+import mlx.core as mx
+import pytest
+
+
+def _clear_mlx_cache():
+    """Clear MLX cache using current API."""
+    # Use new API if available, fall back to deprecated
+    if hasattr(mx, "clear_cache"):
+        mx.clear_cache()
+    elif mx.metal.is_available():
+        mx.metal.clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    """Clean up MLX memory after each test.
+
+    This runs automatically after every test to prevent memory accumulation.
+    """
+    yield
+    # Force garbage collection
+    gc.collect()
+    # Clear MLX cache
+    _clear_mlx_cache()
+
+
+@pytest.fixture(scope="class", autouse=True)
+def cleanup_after_class():
+    """Clean up MLX memory after each test class.
+
+    More aggressive cleanup after all tests in a class complete.
+    """
+    yield
+    # Force multiple GC passes to clean up circular references
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    # Clear MLX cache
+    _clear_mlx_cache()
+
+
+@pytest.fixture
+def memory_tracker():
+    """Fixture to track memory usage during a test.
+
+    Usage:
+        def test_something(memory_tracker):
+            memory_tracker.start()
+            # ... do stuff ...
+            peak_mb = memory_tracker.get_peak_mb()
+            assert peak_mb < 1000, f"Used {peak_mb}MB, expected < 1000MB"
+    """
+
+    class MemoryTracker:
+        def start(self):
+            if hasattr(mx, "reset_peak_memory"):
+                mx.reset_peak_memory()
+            elif mx.metal.is_available():
+                mx.metal.reset_peak_memory()
+
+        def get_active_mb(self):
+            if hasattr(mx, "get_active_memory"):
+                return mx.get_active_memory() / (1024 * 1024)
+            elif mx.metal.is_available():
+                return mx.metal.get_active_memory() / (1024 * 1024)
+            return 0
+
+        def get_peak_mb(self):
+            if hasattr(mx, "get_peak_memory"):
+                return mx.get_peak_memory() / (1024 * 1024)
+            elif mx.metal.is_available():
+                return mx.metal.get_peak_memory() / (1024 * 1024)
+            return 0
+
+        def get_cache_mb(self):
+            if hasattr(mx, "get_cache_memory"):
+                return mx.get_cache_memory() / (1024 * 1024)
+            elif mx.metal.is_available():
+                return mx.metal.get_cache_memory() / (1024 * 1024)
+            return 0
+
+    return MemoryTracker()

--- a/tests/test_zimage_e2e.py
+++ b/tests/test_zimage_e2e.py
@@ -1,0 +1,83 @@
+"""End-to-end tests that load actual model weights.
+
+These require ~16GB+ memory and network access.
+They require a Mac with 48GB RAM for unqantized models.
+Skip by default: pytest -m "not high_memory_requirement"
+"""
+
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.high_memory_requirement
+
+
+class TestZImageEndToEnd:
+    """End-to-end tests that load actual model weights.
+
+    These tests require ~16GB+ memory and network access.
+    Skip by default: pytest -m "not high_memory_requirement"
+    """
+
+    @pytest.mark.skipif(
+        True,  # Skip until model is available and verified
+        reason="Requires model download and high memory",
+    )
+    def test_e2e_generation_8bit(self):
+        """Test actual generation with 8-bit quantization."""
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            quantize=8,
+        )
+
+        config = Config(
+            num_inference_steps=9,
+            height=512,
+            width=512,
+            guidance=0.0,
+        )
+
+        image = zimage.generate_image(
+            seed=42,
+            prompt="A red apple on a white table",
+            config=config,
+        )
+
+        assert hasattr(image, "image")
+        assert isinstance(image.image, Image.Image)
+        assert image.image.size == (512, 512)
+        assert image.image.mode == "RGB"
+
+    @pytest.mark.skipif(
+        True,
+        reason="Requires model download and high memory",
+    )
+    def test_e2e_all_quantization_levels(self):
+        """Verify all quantization levels work."""
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        config = Config(
+            num_inference_steps=2,  # Minimal steps
+            height=256,
+            width=256,
+            guidance=0.0,
+        )
+
+        for bits in [8, 6, 4]:  # Skip 3-bit for speed
+            zimage = ZImage(
+                model_config=ModelConfig.zimage_turbo(),
+                quantize=bits,
+            )
+
+            image = zimage.generate_image(
+                seed=42,
+                prompt="test",
+                config=config,
+            )
+
+            assert isinstance(image.image, Image.Image)

--- a/tests/zimage/__init__.py
+++ b/tests/zimage/__init__.py
@@ -1,0 +1,1 @@
+# ZImage tests

--- a/tests/zimage/test_attention_sdpa.py
+++ b/tests/zimage/test_attention_sdpa.py
@@ -1,0 +1,210 @@
+"""Unit tests for SDPA-based attention modules.
+
+Tests verify that attention modules using scaled_dot_product_attention
+produce correct shapes and numerically reasonable outputs.
+"""
+
+import mlx.core as mx
+import pytest
+
+from mflux.models.zimage.text_encoder.qwen3_attention import Qwen3Attention
+from mflux.models.zimage.transformer.attention import Attention as S3DiTAttention
+
+
+class TestS3DiTAttention:
+    """Test S3DiT attention with SDPA."""
+
+    def test_attention_output_shape(self):
+        """Test that attention output has correct shape."""
+        attn = S3DiTAttention()
+
+        # Typical batch input
+        B, S, D = 1, 64, 3840
+        x = mx.random.normal((B, S, D))
+
+        out = attn(x, rope=None)
+
+        assert out.shape == (B, S, D)
+        assert out.dtype == mx.float32
+
+    @pytest.mark.skip(reason="RoPE3D has complex shape requirements - tested via integration test")
+    def test_attention_with_rope(self):
+        """Test attention with RoPE embeddings.
+
+        Note: Skipped because mocking RoPE3D correctly requires understanding the
+        exact rope_3d.apply_rope implementation. This is tested properly in the
+        integration test where real RoPE is used.
+        """
+        pass
+
+    def test_attention_deterministic(self):
+        """Test that attention is deterministic with same input."""
+        attn = S3DiTAttention()
+
+        B, S, D = 1, 32, 3840
+        x = mx.random.normal((B, S, D))
+
+        out1 = attn(x, rope=None)
+        out2 = attn(x, rope=None)
+
+        # Should be identical (deterministic)
+        assert mx.allclose(out1, out2, atol=1e-6)
+
+    def test_attention_different_sequence_lengths(self):
+        """Test attention with various sequence lengths."""
+        attn = S3DiTAttention()
+        D = 3840
+
+        for S in [16, 32, 64, 128]:
+            x = mx.random.normal((1, S, D))
+            out = attn(x, rope=None)
+            assert out.shape == (1, S, D)
+
+    def test_attention_output_not_nan(self):
+        """Test that attention output contains no NaN values."""
+        attn = S3DiTAttention()
+
+        B, S, D = 1, 64, 3840
+        x = mx.random.normal((B, S, D))
+
+        out = attn(x, rope=None)
+
+        assert not mx.any(mx.isnan(out))
+        assert not mx.any(mx.isinf(out))
+
+
+class TestQwen3Attention:
+    """Test Qwen3 attention with SDPA."""
+
+    def test_attention_output_shape(self):
+        """Test that attention output has correct shape."""
+        attn = Qwen3Attention()
+
+        # Typical text encoder input
+        B, S, H = 1, 77, 2560  # HIDDEN_SIZE = 2560
+        x = mx.random.normal((B, S, H))
+
+        out = attn(x, mask=None)
+
+        assert out.shape == (B, S, H)
+        assert out.dtype == mx.float32
+
+    def test_attention_with_mask(self):
+        """Test attention with causal mask."""
+        attn = Qwen3Attention()
+
+        B, S, H = 1, 77, 2560
+        x = mx.random.normal((B, S, H))
+
+        # Create causal mask (upper triangular with -inf)
+        mask = mx.full((S, S), -float("inf"))
+        mask = mx.triu(mask, k=1)  # Upper triangle (excluding diagonal)
+
+        out = attn(x, mask=mask)
+
+        assert out.shape == (B, S, H)
+        assert out.dtype == mx.float32
+
+    def test_attention_deterministic(self):
+        """Test that attention is deterministic with same input."""
+        attn = Qwen3Attention()
+
+        B, S, H = 1, 32, 2560
+        x = mx.random.normal((B, S, H))
+
+        out1 = attn(x, mask=None)
+        out2 = attn(x, mask=None)
+
+        # Should be identical (deterministic, RoPE cache is used)
+        assert mx.allclose(out1, out2, atol=1e-6)
+
+    def test_attention_different_sequence_lengths(self):
+        """Test attention with various sequence lengths."""
+        attn = Qwen3Attention()
+        H = 2560
+
+        for S in [16, 32, 77, 128]:
+            x = mx.random.normal((1, S, H))
+            out = attn(x, mask=None)
+            assert out.shape == (1, S, H)
+
+    def test_attention_output_not_nan(self):
+        """Test that attention output contains no NaN values."""
+        attn = Qwen3Attention()
+
+        B, S, H = 1, 77, 2560
+        x = mx.random.normal((B, S, H))
+
+        out = attn(x, mask=None)
+
+        assert not mx.any(mx.isnan(out))
+        assert not mx.any(mx.isinf(out))
+
+    def test_gqa_expansion(self):
+        """Test that GQA expansion works correctly."""
+        attn = Qwen3Attention()
+
+        # Qwen3 uses 32 Q heads, 8 KV heads (4:1 ratio)
+        assert attn.NUM_HEADS == 32
+        assert attn.NUM_KV_HEADS == 8
+        assert attn.NUM_HEADS // attn.NUM_KV_HEADS == 4
+
+        B, S, H = 1, 32, 2560
+        x = mx.random.normal((B, S, H))
+
+        out = attn(x, mask=None)
+
+        # Should work without errors
+        assert out.shape == (B, S, H)
+
+
+class TestAttentionNumericalStability:
+    """Test numerical stability of attention implementations."""
+
+    def test_s3dit_large_sequence(self):
+        """Test S3DiT attention with larger sequence length."""
+        attn = S3DiTAttention()
+
+        B, S, D = 1, 256, 3840
+        x = mx.random.normal((B, S, D))
+
+        out = attn(x, rope=None)
+
+        assert out.shape == (B, S, D)
+        assert not mx.any(mx.isnan(out))
+
+    def test_qwen3_large_sequence(self):
+        """Test Qwen3 attention with larger sequence length."""
+        attn = Qwen3Attention()
+
+        B, S, H = 1, 512, 2560
+        x = mx.random.normal((B, S, H))
+
+        out = attn(x, mask=None)
+
+        assert out.shape == (B, S, H)
+        assert not mx.any(mx.isnan(out))
+
+    def test_s3dit_small_values(self):
+        """Test S3DiT attention with small input values."""
+        attn = S3DiTAttention()
+
+        B, S, D = 1, 32, 3840
+        x = mx.random.normal((B, S, D)) * 0.01  # Small values
+
+        out = attn(x, rope=None)
+
+        assert not mx.any(mx.isnan(out))
+        assert not mx.any(mx.isinf(out))
+
+    def test_qwen3_small_values(self):
+        """Test Qwen3 attention with small input values."""
+        attn = Qwen3Attention()
+
+        B, S, H = 1, 32, 2560
+        x = mx.random.normal((B, S, H)) * 0.01  # Small values
+
+        out = attn(x, mask=None)
+
+        assert not mx.any(mx.isnan(out))
+        assert not mx.any(mx.isinf(out))

--- a/tests/zimage/test_library_memory_cleanup.py
+++ b/tests/zimage/test_library_memory_cleanup.py
@@ -1,0 +1,59 @@
+"""Test that memory is properly released when using ZImage as a library."""
+
+import gc
+
+import mlx.core as mx
+import pytest
+
+from mflux.config.config import Config
+from mflux.config.model_config import ModelConfig
+from mflux.zimage import ZImage
+
+pytestmark = pytest.mark.high_memory_requirement
+
+
+class TestLibraryMemoryCleanup:
+    """Verify memory cleanup works without CLI-level cleanup."""
+
+    @pytest.mark.skipif(False, reason="Requires local model at ./zimage-q4")
+    def test_generation_tensors_released_after_image_deleted(self):
+        """After deleting generated image, memory should return to baseline."""
+        # Load model
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        # Measure baseline (model loaded, no generation)
+        mx.eval(zimage.parameters())  # Ensure model is fully loaded
+        gc.collect()
+        mx.clear_cache()
+        mem_baseline = mx.get_active_memory()
+
+        # Generate image
+        config = Config(
+            num_inference_steps=2,  # Minimal steps for speed
+            height=512,
+            width=512,
+            guidance=0.0,
+        )
+        image = zimage.generate_image(seed=42, prompt="test", config=config)
+
+        # Delete image and cleanup
+        del image
+        gc.collect()
+        mx.clear_cache()
+        mem_after = mx.get_active_memory()
+
+        # Generation tensors should be released
+        # Allow 20% tolerance for MLX internal caching
+        assert mem_after < mem_baseline * 1.2, (
+            f"Generation tensors not released: baseline={mem_baseline / 1e9:.2f}GB, "
+            f"after={mem_after / 1e9:.2f}GB (expected < {mem_baseline * 1.2 / 1e9:.2f}GB)"
+        )
+
+        # Model should still be in memory
+        assert mem_after > mem_baseline * 0.5, (
+            f"Model was unexpectedly released: baseline={mem_baseline / 1e9:.2f}GB, after={mem_after / 1e9:.2f}GB"
+        )

--- a/tests/zimage/test_no_item_calls.py
+++ b/tests/zimage/test_no_item_calls.py
@@ -1,0 +1,157 @@
+"""Unit tests for GPU synchronization optimization.
+
+Tests verify that .item() calls have been removed from hot paths
+to avoid CPU-GPU synchronization barriers during image generation.
+"""
+
+import mlx.core as mx
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.high_memory_requirement
+
+
+class TestNoItemCalls:
+    """Tests for removing .item() calls that cause GPU sync barriers."""
+
+    @pytest.mark.skipif(
+        False,  # Run this test
+        reason="Requires local model at ./zimage-q4",
+    )
+    def test_generation_without_item_in_hot_path(self):
+        """Test that image generation works without .item() in denoising loop.
+
+        This verifies that the timestep handling optimization works correctly,
+        keeping timesteps as mx.array throughout the denoising loop instead of
+        converting to Python scalars with .item().
+        """
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        config = Config(
+            num_inference_steps=4,  # Fewer steps for speed
+            height=256,
+            width=256,
+            guidance=0.0,
+        )
+
+        # This should work without any .item() calls in the denoising loop
+        image = zimage.generate_image(
+            seed=42,
+            prompt="A test image",
+            config=config,
+        )
+
+        # Verify image is generated correctly
+        assert hasattr(image, "image")
+        assert isinstance(image.image, Image.Image)
+        assert image.image.size == (256, 256)
+        assert image.image.mode == "RGB"
+
+    @pytest.mark.skipif(
+        False,
+        reason="Requires local model",
+    )
+    def test_timestep_handling_produces_correct_values(self):
+        """Test that timestep handling without .item() produces correct values.
+
+        Verifies that keeping timesteps as mx.array and using array indexing
+        produces the same results as the previous .item() approach.
+        """
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.models.zimage.scheduler import ZImageScheduler
+
+        config = Config(
+            num_inference_steps=9,
+            height=512,
+            width=512,
+            guidance=0.0,
+        )
+
+        # Create scheduler
+        from mflux.config.runtime_config import RuntimeConfig
+
+        runtime_config = RuntimeConfig(config, ModelConfig.zimage_turbo())
+        scheduler = ZImageScheduler(runtime_config)
+
+        # Test that we can access timesteps as mx.array without .item()
+        for t_idx in range(runtime_config.num_inference_steps):
+            # Get timestep as mx.array (no .item())
+            t_raw = scheduler.timesteps[t_idx]
+
+            # Verify it's an mx.array
+            assert isinstance(t_raw, mx.array)
+
+            # Verify we can do arithmetic without .item()
+            t_value = (1000.0 - t_raw) / 1000.0
+            assert isinstance(t_value, mx.array)
+
+            # Verify we can add batch dimension with [None]
+            t_batch = t_value[None]
+            assert isinstance(t_batch, mx.array)
+            assert t_batch.shape == (1,)
+
+            # Verify the value is in expected range [0, 1]
+            # We need .item() here only for assertion, not in hot path
+            t_val_scalar = float(t_value.item())
+            assert 0.0 <= t_val_scalar <= 1.0
+
+    @pytest.mark.skipif(
+        False,
+        reason="Requires local model",
+    )
+    def test_deterministic_results_after_optimization(self):
+        """Test that optimization doesn't change output (determinism check).
+
+        Generates images with same seed and verifies they're identical,
+        ensuring the optimization didn't change the numerical results.
+        """
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        config = Config(
+            num_inference_steps=4,
+            height=256,
+            width=256,
+            guidance=0.0,
+        )
+
+        # Generate twice with same seed
+        image1 = zimage.generate_image(
+            seed=999,
+            prompt="A red apple",
+            config=config,
+        )
+
+        image2 = zimage.generate_image(
+            seed=999,
+            prompt="A red apple",
+            config=config,
+        )
+
+        # Convert to arrays for comparison
+        import numpy as np
+
+        arr1 = np.array(image1.image)
+        arr2 = np.array(image2.image)
+
+        # Images should be identical with same seed
+        assert arr1.shape == arr2.shape
+        # Allow for minor floating point differences from quantization
+        diff = np.abs(arr1.astype(float) - arr2.astype(float)).mean()
+        assert diff < 1.0, f"Images differ too much: mean diff = {diff}"

--- a/tests/zimage/test_rope_vectorized.py
+++ b/tests/zimage/test_rope_vectorized.py
@@ -1,0 +1,285 @@
+"""Tests for vectorized RoPE implementation in Z-Image.
+
+This test suite verifies that the vectorized RoPE implementation produces
+numerically equivalent results to the original implementation.
+"""
+
+import mlx.core as mx
+import pytest
+
+from mflux.models.zimage.embeddings.rope_3d import RoPE3D
+
+
+class TestRoPEVectorized:
+    """Test suite for vectorized RoPE frequency lookups."""
+
+    def test_rope_initialization(self):
+        """Test that RoPE initializes correctly."""
+        rope = RoPE3D()
+
+        # Check that frequency cache is populated
+        assert len(rope._freqs_cache) == 3, "Should have 3 axes"
+
+        # Check dimensions
+        for axis_idx in range(3):
+            cos_table, sin_table = rope._freqs_cache[axis_idx]
+            expected_max_len = RoPE3D.AXES_LENS[axis_idx]
+            expected_dim = RoPE3D.AXES_DIMS[axis_idx] // 2
+
+            assert cos_table.shape == (expected_max_len, expected_dim)
+            assert sin_table.shape == (expected_max_len, expected_dim)
+
+    def test_get_freqs_for_positions_single_position(self):
+        """Test frequency lookup for a single position."""
+        rope = RoPE3D()
+
+        # Single position: time=5, h=10, w=20
+        pos_ids = mx.array([[5, 10, 20]], dtype=mx.int32)
+        freqs_cos, freqs_sin = rope.get_freqs_for_positions(pos_ids)
+
+        # Check output shape
+        assert freqs_cos.shape == (1, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (1, RoPE3D.HEAD_DIM // 2)
+
+        # Verify concatenation: should have all three axes
+        expected_dim = sum(RoPE3D.AXES_DIMS) // 2
+        assert freqs_cos.shape[1] == expected_dim
+
+    def test_get_freqs_for_positions_multiple_positions(self):
+        """Test frequency lookup for multiple positions."""
+        rope = RoPE3D()
+
+        # Multiple positions
+        pos_ids = mx.array([[1, 0, 0], [2, 5, 10], [10, 20, 30], [100, 50, 50]], dtype=mx.int32)
+
+        freqs_cos, freqs_sin = rope.get_freqs_for_positions(pos_ids)
+
+        # Check output shape
+        assert freqs_cos.shape == (4, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (4, RoPE3D.HEAD_DIM // 2)
+
+    def test_get_freqs_numerical_correctness(self):
+        """Test that frequencies are computed correctly.
+
+        This verifies the lookup is working by checking:
+        1. Position [0,0,0] should give specific values (all axes at position 0)
+        2. Different positions should give different frequencies
+        """
+        rope = RoPE3D()
+
+        # Position at origin
+        pos_zero = mx.array([[0, 0, 0]], dtype=mx.int32)
+        freqs_cos_zero, freqs_sin_zero = rope.get_freqs_for_positions(pos_zero)
+
+        # At position 0, cos should be 1.0 and sin should be 0.0
+        assert mx.allclose(freqs_cos_zero, mx.ones_like(freqs_cos_zero), atol=1e-6)
+        assert mx.allclose(freqs_sin_zero, mx.zeros_like(freqs_sin_zero), atol=1e-6)
+
+        # Position away from origin should give different values
+        pos_other = mx.array([[10, 20, 30]], dtype=mx.int32)
+        freqs_cos_other, freqs_sin_other = rope.get_freqs_for_positions(pos_other)
+
+        # Should not be all ones/zeros
+        assert not mx.allclose(freqs_cos_other, mx.ones_like(freqs_cos_other), atol=1e-2)
+        assert not mx.allclose(freqs_sin_other, mx.zeros_like(freqs_sin_other), atol=1e-2)
+
+    def test_get_image_freqs_shape(self):
+        """Test image frequency generation."""
+        rope = RoPE3D()
+
+        # Test common image dimensions
+        h_patches, w_patches = 64, 64  # 1024x1024 image
+        time_offset = 128
+
+        freqs_cos, freqs_sin = rope.get_image_freqs(h_patches, w_patches, time_offset)
+
+        n_patches = h_patches * w_patches
+        assert freqs_cos.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+
+    def test_get_image_freqs_time_offset(self):
+        """Test that time offset is applied correctly in image frequencies."""
+        rope = RoPE3D()
+
+        h_patches, w_patches = 4, 4
+
+        # Get frequencies with different time offsets
+        freqs_cos_t1, freqs_sin_t1 = rope.get_image_freqs(h_patches, w_patches, time_offset=1)
+        freqs_cos_t10, freqs_sin_t10 = rope.get_image_freqs(h_patches, w_patches, time_offset=10)
+
+        # Frequencies should be different due to time offset
+        assert not mx.allclose(freqs_cos_t1, freqs_cos_t10, atol=1e-6)
+        assert not mx.allclose(freqs_sin_t1, freqs_sin_t10, atol=1e-6)
+
+    def test_get_caption_freqs_shape(self):
+        """Test caption frequency generation."""
+        rope = RoPE3D()
+
+        cap_len = 77  # Typical caption length
+        freqs_cos, freqs_sin = rope.get_caption_freqs(cap_len)
+
+        assert freqs_cos.shape == (cap_len, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (cap_len, RoPE3D.HEAD_DIM // 2)
+
+    def test_caption_freqs_positions(self):
+        """Test that caption positions follow the expected pattern.
+
+        Caption tokens should have:
+        - time = 1, 2, 3, ..., cap_len (sequential)
+        - h = 0, w = 0 (fixed)
+        """
+        rope = RoPE3D()
+
+        cap_len = 10
+        freqs_cos, freqs_sin = rope.get_caption_freqs(cap_len)
+
+        # Manually compute what the first token should be (time=1, h=0, w=0)
+        pos_first = mx.array([[1, 0, 0]], dtype=mx.int32)
+        expected_cos_first, expected_sin_first = rope.get_freqs_for_positions(pos_first)
+
+        # Check first token matches
+        assert mx.allclose(freqs_cos[0:1], expected_cos_first, atol=1e-6)
+        assert mx.allclose(freqs_sin[0:1], expected_sin_first, atol=1e-6)
+
+        # Check last token (time=cap_len, h=0, w=0)
+        pos_last = mx.array([[cap_len, 0, 0]], dtype=mx.int32)
+        expected_cos_last, expected_sin_last = rope.get_freqs_for_positions(pos_last)
+
+        assert mx.allclose(freqs_cos[-1:], expected_cos_last, atol=1e-6)
+        assert mx.allclose(freqs_sin[-1:], expected_sin_last, atol=1e-6)
+
+    def test_get_combined_freqs_caching(self):
+        """Test that combined frequencies are cached correctly."""
+        rope = RoPE3D()
+
+        h_patches, w_patches = 32, 32
+        cap_len = 77
+        padded_cap_len = 96  # Rounded to multiple of 32
+
+        # First call should compute
+        freqs_cos_1, freqs_sin_1 = rope.get_combined_freqs(h_patches, w_patches, cap_len, padded_cap_len)
+
+        # Second call should return cached value
+        freqs_cos_2, freqs_sin_2 = rope.get_combined_freqs(h_patches, w_patches, cap_len, padded_cap_len)
+
+        # Should be identical (same object, not just equal values)
+        assert freqs_cos_1 is freqs_cos_2
+        assert freqs_sin_1 is freqs_sin_2
+
+    def test_combined_freqs_shape(self):
+        """Test that combined frequencies have correct shape."""
+        rope = RoPE3D()
+
+        h_patches, w_patches = 64, 64
+        cap_len = 77
+        padded_cap_len = 96
+
+        freqs_cos, freqs_sin = rope.get_combined_freqs(h_patches, w_patches, cap_len, padded_cap_len)
+
+        n_img_tokens = h_patches * w_patches
+        total_tokens = n_img_tokens + cap_len
+
+        assert freqs_cos.shape == (total_tokens, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (total_tokens, RoPE3D.HEAD_DIM // 2)
+
+    def test_combined_freqs_correctness(self):
+        """Test that combined frequencies match separate computations."""
+        rope = RoPE3D()
+
+        h_patches, w_patches = 16, 16
+        cap_len = 32
+        padded_cap_len = 32
+
+        # Get combined frequencies
+        combined_cos, combined_sin = rope.get_combined_freqs(h_patches, w_patches, cap_len, padded_cap_len)
+
+        # Get separate frequencies
+        img_cos, img_sin = rope.get_image_freqs(h_patches, w_patches, time_offset=padded_cap_len + 1)
+        cap_cos, cap_sin = rope.get_caption_freqs(cap_len)
+
+        n_img_tokens = h_patches * w_patches
+
+        # Check image part
+        assert mx.allclose(combined_cos[:n_img_tokens], img_cos, atol=1e-6)
+        assert mx.allclose(combined_sin[:n_img_tokens], img_sin, atol=1e-6)
+
+        # Check caption part
+        assert mx.allclose(combined_cos[n_img_tokens:], cap_cos, atol=1e-6)
+        assert mx.allclose(combined_sin[n_img_tokens:], cap_sin, atol=1e-6)
+
+    def test_legacy_call_interface(self):
+        """Test that the legacy __call__ interface still works."""
+        rope = RoPE3D()
+
+        height, width = 512, 512
+        freqs_cos, freqs_sin = rope(height, width)
+
+        h_patches = height // 16
+        w_patches = width // 16
+        n_patches = h_patches * w_patches
+
+        assert freqs_cos.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+
+    @pytest.mark.parametrize(
+        "h_patches,w_patches",
+        [
+            (16, 16),  # 256x256
+            (32, 32),  # 512x512
+            (64, 64),  # 1024x1024
+            (32, 64),  # Rectangular
+            (96, 96),  # 1536x1536
+        ],
+    )
+    def test_various_image_sizes(self, h_patches, w_patches):
+        """Test RoPE with various image dimensions."""
+        rope = RoPE3D()
+
+        freqs_cos, freqs_sin = rope.get_image_freqs(h_patches, w_patches, time_offset=1)
+
+        n_patches = h_patches * w_patches
+        assert freqs_cos.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (n_patches, RoPE3D.HEAD_DIM // 2)
+
+    @pytest.mark.parametrize("cap_len", [1, 32, 77, 128, 256])
+    def test_various_caption_lengths(self, cap_len):
+        """Test RoPE with various caption lengths."""
+        rope = RoPE3D()
+
+        freqs_cos, freqs_sin = rope.get_caption_freqs(cap_len)
+
+        assert freqs_cos.shape == (cap_len, RoPE3D.HEAD_DIM // 2)
+        assert freqs_sin.shape == (cap_len, RoPE3D.HEAD_DIM // 2)
+
+    def test_frequencies_in_valid_range(self):
+        """Test that cos/sin values are in valid range [-1, 1]."""
+        rope = RoPE3D()
+
+        # Test with large positions
+        pos_ids = mx.array(
+            [
+                [500, 400, 400],
+                [1000, 500, 500],
+            ],
+            dtype=mx.int32,
+        )
+
+        freqs_cos, freqs_sin = rope.get_freqs_for_positions(pos_ids)
+
+        # Cos and sin should be in [-1, 1]
+        assert mx.all(freqs_cos >= -1.0) and mx.all(freqs_cos <= 1.0)
+        assert mx.all(freqs_sin >= -1.0) and mx.all(freqs_sin <= 1.0)
+
+    def test_cache_isolation(self):
+        """Test that different cache keys don't interfere."""
+        rope = RoPE3D()
+
+        # Create different cached entries
+        freqs1 = rope.get_combined_freqs(32, 32, 77, 96)
+        freqs2 = rope.get_combined_freqs(64, 64, 77, 96)
+        freqs3 = rope.get_combined_freqs(32, 32, 64, 64)
+
+        # Should all be different
+        assert not mx.array_equal(freqs1[0], freqs2[0])
+        assert not mx.array_equal(freqs1[0], freqs3[0])
+        assert not mx.array_equal(freqs2[0], freqs3[0])

--- a/tests/zimage/test_zimage_generation.py
+++ b/tests/zimage/test_zimage_generation.py
@@ -1,0 +1,197 @@
+"""Integration tests for Z-Image generation with SDPA.
+
+Tests verify that the complete generation pipeline works correctly
+with the SDPA-based attention implementation.
+"""
+
+import mlx.core as mx
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.high_memory_requirement
+
+
+class TestZImageGenerationWithSDPA:
+    """Integration tests for Z-Image generation using SDPA attention."""
+
+    @pytest.mark.skipif(
+        False,  # Run this test (model is available locally)
+        reason="Requires local model at ./zimage-q4",
+    )
+    def test_generation_with_4bit_model(self):
+        """Test generation with local 4-bit quantized model."""
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        # Use local 4-bit model
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,  # Already quantized
+        )
+
+        config = Config(
+            num_inference_steps=9,
+            height=512,
+            width=512,
+            guidance=0.0,
+        )
+
+        image = zimage.generate_image(
+            seed=42,
+            prompt="A red apple on a white table",
+            config=config,
+        )
+
+        # Verify image is generated correctly
+        assert hasattr(image, "image")
+        assert isinstance(image.image, Image.Image)
+        assert image.image.size == (512, 512)
+        assert image.image.mode == "RGB"
+
+        # Verify image contains valid pixel data
+        pixels = list(image.image.getdata())
+        assert len(pixels) == 512 * 512
+        assert all(isinstance(p, tuple) and len(p) == 3 for p in pixels[:10])
+
+    @pytest.mark.skipif(
+        False,  # Run this test
+        reason="Requires local model",
+    )
+    def test_generation_deterministic(self):
+        """Test that generation with same seed produces similar results."""
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        config = Config(
+            num_inference_steps=4,  # Fewer steps for speed
+            height=256,
+            width=256,
+            guidance=0.0,
+        )
+
+        # Generate twice with same seed
+        image1 = zimage.generate_image(
+            seed=123,
+            prompt="A cat sitting on a chair",
+            config=config,
+        )
+
+        image2 = zimage.generate_image(
+            seed=123,
+            prompt="A cat sitting on a chair",
+            config=config,
+        )
+
+        # Images should be identical with same seed
+        assert image1.image.size == image2.image.size
+        # Note: Due to quantization and numerical precision,
+        # images might not be bit-identical but should be very similar
+
+    @pytest.mark.skipif(
+        False,
+        reason="Requires local model",
+    )
+    def test_generation_various_resolutions(self):
+        """Test generation at different resolutions."""
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        resolutions = [
+            (512, 512),
+            (768, 768),
+            (1024, 1024),
+        ]
+
+        for height, width in resolutions:
+            config = Config(
+                num_inference_steps=2,  # Minimal steps for speed
+                height=height,
+                width=width,
+                guidance=0.0,
+            )
+
+            image = zimage.generate_image(
+                seed=42,
+                prompt="test",
+                config=config,
+            )
+
+            assert isinstance(image.image, Image.Image)
+            assert image.image.size == (width, height)
+            assert image.image.mode == "RGB"
+
+    @pytest.mark.skipif(
+        False,
+        reason="Requires local model",
+    )
+    def test_memory_usage_stays_reasonable(self):
+        """Test that memory usage doesn't spike during generation.
+
+        This is a regression test for the bug where VAE decode without
+        mx.eval() caused memory to spike to 30+GB. With the fix, memory
+        should stay under 10GB for q4 quantized models.
+        """
+        from mflux.config.config import Config
+        from mflux.config.model_config import ModelConfig
+        from mflux.zimage import ZImage
+
+        zimage = ZImage(
+            model_config=ModelConfig.zimage_turbo(),
+            local_path="./zimage-q4",
+            quantize=None,
+        )
+
+        config = Config(
+            num_inference_steps=9,
+            height=1024,
+            width=1024,
+            guidance=0.0,
+        )
+
+        # Record memory after model load (baseline for model + generation)
+        memory_after_load = mx.get_active_memory() / 1e9
+
+        image = zimage.generate_image(
+            seed=42,
+            prompt="test image for memory regression",
+            config=config,
+        )
+
+        # Get current active memory
+        memory_after_generation = mx.get_active_memory() / 1e9
+
+        # Calculate the memory used during generation (delta from baseline)
+        generation_memory_delta = memory_after_generation - memory_after_load
+
+        # Verify image was generated
+        assert isinstance(image.image, Image.Image)
+        assert image.image.size == (1024, 1024)
+
+        # CRITICAL: Memory increase during generation should be reasonable
+        # For a q4 1024x1024 image, we expect ~6-7GB for latents + VAE decode
+        # Before the fix, this would spike to 30+GB due to graph explosion
+        assert generation_memory_delta < 15.0, (
+            f"Memory delta too high: {generation_memory_delta:.2f} GB (expected < 15 GB for generation)"
+        )
+
+        # Total memory (model + generation) should be under 25GB for q4
+        # Before the fix, this would exceed 30GB
+        assert memory_after_generation < 25.0, (
+            f"Total memory too high: {memory_after_generation:.2f} GB (expected < 25 GB)"
+        )


### PR DESCRIPTION
## Summary

Adds support for [Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo), a 6B text-to-image model from Alibaba. New architecture—single-stream diffusion transformer (S3-DiT) with Qwen3-4B text encoder.

## What's included

- `mflux-generate-zimage` and `mflux-save-zimage` CLI commands
- S3-DiT transformer (30 blocks, 3840 hidden dim, 3D RoPE)
- Qwen3-4B encoder (36 layers, GQA, chat template preprocessing)
- Quantization support (3/4/5/6/8-bit)
- Reuses existing FLUX VAE

## How it differs from FLUX

| | Z-Image-Turbo | FLUX |
|---|---|---|
| Architecture | Single-stream (concatenated tokens) | Dual-stream |
| Text encoder | Qwen3-4B | CLIP + T5 |
| CFG | Distilled (guidance=0) | Runtime |
| Steps | 8-9 | 4-50 |

## Usage

```bash
# Basic (fp16, ~90s on M4 Max at 1024x1024)
mflux-generate-zimage \
  --prompt "A serene mountain landscape at sunset" \
  --seed 42 --output mountain.png

# Faster iteration (512x512, ~21s)
mflux-generate-zimage \
  --prompt "A cyberpunk city at night" \
  --height 512 --width 512 \
  --seed 42 --output cyberpunk.png

# Save quantized model, then generate from it
mflux-save-zimage --quantize 4 --path ./zimage-q4
mflux-generate-zimage --prompt "..." --path ./zimage-q4
```

## Known limitations

- Requires ~48GB RAM in FP16 (transformer + Qwen3-4B loaded together)
- Qwen3 encoder is not quantized (quality degradation when quantized)
- No LoRA support yet
