### PR TITLE
Fix #314: Built a Mac App based on this.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See the [common README](src/mflux/models/common/README.md) for detailed usage an
 
 ### 🌱 Related projects
 
-- [MindCraft Studio](https://themindstudio.cc/mindcraft#models) by [@shaoju](https://github.com/shaoju)
+- [MindCraft Studio](https://themindstudio.cc/mindcraft#models) — macOS app built on mflux by [@shaoju](https://github.com/shaoju)
 - [Mflux-ComfyUI](https://github.com/raysers/Mflux-ComfyUI) by [@raysers](https://github.com/raysers)
 - [MFLUX-WEBUI](https://github.com/CharafChnioune/MFLUX-WEBUI) by [@CharafChnioune](https://github.com/CharafChnioune)
 - [mflux-fasthtml](https://github.com/anthonywu/mflux-fasthtml) by [@anthonywu](https://github.com/anthonywu)


### PR DESCRIPTION
Closes #314

## Motivation

The existing entry for MindCraft Studio in the Related Projects section lacked context about what the project actually is, making it indistinguishable from other listed tools.

## Changes

- **`README.md`, line 159**: Updated the MindCraft Studio list entry to append `— macOS app built on mflux` between the project link and the author attribution, clarifying the nature of the project without altering the link URL (`https://themindstudio.cc/mindcraft#models`) or the author handle (`@shaoju`).

## Testing

Visual verification: confirm the rendered README displays the updated description inline with the existing list formatting, and that the hyperlink and author mention remain correctly formatted. No functional code changes; no automated tests required.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*