### PR TITLE
Fix mflux-save dropping VisionTransformer weights for Qwen edit models

### DIFF
--- a/src/mflux/models/common/cli/save.py
+++ b/src/mflux/models/common/cli/save.py
@@ -3,6 +3,7 @@ from mflux.models.common.config import ModelConfig
 from mflux.models.fibo.variants.txt2img.fibo import FIBO
 from mflux.models.flux.variants.txt2img.flux import Flux1
 from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+from mflux.models.qwen.variants.edit.qwen_image_edit import QwenImageEdit
 from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
 from mflux.models.z_image import ZImage, ZImageTurbo
 
@@ -16,7 +17,9 @@ def main():
 
     # 1. Determine model class based on model name
     model_name_lower = args.model.lower()
-    if "qwen" in model_name_lower:
+    if "qwen" in model_name_lower and "edit" in model_name_lower:
+        model_class = QwenImageEdit
+    elif "qwen" in model_name_lower:
         model_class = QwenImage
     elif "fibo" in model_name_lower:
         model_class = FIBO

--- a/src/mflux/models/qwen/variants/edit/qwen_image_edit.py
+++ b/src/mflux/models/qwen/variants/edit/qwen_image_edit.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from mflux.models.common.config.config import Config
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.common.vae.vae_util import VAEUtil
+from mflux.models.common.weights.saving.model_saver import ModelSaver
 from mflux.models.qwen.latent_creator.qwen_latent_creator import QwenLatentCreator
 from mflux.models.qwen.model.qwen_text_encoder.qwen_text_encoder import QwenTextEncoder
 from mflux.models.qwen.model.qwen_transformer.qwen_transformer import QwenTransformer
@@ -15,6 +16,7 @@ from mflux.models.qwen.model.qwen_vae.qwen_vae import QwenVAE
 from mflux.models.qwen.qwen_initializer import QwenImageInitializer
 from mflux.models.qwen.variants.edit.qwen_edit_util import QwenEditUtil
 from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
+from mflux.models.qwen.weights.qwen_weight_definition import QwenWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
 from mflux.utils.image_util import ImageUtil
@@ -41,6 +43,14 @@ class QwenImageEdit(nn.Module):
             lora_paths=lora_paths,
             lora_scales=lora_scales,
             model_config=model_config,
+        )
+
+    def save_model(self, base_path: str) -> None:
+        ModelSaver.save_model(
+            model=self,
+            bits=self.bits,
+            base_path=base_path,
+            weight_definition=QwenWeightDefinition,
         )
 
     def generate_image(


### PR DESCRIPTION
## Summary

- `mflux-save` always used `QwenImage` (txt2img) for all Qwen models, silently dropping 390 VisionTransformer weights when saving edit models
- Saved Qwen-Image-Edit models loaded with random vision encoder weights, producing degraded output
- Added edit model detection in `save.py` and `save_model()` to `QwenImageEdit`

## Details

The save CLI (`save.py`) matched all Qwen models to `QwenImage`, which initializes via `_init_models()` — no `VisionTransformer`. When `QwenImageEdit` later loaded the saved file, `strict=False` silently skipped the missing 390 `encoder.visual.*` weights, leaving the vision encoder on random initialization.

**Fix:** check for `"edit"` in the model name before the generic Qwen branch, and give `QwenImageEdit` its own `save_model()` method so the full model graph is captured.

## Reproduction

```bash
# Before fix: saved model is ~29GB (missing ~1GB of vision weights)
mflux-save --model Qwen/Qwen-Image-Edit-2511 --base-model qwen --path ./saved-q6 --quantize 6

# After fix: saved model is ~30GB (all weights included)
mflux-save --model Qwen/Qwen-Image-Edit-2511 --base-model qwen --path ./saved-q6 --quantize 6
```

## Test plan

- [ ] Save a Qwen-Image-Edit model and verify output is ~1GB larger than before
- [ ] Load saved model with `mflux-generate-qwen-edit` and confirm output matches on-the-fly quality
- [ ] Verify `mflux-save` still works for non-edit Qwen models (txt2img path unchanged)