### PR TITLE
Add mlx-taef and mlx-teacache to Related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ See the [common README](src/mflux/models/common/README.md) for detailed usage an
 - [MFLUX-WEBUI](https://github.com/CharafChnioune/MFLUX-WEBUI) by [@CharafChnioune](https://github.com/CharafChnioune)
 - [mflux-fasthtml](https://github.com/anthonywu/mflux-fasthtml) by [@anthonywu](https://github.com/anthonywu)
 - [mflux-streamlit](https://github.com/elitexp/mflux-streamlit) by [@elitexp](https://github.com/elitexp)
+- [mlx-taef](https://github.com/IonDen/mlx-taef) — TAESD/TAEF tiny-autoencoder live previews and low-memory FLUX decode for mflux, by [@IonDen](https://github.com/IonDen)
+- [mlx-teacache](https://github.com/IonDen/mlx-teacache) — TeaCache step-skipping to speed up FLUX generation in mflux, by [@IonDen](https://github.com/IonDen)
 
 ---
 


### PR DESCRIPTION
Hi — I've built two small MLX libraries that plug into mflux and I'd like to add them to the Related projects list:

- mlx-taef — TAESD/TAEF tiny autoencoders for live previews and low-memory FLUX decode. It hooks into mflux's stepwise callback, so you get a preview image each step without paying for the full VAE.
- mlx-teacache — a TeaCache step-skipping wrapper that speeds up FLUX on Apple Silicon by skipping denoising steps when the schedule is actually cacheable.

Both install from PyPI and keep their benchmarks and caveats in their own READMEs. I've tried to keep the caveats honest: teacache doesn't skip steps on distilled 4–8 step schedules, and taef previews are approximate, not full-VAE quality.

This only touches the Related projects list — two bullets, no code.

Happy to reword or drop either if you'd rather keep the list tight. Either way — thanks for mflux. Both libraries are built on top of it.
