### PR TITLE
Enable gradient checkpointing for Flux2 training to reduce peak memory

### DIFF
--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -117,6 +117,10 @@ class TrainingTrainer:
         adapter.freeze_base()
         TrainingTrainer._unfreeze_lora_layers(adapter.transformer())
 
+        # Enable gradient checkpointing to reduce memory usage
+        if hasattr(adapter.transformer(), '_gradient_checkpointing'):
+            adapter.transformer()._gradient_checkpointing = True
+
         train_step_function = nn.value_and_grad(
             model=adapter.model(),
             fn=lambda b: TrainingTrainer.compute_loss(adapter, training_spec, base_config, b),
@@ -249,6 +253,8 @@ class TrainingTrainer:
             try:
                 TrainingTrainer._generate_previews(adapter, training_spec, training_state)
             finally:
+                gc.collect()
+                mx.clear_cache()
                 restored_state = tree_unflatten(list(mx.load(str(offload_path)).items()))
                 optimizer.optimizer.state = restored_state
                 gc.collect()

--- a/src/mflux/models/flux2/model/flux2_transformer/transformer.py
+++ b/src/mflux/models/flux2/model/flux2_transformer/transformer.py
@@ -1,5 +1,6 @@
 import mlx.core as mx
 from mlx import nn
+from mlx.nn.utils import checkpoint
 
 from mflux.models.common.config.model_config import ModelConfig
 from mflux.models.flux.model.flux_transformer.ada_layer_norm_continuous import AdaLayerNormContinuous
@@ -63,6 +64,7 @@ class Flux2Transformer(nn.Module):
         ]
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim)
         self.proj_out = nn.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=False)
+        self._gradient_checkpointing = False
 
     def __call__(
         self,
@@ -109,7 +111,8 @@ class Flux2Transformer(nn.Module):
         temb_mod_params_txt = self.double_stream_modulation_txt(temb)
 
         for block in self.transformer_blocks:
-            encoder_hidden_states, hidden_states = block(
+            block_fn = checkpoint(block) if self._gradient_checkpointing else block
+            encoder_hidden_states, hidden_states = block_fn(
                 hidden_states=hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 temb_mod_params_img=temb_mod_params_img,
@@ -121,7 +124,8 @@ class Flux2Transformer(nn.Module):
 
         temb_mod_params_single = self.single_stream_modulation(temb)[0]
         for block in self.single_transformer_blocks:
-            hidden_states = block(
+            block_fn = checkpoint(block) if self._gradient_checkpointing else block
+            hidden_states = block_fn(
                 hidden_states=hidden_states,
                 temb_mod_params=temb_mod_params_single,
                 image_rotary_emb=concat_rotary_emb,


### PR DESCRIPTION
## Motivation

During LoRA training on Flux2 Klein (4B), `nn.value_and_grad` stores all intermediate activations across 25 transformer blocks for the backward pass. On a 64GB Mac, this causes peak memory usage of ~40GB per training step, leaving little headroom for preview generation or larger batch sizes.

## Changes

- **`Flux2Transformer`**: Add `_gradient_checkpointing` flag (default `False`) and wrap both `transformer_blocks` and `single_transformer_blocks` loops with `mlx.nn.utils.checkpoint` when enabled. This recomputes intermediate activations during the backward pass instead of storing them all.
- **`TrainingTrainer.train()`**: Enable gradient checkpointing on the transformer before training begins.
- **`TrainingTrainer._generate_previews_with_optimizer_offload()`**: Add `gc.collect()` + `mx.clear_cache()` before restoring optimizer state from disk to free preview-related memory first.

Inference is unaffected — the flag stays `False` unless the trainer explicitly enables it.

## Results (Flux2 Klein 4B, 64GB Mac)

| Metric | Before | After |
|--------|--------|-------|
| Training step peak | ~40,000 MB | ~19,000 MB |
| Training step temp allocation | ~24,500 MB | ~3,700 MB |
| With preview generation peak | OOM-prone | ~25,000 MB |
| Step time | ~2.4s | ~3.1s |

Peak memory is halved with a modest ~30% increase in step time due to recomputation.

## Test plan

- [x] Ran full training loop (2 epochs, 10 steps) without preview — peak 19GB, stable
- [x] Ran full training loop with preview generation every 5 steps — peak 25GB, stable
- [ ] Verify inference is unaffected (flag defaults to `False`)