### PR TITLE
fix: always evict text encoder and clear MLX cache between seeds

### DIFF
--- a/src/mflux/callbacks/callback_manager.py
+++ b/src/mflux/callbacks/callback_manager.py
@@ -63,25 +63,30 @@ class CallbackManager:
 
     @staticmethod
     def _register_memory_saver(args: Namespace, model) -> MemorySaver | None:
-        memory_saver = None
         cache_limit_bytes = CallbackManager._resolve_cache_limit_bytes(getattr(args, "mlx_cache_limit_gb", None))
+        seeds = getattr(args, "seed", []) or []
+        num_seeds = len(seeds) if seeds else 1
         if args.low_ram:
-            seeds = getattr(args, "seed", []) or []
             images = getattr(args, "image_path", [])
             if not isinstance(images, list):
                 images = [images] if images is not None else []
-            keep_transformer = len(seeds) > 1 or len(images) > 1
+            keep_transformer = num_seeds > 1 or len(images) > 1
             memory_saver = MemorySaver(
                 model=model,
                 keep_transformer=keep_transformer,
                 cache_limit_bytes=cache_limit_bytes or 1000**3,
                 args=args,
+                num_seeds=num_seeds,
             )
-            model.callbacks.register(memory_saver)
-        elif cache_limit_bytes is not None:
-            mx.set_cache_limit(cache_limit_bytes)
-            mx.clear_cache()
-            mx.reset_peak_memory()
+        else:
+            # Always evict text encoders after encoding — they are never needed post-encode
+            # and keeping them wastes 8-12 GB throughout the denoising loop.
+            memory_saver = MemorySaver(model=model, keep_transformer=True, cache_limit_bytes=None, num_seeds=num_seeds)
+            if cache_limit_bytes is not None:
+                mx.set_cache_limit(cache_limit_bytes)
+                mx.clear_cache()
+                mx.reset_peak_memory()
+        model.callbacks.register(memory_saver)
         return memory_saver
 
     @staticmethod

--- a/src/mflux/callbacks/instances/memory_saver.py
+++ b/src/mflux/callbacks/instances/memory_saver.py
@@ -10,15 +10,24 @@ from mflux.models.common.vae.tiling_config import TilingConfig
 
 
 class MemorySaver(BeforeLoopCallback, InLoopCallback, AfterLoopCallback):
-    def __init__(self, model, keep_transformer: bool = True, cache_limit_bytes: int = 1000**3, args=None):
+    def __init__(
+        self,
+        model,
+        keep_transformer: bool = True,
+        cache_limit_bytes: int | None = 1000**3,
+        args=None,
+        num_seeds: int = 1,
+    ):
         self.model = model
         self.keep_transformer = keep_transformer
         self.peak_memory: int = 0
-        if model.tiling_config is None:
-            self.model.tiling_config = TilingConfig()
-        mx.set_cache_limit(cache_limit_bytes)
-        mx.clear_cache()
-        mx.reset_peak_memory()
+        self._num_seeds = num_seeds
+        if cache_limit_bytes is not None:
+            if model.tiling_config is None:
+                self.model.tiling_config = TilingConfig()
+            mx.set_cache_limit(cache_limit_bytes)
+            mx.clear_cache()
+            mx.reset_peak_memory()
 
     def call_before_loop(
         self,
@@ -30,7 +39,12 @@ class MemorySaver(BeforeLoopCallback, InLoopCallback, AfterLoopCallback):
         depth_image: PIL.Image.Image | None = None,
     ) -> None:
         self.peak_memory = mx.get_peak_memory()
-        self._delete_text_encoders()
+        # Only evict when safe: single-seed run, or embeddings are cached in prompt_cache
+        # (Flux1 caches embeddings so encoder isn't needed for subsequent seeds;
+        #  Flux2 re-encodes each call and has no prompt_cache — keep encoder for multi-seed)
+        has_cached_embeds = hasattr(self.model, "prompt_cache") and prompt in (self.model.prompt_cache or {})
+        if self._num_seeds <= 1 or has_cached_embeds:
+            self._delete_text_encoders()
 
     def call_in_loop(
         self,
@@ -53,6 +67,11 @@ class MemorySaver(BeforeLoopCallback, InLoopCallback, AfterLoopCallback):
         self.peak_memory = mx.get_peak_memory()
         if not self.keep_transformer:
             self._delete_transformer()
+        else:
+            # Clear Metal cache between seeds — without a cache limit, MLX accumulates
+            # freed tensor buffers indefinitely across sequential denoising passes.
+            gc.collect()
+            mx.clear_cache()
 
     def _delete_text_encoders(self) -> None:
         # repeated image generation only works with the same prompt (cache)

--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -32,7 +32,9 @@ def main():
         args.guidance = 1.0
     model_name_lower = model_config.model_name.lower()
     base_model_lower = (model_config.base_model or "").lower()
-    is_flux2 = any(identifier in model_name_lower or identifier in base_model_lower for identifier in ("flux.2", "flux2"))
+    is_flux2 = any(
+        identifier in model_name_lower or identifier in base_model_lower for identifier in ("flux.2", "flux2")
+    )
     if args.guidance != 1.0 and not is_flux2:
         parser.error("--guidance is only supported for FLUX.2 models. Use --guidance 1.0.")
 

--- a/tests/callbacks/test_callback_manager_cache_limit.py
+++ b/tests/callbacks/test_callback_manager_cache_limit.py
@@ -19,11 +19,12 @@ def test_register_memory_saver_sets_mlx_cache_limit_without_low_ram():
     ):
         memory_saver = CallbackManager._register_memory_saver(args=args, model=model)
 
-    assert memory_saver is None
+    # MemorySaver is now always registered (encoder eviction is unconditional)
+    assert memory_saver is not None
     mock_set_cache_limit.assert_called_once_with(int(2.5 * (1000**3)))
     mock_clear_cache.assert_called_once()
     mock_reset_peak_memory.assert_called_once()
-    model.callbacks.register.assert_not_called()
+    model.callbacks.register.assert_called_once()
 
 
 @pytest.mark.fast

--- a/tests/callbacks/test_callback_manager_cache_limit.py
+++ b/tests/callbacks/test_callback_manager_cache_limit.py
@@ -19,7 +19,7 @@ def test_register_memory_saver_sets_mlx_cache_limit_without_low_ram():
     ):
         memory_saver = CallbackManager._register_memory_saver(args=args, model=model)
 
-    # MemorySaver is now always registered (encoder eviction is unconditional)
+    # MemorySaver is always registered when a cache limit is set without low_ram.
     assert memory_saver is not None
     mock_set_cache_limit.assert_called_once_with(int(2.5 * (1000**3)))
     mock_clear_cache.assert_called_once()
@@ -28,8 +28,21 @@ def test_register_memory_saver_sets_mlx_cache_limit_without_low_ram():
 
 
 @pytest.mark.fast
+def test_register_memory_saver_registers_by_default_without_low_ram_or_cache_limit():
+    args = Namespace(low_ram=False, seed=[1, 2, 3])
+    model = SimpleNamespace(callbacks=MagicMock())
+
+    memory_saver = CallbackManager._register_memory_saver(args=args, model=model)
+
+    assert memory_saver is not None
+    assert memory_saver._num_seeds == 3
+    assert memory_saver.keep_transformer is True
+    model.callbacks.register.assert_called_once_with(memory_saver)
+
+
+@pytest.mark.fast
 def test_register_memory_saver_uses_mlx_cache_limit_for_low_ram_mode():
-    args = Namespace(low_ram=True, mlx_cache_limit_gb=3.0, seed=[42], image_path=None)
+    args = Namespace(low_ram=True, mlx_cache_limit_gb=3.0, seed=[42, 43], image_path=None)
     model = SimpleNamespace(callbacks=MagicMock())
     mocked_memory_saver = object()
 
@@ -39,4 +52,6 @@ def test_register_memory_saver_uses_mlx_cache_limit_for_low_ram_mode():
     assert memory_saver is mocked_memory_saver
     _, kwargs = mock_memory_saver.call_args
     assert kwargs["cache_limit_bytes"] == int(3.0 * (1000**3))
+    assert kwargs["num_seeds"] == 2
+    assert kwargs["keep_transformer"] is True
     model.callbacks.register.assert_called_once_with(mocked_memory_saver)

--- a/tests/callbacks/test_memory_saver.py
+++ b/tests/callbacks/test_memory_saver.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+import pytest
+
+from mflux.callbacks.instances.memory_saver import MemorySaver
+from mflux.models.common.config.config import Config
+from mflux.models.common.config.model_config import ModelConfig
+
+
+class _EncoderModel:
+    def __init__(self, *, prompt_cache: dict | None = None) -> None:
+        self.text_encoder = object()
+        self.transformer = object()
+        self.tiling_config = None
+        self.prompt_cache = {} if prompt_cache is None else prompt_cache
+
+
+def _config() -> Config:
+    return Config(
+        width=256,
+        height=256,
+        guidance=1.0,
+        scheduler="linear",
+        model_config=ModelConfig.flux2_klein_4b(),
+        num_inference_steps=1,
+    )
+
+
+@pytest.mark.fast
+def test_memory_saver_skips_mlx_cache_setup_when_cache_limit_is_none():
+    model = _EncoderModel()
+
+    with (
+        patch("mflux.callbacks.instances.memory_saver.mx.set_cache_limit") as mock_set_cache_limit,
+        patch("mflux.callbacks.instances.memory_saver.mx.clear_cache") as mock_clear_cache,
+        patch("mflux.callbacks.instances.memory_saver.mx.reset_peak_memory") as mock_reset_peak_memory,
+    ):
+        MemorySaver(model=model, cache_limit_bytes=None)
+
+    mock_set_cache_limit.assert_not_called()
+    mock_clear_cache.assert_not_called()
+    mock_reset_peak_memory.assert_not_called()
+
+
+@pytest.mark.fast
+def test_call_before_loop_evicts_text_encoder_for_single_seed():
+    model = _EncoderModel()
+    saver = MemorySaver(model=model, cache_limit_bytes=None, num_seeds=1)
+
+    saver.call_before_loop(seed=1, prompt="a cat", latents=None, config=_config())
+
+    assert model.text_encoder is None
+
+
+@pytest.mark.fast
+def test_call_before_loop_keeps_text_encoder_for_multi_seed_without_prompt_cache():
+    model = _EncoderModel()
+    saver = MemorySaver(model=model, cache_limit_bytes=None, num_seeds=3)
+
+    saver.call_before_loop(seed=1, prompt="a cat", latents=None, config=_config())
+
+    assert model.text_encoder is not None
+
+
+@pytest.mark.fast
+def test_call_before_loop_evicts_text_encoder_for_multi_seed_with_cached_prompt():
+    model = _EncoderModel(prompt_cache={"a cat": object()})
+    saver = MemorySaver(model=model, cache_limit_bytes=None, num_seeds=3)
+
+    saver.call_before_loop(seed=2, prompt="a cat", latents=None, config=_config())
+
+    assert model.text_encoder is None
+
+
+@pytest.mark.fast
+def test_call_after_loop_clears_cache_when_keep_transformer_true():
+    model = _EncoderModel()
+    saver = MemorySaver(model=model, keep_transformer=True, cache_limit_bytes=None)
+
+    with (
+        patch("mflux.callbacks.instances.memory_saver.gc.collect") as mock_gc_collect,
+        patch("mflux.callbacks.instances.memory_saver.mx.clear_cache") as mock_clear_cache,
+    ):
+        saver.call_after_loop(seed=1, prompt="a cat", latents=None, config=_config())
+
+    mock_gc_collect.assert_called_once()
+    mock_clear_cache.assert_called_once()
+    assert model.transformer is not None


### PR DESCRIPTION
In testing mflux while using the option to pass in multiple seeds (batch jobs), I found a couple places where memory management is risky or outright dangerous.  This fixes two of those situations.

- Frees text encoder from unified memory after encoding — it's never needed during the denoising loop, saving 8–12 GB throughout generation.  This was a bigger issue when testing on Flux.2 Klein 9B, specifically, since the official version and even the mlx-community quants don't quantiza the Qwen encoder.
- Clears MLX cache between seeds when keep_transformer=True to prevent buffer accumulation and OOM on multi-seed generation runs.  This presented only when doing mult-seed generation, where each one left RAM held until the end of the whole batch, leading to a game of OOM Russian Roulette depending on batch size.  On my 64GB MBP with Flux.2 Klein 9b q8, it only took 5 seed sin a batch to completely RAM-lock and require a hard reboot.