### PR TITLE
Scale training images according to area, not longest side

### DIFF
--- a/src/mflux/models/common/training/utils.py
+++ b/src/mflux/models/common/training/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -56,12 +58,14 @@ class TrainingUtil:
         default_max_resolution: int | None = None,
         error_template: str | None = None,
     ) -> tuple[int, int]:
-        max_dim = max(width, height)
         effective_max = max_resolution if max_resolution is not None else default_max_resolution
-        if effective_max is not None and max_dim > effective_max:
-            scale = effective_max / max_dim
-            width = int(width * scale)
-            height = int(height * scale)
+        if effective_max is not None:
+            max_area = effective_max * effective_max
+            current_area = width * height
+            if current_area > max_area:
+                scale = math.sqrt(max_area / current_area)
+                width = int(width * scale)
+                height = int(height * scale)
 
         adj_width = 16 * (int(width) // 16)
         adj_height = 16 * (int(height) // 16)


### PR DESCRIPTION
When the user limits the `max_resolution` it's very likely because of resource constaints. But the resource use is strongly correlated to the total number of pixels and not the length of the longer side of an image.

This change modifies the logic to resolve dimensions where the *area* of the resolved image is ~ `max_resoluton ^ 2`, which means non-square images get the same "pixel budget" as square images.

