### PR TITLE
allow current major 7.x versions of protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "transformers>=5.0.0,<6.0",
     "twine>=6.1.0,<7.0",
     "urllib3>=2.6.0",
-    "protobuf>=4.25.0,<6.0",
+    "protobuf>=4.25.0,<8.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
https://pypi.org/project/protobuf/#history shows the project has moved to 7.x series, and still supports Python 3.10, consistent with this project's metadata.

I tested this way:

## without the change

```
 $ uv tool install -p 3.14 --with mlx-audio==0.4.2 mflux==0.17.3
  × No solution found when resolving dependencies:
  ╰─▶ Because mflux==0.17.3 depends on protobuf>=4.25.0,<6.0 and mlx-audio==0.4.2 depends on
      protobuf>=6.33.5, we can conclude that mflux==0.17.3 and mlx-audio==0.4.2 are incompatible.
      And because you require mflux==0.17.3 and mlx-audio==0.4.2, we can conclude that your
      requirements are unsatisfiable.
```

## with the change

```
 $ uv tool install -p 3.14 --with mlx-audio==0.4.2 .
Resolved 93 packages in 39ms
Audited 93 packages in 1ms
Installed 29 executables: mflux-completions, mflux-concept, mflux-concept-from-image, mflux-generate, mflux-generate-controlnet, mflux-generate-depth, mflux-generate-fibo, mflux-generate-fibo-edit, mflux-generate-fill, mflux-generate-flux2, mflux-generate-flux2-edit, mflux-generate-in-context, mflux-generate-in-context-catvton, mflux-generate-in-context-edit, mflux-generate-kontext, mflux-generate-qwen, mflux-generate-qwen-edit, mflux-generate-redux, mflux-generate-z-image, mflux-generate-z-image-turbo, mflux-info, mflux-inspire-fibo, mflux-lora-library, mflux-refine-fibo, mflux-save, mflux-save-depth, mflux-train, mflux-upscale-controlnet, mflux-upscale-seedvr2
```

## risk

- this is a transitive dep of the ecosystem
- need to pass tests to make sure the bump doesn't break image generation somehow

^ WIP, I don't have time for this today just offering this quick fix/check