### PR TITLE
Fix not evaluating the optimizer state after each step

### DIFF
--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -140,6 +140,7 @@ class TrainingTrainer:
         for batch in batches:
             loss, grads = train_step_function(batch)
             training_state.optimizer.optimizer.update(model=adapter.model(), gradients=grads)
+            mx.eval(adapter.model().parameters(), training_state.optimizer.optimizer.state)
             del loss, grads
 
             if training_state.should_plot_loss(training_spec):


### PR DESCRIPTION
Not doing this causes huge memory use if neither "should_plot_loss", "should_generate_image" or "should_save" force an evaluation in the code below.

I found this when setting `plot_frequency` to 32 because evaluating the loss using the validation set is not cheap at all. But this is a separate issue.