### PR TITLE
feat: expose img2img CLI flags for Flux.2 Klein

### DIFF
--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -16,6 +16,7 @@ def main():
     parser.add_model_arguments(require_model_arg=False)
     parser.add_lora_arguments()
     parser.add_image_generator_arguments(supports_metadata_config=True, supports_dimension_scale_factor=True)
+    parser.add_image_to_image_arguments(required=False)
     parser.add_output_arguments()
     args = parser.parse_args()
 
@@ -49,7 +50,7 @@ def main():
         width, height = DimensionResolver.resolve(
             width=args.width,
             height=args.height,
-            reference_image_path=None,
+            reference_image_path=args.image_path,
         )
 
         for seed in args.seed:
@@ -59,7 +60,9 @@ def main():
                 width=width,
                 height=height,
                 guidance=args.guidance,
+                image_path=args.image_path,
                 num_inference_steps=args.steps,
+                image_strength=args.image_strength,
                 scheduler="flow_match_euler_discrete",
             )
             ImageUtil.save_image(


### PR DESCRIPTION
Add --image-path and --image-strength to mflux-generate-flux2, following the same pattern used by flux_generate.py (Flux.1).

>Note: This is independent of #353  (Z-Image enhancements), and can be reviewed/merged separately.

Three additions:
1. parser.add_image_to_image_arguments(required=False)
2. reference_image_path=args.image_path in DimensionResolver.resolve()
3. image_path + image_strength passed to model.generate_image()

## Summary

The `Flux2Klein` Python class already implements full img2img support via
`_prepare_img2img_latents()`, accepting `image_path` and `image_strength`
parameters in `generate_image()`. However, the `mflux-generate-flux2` CLI
does not register `--image-path` / `--image-strength`, so users cannot
access img2img from the command line.

This PR adds 3 lines to `flux2_generate.py` to expose these flags,
following the exact same pattern used by `flux_generate.py` (Flux.1):

1. `parser.add_image_to_image_arguments(required=False)`
2. `reference_image_path=args.image_path` in `DimensionResolver.resolve()`
3. `image_path=args.image_path` + `image_strength=args.image_strength` in `generate_image()`

When `--image-path` is not provided, behavior is identical to upstream.

## **Why this is different from `mflux-generate-flux2-edit`**

Flux.2 Klein already has an **image-conditioned editing** CLI
(`mflux-generate-flux2-edit` with `--image-paths`), but that is a
fundamentally different operation from **img2img**:

| | img2img (`--image-path`) | Image-conditioned editing (`--image-paths`) |
|---|---|---|
| **Purpose** | Transform a single input image while preserving its overall structure and composition | Use one or more reference images as semantic context for generation |
| **How it works** | Encodes the input into latent space, adds noise controlled by `--image-strength`, then denoises — the result follows the spatial layout of the original | Reference images are injected as conditioning tokens alongside the text prompt — the model draws on their content freely |
| **Strength control** | `--image-strength` (0.0 = ignore input, 1.0 = pure noise) controls how much of the original is preserved | No strength parameter — the prompt determines what changes |
| **Number of inputs** | Exactly 1 image | 1 or more reference images |
| **Typical use cases** | Style transfer, color grading, detail refinement, artistic re-interpretation of a photo | "Put these sunglasses on this person", combining elements from multiple images, subject-driven editing |
| **CLI command** | `mflux-generate-flux2` (this PR) | `mflux-generate-flux2-edit` (already exists) |

Every other generation command in MFLUX that supports img2img
(Flux.1, FIBO, Qwen Image, Z-Image) already exposes `--image-path` /
`--image-strength` in its CLI. Flux.2 Klein is the only model where the
underlying class supports it but the CLI does not — this PR closes that gap.

## Testing

Tested on Apple Silicon with `flux2-klein-4b` (distilled) and
`flux2-klein-base-9b` (undistilled). Verified:
- txt2img (no new flags) produces identical output to upstream
- img2img with `--image-path` + `--image-strength` works correctly
- DimensionResolver auto-sizes from the reference image when `--width`/`--height` are omitted

## Checklist
- [x] Single file changed (`flux2_generate.py`)
- [x] No new dependencies
- [x] Backward-compatible (no flags = identical behavior)
- [x] Follows existing pattern from `flux_generate.py`