### PR TITLE
Silence external test warnings and close image files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,12 @@ docstring-code-line-length = "dynamic"
 testpaths = ["tests"]
 python_files = "test_*.py"
 addopts = '-v --failed-first --showlocals --tb=long --full-trace -m "not high_memory_requirement"'
+filterwarnings = [
+    "ignore::DeprecationWarning:transformers\\.models\\.clip\\.tokenization_clip",
+    "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
+    "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
+    "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
+]
 markers = [
     "fast: marks tests as fast (no image generation)",
     "slow: marks tests as slow (generates images)",

--- a/src/mflux/utils/metadata_reader.py
+++ b/src/mflux/utils/metadata_reader.py
@@ -12,24 +12,24 @@ class MetadataReader:
     @staticmethod
     def read_exif_metadata(image_path: str | Path) -> dict | None:
         try:
-            img = PIL.Image.open(image_path)
-            exif_bytes = img.info.get("exif")
+            with PIL.Image.open(image_path) as img:
+                exif_bytes = img.info.get("exif")
 
-            if not exif_bytes:
+                if not exif_bytes:
+                    return None
+
+                exif_dict = piexif.load(exif_bytes)
+                user_comment = exif_dict["Exif"].get(0x9286, b"")
+
+                if user_comment:
+                    # Try to parse as JSON (strip the ASCII prefix if present)
+                    if user_comment.startswith(b"ASCII\x00\x00\x00"):
+                        metadata_str = user_comment[8:].decode("utf-8")
+                    else:
+                        metadata_str = user_comment.decode("utf-8")
+                    return json.loads(metadata_str)
+
                 return None
-
-            exif_dict = piexif.load(exif_bytes)
-            user_comment = exif_dict["Exif"].get(0x9286, b"")
-
-            if user_comment:
-                # Try to parse as JSON (strip the ASCII prefix if present)
-                if user_comment.startswith(b"ASCII\x00\x00\x00"):
-                    metadata_str = user_comment[8:].decode("utf-8")
-                else:
-                    metadata_str = user_comment.decode("utf-8")
-                return json.loads(metadata_str)
-
-            return None
 
         except (OSError, KeyError, json.JSONDecodeError, UnicodeDecodeError) as e:
             log.debug(f"Error reading EXIF metadata: {e}")
@@ -38,49 +38,49 @@ class MetadataReader:
     @staticmethod
     def read_xmp_metadata(image_path: str | Path) -> dict | None:
         try:
-            img = PIL.Image.open(image_path)
-            xmp_data = img.info.get("XML:com.adobe.xmp")
+            with PIL.Image.open(image_path) as img:
+                xmp_data = img.info.get("XML:com.adobe.xmp")
 
-            if not xmp_data:
-                return None
+                if not xmp_data:
+                    return None
 
-            # Parse XMP XML to extract key fields
-            xmp_dict = {}
+                # Parse XMP XML to extract key fields
+                xmp_dict = {}
 
-            # Simple XML parsing for common fields
-            fields = {
-                "description": '<dc:description><rdf:Alt><rdf:li xml:lang="x-default">',
-                "creator": "<dc:creator><rdf:Seq><rdf:li>",
-                "rights": '<dc:rights><rdf:Alt><rdf:li xml:lang="x-default">',
-                "creator_tool": "<xmp:CreatorTool>",
-                "category": "<photoshop:Category>",
-                "credit": "<photoshop:Credit>",
-                "seed": "<mflux:seed>",
-                "steps": "<mflux:steps>",
-                "guidance": "<mflux:guidance>",
-                "model": "<mflux:model>",
-                "loras": "<mflux:loras>",
-                "generation_time": "<mflux:generationTime>",
-            }
+                # Simple XML parsing for common fields
+                fields = {
+                    "description": '<dc:description><rdf:Alt><rdf:li xml:lang="x-default">',
+                    "creator": "<dc:creator><rdf:Seq><rdf:li>",
+                    "rights": '<dc:rights><rdf:Alt><rdf:li xml:lang="x-default">',
+                    "creator_tool": "<xmp:CreatorTool>",
+                    "category": "<photoshop:Category>",
+                    "credit": "<photoshop:Credit>",
+                    "seed": "<mflux:seed>",
+                    "steps": "<mflux:steps>",
+                    "guidance": "<mflux:guidance>",
+                    "model": "<mflux:model>",
+                    "loras": "<mflux:loras>",
+                    "generation_time": "<mflux:generationTime>",
+                }
 
-            for key, start_tag in fields.items():
-                if start_tag in xmp_data:
-                    start_idx = xmp_data.index(start_tag) + len(start_tag)
-                    # Find the closing tag
-                    if key in ["description", "rights"]:
-                        end_tag = "</rdf:li>"
-                    elif key == "creator":
-                        end_tag = "</rdf:li>"
-                    else:
-                        # Extract tag name from start_tag
-                        tag_name = start_tag.split(":")[1].rstrip(">")
-                        end_tag = f"</{start_tag.split(':')[0]}:{tag_name}>"
+                for key, start_tag in fields.items():
+                    if start_tag in xmp_data:
+                        start_idx = xmp_data.index(start_tag) + len(start_tag)
+                        # Find the closing tag
+                        if key in ["description", "rights"]:
+                            end_tag = "</rdf:li>"
+                        elif key == "creator":
+                            end_tag = "</rdf:li>"
+                        else:
+                            # Extract tag name from start_tag
+                            tag_name = start_tag.split(":")[1].rstrip(">")
+                            end_tag = f"</{start_tag.split(':')[0]}:{tag_name}>"
 
-                    end_idx = xmp_data.index(end_tag, start_idx)
-                    value = xmp_data[start_idx:end_idx]
-                    xmp_dict[key] = value
+                        end_idx = xmp_data.index(end_tag, start_idx)
+                        value = xmp_data[start_idx:end_idx]
+                        xmp_dict[key] = value
 
-            return xmp_dict if xmp_dict else None
+                return xmp_dict if xmp_dict else None
 
         except (OSError, KeyError, ValueError) as e:
             log.debug(f"Error reading XMP metadata: {e}")

--- a/tests/metadata/test_metadata.py
+++ b/tests/metadata/test_metadata.py
@@ -119,9 +119,9 @@ class TestMetadata:
             import piexif
             from PIL import Image
 
-            img = Image.open(output_path)
-            exif_bytes = img.info.get("exif")
-            assert exif_bytes is not None, "EXIF bytes should be present"
+            with Image.open(output_path) as img:
+                exif_bytes = img.info.get("exif")
+                assert exif_bytes is not None, "EXIF bytes should be present"
 
             exif_dict = piexif.load(exif_bytes)
             user_comment = exif_dict.get("Exif", {}).get(piexif.ExifIFD.UserComment)


### PR DESCRIPTION
Keep pytest output clean by filtering known third-party deprecations and ensure metadata readers/tests close image handles properly.