### PR TITLE
Narrow M1/M2 compile guard to exclude Max and Ultra variants.

### DIFF
--- a/src/mflux/utils/apple_silicon.py
+++ b/src/mflux/utils/apple_silicon.py
@@ -12,6 +12,8 @@ class AppleSiliconUtil:
         if platform.machine() not in {"arm64", "aarch64"}:
             return False
         chip_name = cls._get_chip_name().lower()
+        if "max" in chip_name or "ultra" in chip_name:
+            return False
         return "apple m1" in chip_name or "apple m2" in chip_name
 
     @classmethod

--- a/tests/utils/test_apple_silicon.py
+++ b/tests/utils/test_apple_silicon.py
@@ -1,0 +1,33 @@
+from mflux.utils.apple_silicon import AppleSiliconUtil
+
+
+def test_is_m1_or_m2_true_for_m1_and_m2_non_max_variants(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr(AppleSiliconUtil, "_get_chip_name", lambda: "Apple M2 Pro")
+
+    assert AppleSiliconUtil.is_m1_or_m2() is True
+
+
+def test_is_m1_or_m2_false_for_m2_max(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr(AppleSiliconUtil, "_get_chip_name", lambda: "Apple M2 Max")
+
+    assert AppleSiliconUtil.is_m1_or_m2() is False
+
+
+def test_is_m1_or_m2_false_for_m2_ultra(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr(AppleSiliconUtil, "_get_chip_name", lambda: "Apple M2 Ultra")
+
+    assert AppleSiliconUtil.is_m1_or_m2() is False
+
+
+def test_is_m1_or_m2_false_outside_darwin(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr(AppleSiliconUtil, "_get_chip_name", lambda: "Apple M2")
+
+    assert AppleSiliconUtil.is_m1_or_m2() is False


### PR DESCRIPTION
This keeps compile disabled for lower-end M1/M2 chips while allowing higher-tier Apple Silicon machines that benefit from compilation. Fix for https://github.com/filipstrand/mflux/issues/349