### PR TITLE
Bump version to 0.15.1 for PyPI fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-01-18
+
+### 🐛 Bug Fixes
+
+- **PyPI metadata**: Removed invalid architecture classifier that blocked uploads (`Architecture :: AArch64`).
+
+---
+
 ## [0.15.0] - 2026-01-18
 
 ### 🎨 New Model Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ source-exclude = [
 
 [project]
 name = "mflux"
-version = "0.15.0"
+version = "0.15.1"
 description = "A MLX port of FLUX based on the Huggingface Diffusers implementation."
 readme = "README.md"
 keywords = ["diffusers", "flux", "mlx"]
@@ -52,7 +52,6 @@ dependencies = [
     "urllib3>=2.6.0",
 ]
 classifiers = [
-    "Architecture :: AArch64",
     "Intended Audience :: Developers",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Got the following problem in the release script: 

```
⚠️  Unexpected error during PyPI upload: 400 Client Error: 'Architecture :: AArch64' is not a valid classifier.
```

Suggested fix was to remove the classifier. 