### PR TITLE
Add atomic --lora and --image flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Improvements
+
+- **Atomic `--lora` and `--image` flags**: Pair each path with its value on a single, repeatable flag — `--lora A.safetensors 0.7 --lora B.safetensors` (scale defaults to `1.0`) and `--image photo.jpg 0.6` (strength defaults to the model default). This removes the positional-alignment footgun of the parallel `--lora-paths`/`--lora-scales` and `--image-path`/`--image-strength` lists, which remain fully supported and are marked deprecated in `--help`. (#357)
+
 ## [0.18.0] - 2026-06-07
 
 ### 🎨 New Model Support

--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -260,7 +260,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 except ValueError:
                     self.error(f"Invalid LoRA scale '{group[1]}' for '{group[0]}'.\nTip: --lora takes a PATH and an optional numeric SCALE: --lora {group[0]} 0.7")  # fmt: off
             else:
-                self.error(f"--lora takes one PATH and an optional SCALE but got {len(group)} values: {' '.join(group)}\nTip: repeat --lora for each adapter: --lora {group[0]} {group[1]} --lora {group[2]} ...")  # fmt: off
+                self.error(f"--lora takes one PATH and an optional SCALE but got {len(group)} values: {' '.join(group)}\nTip: give each adapter its own --lora: --lora A.safetensors 0.7 --lora B.safetensors")  # fmt: off
             paths.append(path)
             scales.append(scale)
         namespace.lora_paths = paths

--- a/src/mflux/cli/parser/parsers.py
+++ b/src/mflux/cli/parser/parsers.py
@@ -59,6 +59,7 @@ class CommandLineParser(argparse.ArgumentParser):
         self.supports_image_outpaint = False
         self.supports_lora = False
         self.require_model_arg = True
+        self.require_init_image = False
 
     def add_general_arguments(self) -> None:
         self.add_argument("--battery-percentage-stop-limit", "-B", type=lambda v: max(min(int(v), 99), 1), default=ui_defaults.BATTERY_PERCENTAGE_STOP_LIMIT, help=f"On Macs powered by battery, stop image generation when battery reaches this percentage. Default: {ui_defaults.BATTERY_PERCENTAGE_STOP_LIMIT}")
@@ -93,8 +94,9 @@ class CommandLineParser(argparse.ArgumentParser):
         self.supports_lora = True
         lora_group = self.add_argument_group("LoRA configuration")
         lora_group.add_argument("--lora-style", type=str, choices=sorted(LORA_NAME_MAP.keys()), help="Style of the LoRA to use (e.g., 'storyboard' for film storyboard style)")
-        self.add_argument("--lora-paths", type=str, nargs="*", default=None, help="LoRA paths: local files, HuggingFace repos (org/model), or collection format (repo:filename.safetensors)")
-        self.add_argument("--lora-scales", type=float, nargs="*", default=None, help="Scaling factor to adjust the impact of LoRA weights on the model. A value of 1.0 applies the LoRA weights as they are.")
+        lora_group.add_argument("--lora", dest="lora", action="append", nargs="+", default=None, metavar=("PATH", "SCALE"), help="Add a LoRA as an atomic PATH with optional SCALE (default 1.0). Repeatable: --lora A.safetensors 0.7 --lora B.safetensors. PATH accepts local files, HuggingFace repos (org/model), or collection format (repo:filename.safetensors). Preferred over --lora-paths/--lora-scales.")
+        self.add_argument("--lora-paths", type=str, nargs="*", default=None, help="[DEPRECATED: use --lora] LoRA paths: local files, HuggingFace repos (org/model), or collection format (repo:filename.safetensors)")
+        self.add_argument("--lora-scales", type=float, nargs="*", default=None, help="[DEPRECATED: use --lora] Scaling factor to adjust the impact of LoRA weights on the model. A value of 1.0 applies the LoRA weights as they are.")
 
     def _add_image_generator_common_arguments(self, supports_dimension_scale_factor=False) -> None:
         self.supports_image_generation = True
@@ -124,8 +126,12 @@ class CommandLineParser(argparse.ArgumentParser):
 
     def add_image_to_image_arguments(self, required=False) -> None:
         self.supports_image_to_image = True
-        self.add_argument("--image-path", type=Path, required=required, default=None, help="Local path to init image")
-        self.add_argument("--image-strength", type=float, required=False, default=ui_defaults.IMAGE_STRENGTH, help=f"Controls how strongly the init image influences the output image. A value of 0.0 means no influence. (Default is {ui_defaults.IMAGE_STRENGTH})")
+        # The requirement is enforced after normalization (see parse_args) so it can be
+        # satisfied by either the new --image flag or the legacy --image-path flag.
+        self.require_init_image = required
+        self.add_argument("--image", dest="image", nargs="+", default=None, metavar=("PATH", "STRENGTH"), help=f"Init image as an atomic PATH with optional STRENGTH (default {ui_defaults.IMAGE_STRENGTH}): --image photo.jpg 0.6. Preferred over --image-path/--image-strength.")
+        self.add_argument("--image-path", type=Path, required=False, default=None, help="[DEPRECATED: use --image] Local path to init image")
+        self.add_argument("--image-strength", type=float, required=False, default=ui_defaults.IMAGE_STRENGTH, help=f"[DEPRECATED: use --image] Controls how strongly the init image influences the output image. A value of 0.0 means no influence. (Default is {ui_defaults.IMAGE_STRENGTH})")
 
     def add_batch_image_generator_arguments(self) -> None:
         self.add_argument("--batch-prompts-file", type=Path, required=True, default=argparse.SUPPRESS, help="Local path for a file that holds a batch of prompts.")
@@ -237,8 +243,54 @@ class CommandLineParser(argparse.ArgumentParser):
                     return True
         return False
 
+    def _normalize_atomic_lora_args(self, namespace: argparse.Namespace) -> None:
+        if not self.supports_lora or not hasattr(namespace, "lora") or namespace.lora is None:
+            return
+        if self._option_was_provided("--lora-paths", "--lora-scales"):
+            self.error("Use either --lora or the legacy --lora-paths/--lora-scales, not both.\nTip: --lora pairs each path with its scale: --lora A.safetensors 0.7 --lora B.safetensors 0.4")  # fmt: off
+        paths: list[str] = []
+        scales: list[float] = []
+        for group in namespace.lora:
+            if len(group) == 1:
+                path, scale = group[0], 1.0
+            elif len(group) == 2:
+                path = group[0]
+                try:
+                    scale = float(group[1])
+                except ValueError:
+                    self.error(f"Invalid LoRA scale '{group[1]}' for '{group[0]}'.\nTip: --lora takes a PATH and an optional numeric SCALE: --lora {group[0]} 0.7")  # fmt: off
+            else:
+                self.error(f"--lora takes one PATH and an optional SCALE but got {len(group)} values: {' '.join(group)}\nTip: repeat --lora for each adapter: --lora {group[0]} {group[1]} --lora {group[2]} ...")  # fmt: off
+            paths.append(path)
+            scales.append(scale)
+        namespace.lora_paths = paths
+        namespace.lora_scales = scales
+
+    def _normalize_atomic_image_args(self, namespace: argparse.Namespace) -> None:
+        if not hasattr(namespace, "image") or namespace.image is None:
+            return
+        if self._option_was_provided("--image-path", "--image-strength"):
+            self.error("Use either --image or the legacy --image-path/--image-strength, not both.\nTip: --image pairs the path with its strength: --image photo.jpg 0.6")  # fmt: off
+        group = namespace.image
+        if len(group) == 1:
+            namespace.image_path = Path(group[0])
+        elif len(group) == 2:
+            namespace.image_path = Path(group[0])
+            try:
+                namespace.image_strength = float(group[1])
+            except ValueError:
+                self.error(f"Invalid image strength '{group[1]}' for '{group[0]}'.\nTip: --image takes a PATH and an optional numeric STRENGTH: --image {group[0]} 0.6")  # fmt: off
+        else:
+            self.error(f"--image takes one PATH and an optional STRENGTH but got {len(group)} values: {' '.join(group)}\nTip: --image photo.jpg 0.6")  # fmt: off
+
     def parse_args(self) -> argparse.Namespace:  # type: ignore
         namespace = super().parse_args()
+
+        # Fold the atomic --lora / --image flags into the legacy lora_paths/lora_scales
+        # and image_path/image_strength fields so all downstream logic (metadata merge,
+        # path resolution, model init) stays unchanged. Runs before the metadata block.
+        self._normalize_atomic_lora_args(namespace)
+        self._normalize_atomic_image_args(namespace)
 
         # Check if either training arguments are provided
         has_training_args = (hasattr(namespace, "config") and namespace.config is not None) or \
@@ -321,6 +373,9 @@ class CommandLineParser(argparse.ArgumentParser):
         # Only require model if we're not in training mode and require_model_arg is True
         if hasattr(namespace, "model") and namespace.model is None and not has_training_args and self.require_model_arg:
             self.error("--model / -m must be provided, or 'model' must be specified in the config file.")
+
+        if self.require_init_image and getattr(namespace, "image_path", None) is None:
+            self.error("An init image is required. Provide one with --image PATH [STRENGTH] (e.g. --image photo.jpg 0.8).")
 
         if self.supports_image_generation and namespace.seed is None and namespace.auto_seeds > 0:
             # choose N unique int seeds in the range of  0 < value < 1 billion

--- a/tests/arg_parser/test_cli_argparser.py
+++ b/tests/arg_parser/test_cli_argparser.py
@@ -516,6 +516,116 @@ def test_image_to_image_args(mflux_generate_parser, mflux_generate_minimal_argv,
 
 
 @pytest.mark.fast
+def test_atomic_lora_arg(mflux_generate_parser, mflux_generate_minimal_model_argv):
+    # Each --lora pairs a path with an optional scale; omitted scale defaults to 1.0.
+    argv = mflux_generate_minimal_model_argv + [
+        "--lora",
+        "/some/lora/A.safetensors",
+        "0.7",
+        "--lora",
+        "/some/lora/B.safetensors",
+    ]
+    with patch("mflux.cli.parser.parsers.LoraResolution.resolve", side_effect=lambda x: x):
+        with patch("sys.argv", argv):
+            args = mflux_generate_parser.parse_args()
+    assert args.lora_paths == ["/some/lora/A.safetensors", "/some/lora/B.safetensors"]
+    assert args.lora_scales == [pytest.approx(0.7), pytest.approx(1.0)]
+
+
+@pytest.mark.fast
+def test_atomic_lora_merges_with_metadata(mflux_generate_parser, mflux_generate_minimal_argv, base_metadata_dict, temp_dir):  # fmt: off
+    metadata_file = temp_dir / "atomic_lora.json"
+    with metadata_file.open("wt") as m:
+        base_metadata_dict["lora_paths"] = ["/meta/lora.safetensors"]
+        base_metadata_dict["lora_scales"] = [0.3]
+        json.dump(base_metadata_dict, m, indent=4)
+    argv = mflux_generate_minimal_argv + [
+        "--lora",
+        "/cli/lora.safetensors",
+        "0.9",
+        "--config-from-metadata",
+        metadata_file.as_posix(),
+    ]
+    with patch("mflux.cli.parser.parsers.LoraResolution.resolve", side_effect=lambda x: x):
+        with patch("sys.argv", argv):
+            args = mflux_generate_parser.parse_args()
+    # metadata loras are prepended to the CLI-provided ones, scales stay aligned
+    assert args.lora_paths == ["/meta/lora.safetensors", "/cli/lora.safetensors"]
+    assert args.lora_scales == [pytest.approx(0.3), pytest.approx(0.9)]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        ["--lora", "A.safetensors", "0.7", "--lora-paths", "B.safetensors"],  # mixing new + legacy
+        ["--lora", "A.safetensors", "not-a-number"],  # non-numeric scale
+        ["--lora", "A.safetensors", "B.safetensors", "0.7"],  # too many values in one group
+    ],
+)
+def test_atomic_lora_arg_errors(mflux_generate_parser, mflux_generate_minimal_model_argv, bad_args):
+    with patch("sys.argv", mflux_generate_minimal_model_argv + bad_args):
+        with pytest.raises(SystemExit):
+            mflux_generate_parser.parse_args()
+
+
+@pytest.mark.fast
+def test_atomic_image_arg(mflux_generate_parser, mflux_generate_minimal_model_argv):
+    # --image with explicit strength
+    with patch("sys.argv", mflux_generate_minimal_model_argv + ["--image", "/some/photo.jpg", "0.6"]):
+        args = mflux_generate_parser.parse_args()
+    assert args.image_path == Path("/some/photo.jpg")
+    assert args.image_strength == pytest.approx(0.6)
+
+    # --image with omitted strength falls back to the default
+    with patch("sys.argv", mflux_generate_minimal_model_argv + ["--image", "/some/photo.jpg"]):
+        args = mflux_generate_parser.parse_args()
+    assert args.image_path == Path("/some/photo.jpg")
+    assert args.image_strength == ui_defaults.IMAGE_STRENGTH
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        ["--image", "p.jpg", "--image-strength", "0.6"],  # mixing new + legacy
+        ["--image", "p.jpg", "not-a-number"],  # non-numeric strength
+        ["--image", "p.jpg", "0.6", "extra"],  # too many values
+    ],
+)
+def test_atomic_image_arg_errors(mflux_generate_parser, mflux_generate_minimal_model_argv, bad_args):
+    with patch("sys.argv", mflux_generate_minimal_model_argv + bad_args):
+        with pytest.raises(SystemExit):
+            mflux_generate_parser.parse_args()
+
+
+@pytest.mark.fast
+def test_required_init_image_satisfied_by_either_flag():
+    # Kontext-style commands require an init image; either --image or the legacy
+    # --image-path must satisfy it, and neither present is an error.
+    def _required_image_parser() -> CommandLineParser:
+        parser = CommandLineParser(description="x")
+        parser.add_general_arguments()
+        parser.add_model_arguments(require_model_arg=False)
+        parser.add_image_generator_arguments(supports_metadata_config=True)
+        parser.add_image_to_image_arguments(required=True)
+        parser.add_output_arguments()
+        return parser
+
+    base = ["mflux-generate-kontext", "--prompt", "x", "-m", "dev"]
+
+    with patch("sys.argv", base + ["--image", "p.jpg"]):
+        assert _required_image_parser().parse_args().image_path == Path("p.jpg")
+
+    with patch("sys.argv", base + ["--image-path", "p.jpg"]):
+        assert _required_image_parser().parse_args().image_path == Path("p.jpg")
+
+    with patch("sys.argv", base):
+        with pytest.raises(SystemExit):
+            _required_image_parser().parse_args()
+
+
+@pytest.mark.fast
 def test_image_outpaint_args(mflux_generate_parser, mflux_generate_minimal_argv, base_metadata_dict, temp_dir):  # fmt: off
     metadata_file = temp_dir / "image_outpaint.json"
     test_padding = "10,20,30,40"

--- a/tests/cli/test_completion_generator.py
+++ b/tests/cli/test_completion_generator.py
@@ -16,3 +16,18 @@ def test_completion_generator_includes_fibo_edit_command():
     assert "--image-path" in script
     assert "--mask-path" in script
     assert "--prompt" in script
+
+
+@pytest.mark.fast
+def test_completion_generator_includes_atomic_lora_and_image_flags():
+    generator = CompletionGenerator()
+    parser = generator.create_parser_for_command("mflux-generate")
+    script = generator.generate_command_function("mflux-generate", parser)
+
+    # The atomic --lora / --image flags must be discoverable via shell completion
+    # alongside the retained legacy flags. Match the exact option-spec token
+    # ("'--lora''[") so this can't be satisfied by --lora-paths / --image-path etc.
+    assert "'--lora''[" in script
+    assert "'--image''[" in script
+    assert "'--lora-paths''[" in script
+    assert "'--image-path''[" in script


### PR DESCRIPTION
AI disclosure: assisted by Opus 4.8

-----

Implements the two highest-signal, lowest-risk proposals from #357: atomic flags that pair each path with its value on a single, repeatable flag, instead of two positionally-aligned lists.

```sh
mflux-generate --prompt "cyberpunk mermaid" \
  --lora A.safetensors 0.7 \
  --lora B.safetensors \          # scale omitted -> 1.0
  --image photo.jpg 0.6           # strength omitted -> model default
```

This removes the alignment footgun of `--lora-paths`/`--lora-scales` and `--image-path`/`--image-strength` when working with many adapters — commenting out one LoRA is now one line, with no recount of a parallel scale list.

### Design — zero downstream churn

The new flags fold into the existing `lora_paths`/`lora_scales` and `image_path`/`image_strength` namespace fields in `parse_args`, **before** the metadata-merge and path-resolution logic. So every downstream consumer (metadata reuse via `--config-from-metadata`, library/HF path resolution, model init) is untouched. Downstream code reads the explicit fields, not `vars(namespace)`, so the raw `--lora`/`--image` attrs don't leak into saved metadata.

### Backward compatibility — fully opt-in

- Legacy `--lora-paths`, `--lora-scales`, `--image-path`, `--image-strength` remain registered with identical types/defaults and behavior. Existing scripts and saved metadata work unchanged.
- **No runtime deprecation warnings** — mflux is pre-1.0, which the #357 migration plan designates as silent coexistence (warnings land at v1.0). The only signal is a passive `[DEPRECATED: use --lora]` tag in `--help`.
- No existing invocation can hit a new error path: the new+legacy conflict guard only fires when both are combined, and no current user types the new flags.

### Validation (teaching errors)

Mixing a new flag with its legacy counterpart, a non-numeric scale/strength, or too many values in one group each produce a teaching error rather than silently misparsing — this closes the argparse `nargs="+"` greedy-consumption edge (e.g. `--lora A B 0.7`).

### Note for reviewers — one deliberate behavior change

For kontext (`required=True`), the init-image requirement moved from argparse-time to post-normalization so **either** `--image` or `--image-path` satisfies it. A side effect: since kontext uses `supports_metadata_config=True`, an `image_path` supplied via `--config-from-metadata` now satisfies the requirement where it previously errored without a CLI image. This is strictly more permissive and arguably a fix, but flagging it as a decision rather than an accident. The error message also changed to a teaching message.

### Tests

- 14 new arg-parser tests: scale/strength defaulting, metadata merge, new+legacy conflict, non-numeric value, too-many-values, and the kontext required-image case satisfied by either flag.
- Completion-generator assertion locking the #357 "CLI completion must stay compatible" requirement (matches the exact option-spec token so it can't pass off the legacy `--lora-paths`/`--image-path` substrings).
- Legacy behavior stays regression-locked by the unchanged `test_lora_args` / `test_image_to_image_args`.
- Full fast suite: 489 passed, 3 skipped. New normalization code is 100% line-covered.

Refs #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)