### PR TITLE
Release 0.16.8

### DIFF
--- a/.cursor/skills/mflux-release/SKILL.md
+++ b/.cursor/skills/mflux-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mflux-release
-description: Prepare a release in mflux (version bump, changelog, uv lock) without tagging/publishing.
+description: Prepare a release in mflux (version bump, changelog, contributors, uv lock) without tagging/publishing. Use when preparing a release branch or release PR.
 ---
 # mflux release prep
 
@@ -22,6 +22,19 @@ Releases are prepared in-repo; tagging/publishing is handled by GitHub Actions.
   - Browse relevant file contents if needed to clarify changes
   - Weigh commit impact: some are minor; skim earlier changelog entries to gauge what's worth reporting vs tiny fixes
   - Add a descriptive entry to `CHANGELOG.md` based on those commits
+  - Always add a `### 👩‍💻 Contributors` section to the new changelog entry
+  - Source contributor names from merged GitHub PR authors for the changes included in the release, and format them as `@handle`
+  - Prefer one release commit for the release prep work on the branch
+  - Name that commit `Release <version>`
+  - Prefer GitHub data over local git author names:
+    - Use `gh pr list --state merged` / related `gh` queries when available
+    - Do not assume `gh` is installed; if it is unavailable, inspect GitHub on the web instead
+    - General pages to check on the web:
+      - Closed PRs: `https://github.com/<owner>/<repo>/pulls?q=is%3Apr+is%3Aclosed`
+      - Compare view for release range: `https://github.com/<owner>/<repo>/compare/v.<last-version>...HEAD`
+      - Specific PR page when you know the PR number: `https://github.com/<owner>/<repo>/pull/<number>`
+    - Map included changes to merged PR authors from those pages
+  - Do not invent handles, and do not treat local-only commits as contributors unless the user explicitly wants that
   - Update lockfile: `uv lock`
   - Sanity checks (optional unless requested): `make test-fast`, `make build`
   - Manual checks (optional): if the release includes CLI/callback/image-path changes, consider running the `mflux-manual-testing` skill to exercise the touched commands and visually review outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.8] - 2026-03-06
+
+### ✨ Improvements
+
+- **Local-model LoRA training**: Allow LoRA training to work when the base model is supplied from a local path, including the FLUX.2 and Z-Image training adapters.
+
+### 📝 Documentation
+
+- **Distilled-model step defaults**: Clarify CLI guidance so examples prefer model default inference steps unless the user intentionally overrides them.
+
+### 👩‍💻 Contributors
+
+- **@waldheinz**
+
+---
+
 ## [0.16.7] - 2026-03-02
 
 ### 🎨 New Model Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ source-exclude = [
 
 [project]
 name = "mflux"
-version = "0.16.7"
+version = "0.16.8"
 description = "MLX native implementations of state-of-the-art generative image models."
 readme = "README.md"
 keywords = ["flux", "ai", "ml", "transformers", "mlx", "huggingface", "apple-silicon", "diffusers", "qwen", "qwen-image", "seedvr2", "z-image"]

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "mflux"
-version = "0.16.7"
+version = "0.16.8"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
Prepare the 0.16.8 release by bumping package metadata, updating the changelog, and documenting the release workflow preferences.
