### PR TITLE
Fix Ideogram 4 LoRA generation: corrupted output at any guidance > 1

### DIFF
--- a/src/mflux/models/ideogram4/ideogram4_initializer.py
+++ b/src/mflux/models/ideogram4/ideogram4_initializer.py
@@ -101,6 +101,11 @@ class Ideogram4Initializer:
 
     @staticmethod
     def _apply_lora(model, lora_paths: list[str] | None, lora_scales: list[float] | None) -> None:
+        # Apply ONLY to the conditional transformer. The unconditional transformer is a
+        # DIFFERENT (distilled) model: a LoRA trained against the conditional's weights pushes
+        # it off-distribution, and CFG then amplifies that corrupted negative by the guidance
+        # factor (output degrades into a patch mosaic at any guidance > 1). With a LoRA active,
+        # generation routes the CFG negative through the (LoRA'd) conditional transformer.
         lora_mapping = Ideogram4LoRAMapping.get_mapping()
         model.lora_paths, model.lora_scales = LoRALoader.load_and_apply_lora(
             lora_mapping=lora_mapping,
@@ -108,16 +113,6 @@ class Ideogram4Initializer:
             lora_paths=lora_paths,
             lora_scales=lora_scales,
         )
-        if not model.lora_paths:
-            return
-        for lora_file, scale in zip(model.lora_paths, model.lora_scales):
-            LoRALoader._apply_single_lora(
-                model.unconditional_transformer,
-                lora_file,
-                scale,
-                lora_mapping,
-                role=None,
-            )
 
     @staticmethod
     def _text_encoder_kwargs(directory: Path) -> dict[str, Any]:

--- a/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
+++ b/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
@@ -115,7 +115,15 @@ class Ideogram4(nn.Module):
         ctx = self.callbacks.start(seed=seed, prompt=prompt, config=config)
         ctx.before_loop(z)
         predict_conditional = self._predict_conditional(self.conditional_transformer)
-        predict_unconditional = self._predict_unconditional(self.unconditional_transformer)
+        # CFG negative: with a LoRA active, run the negative inputs through the (LoRA'd)
+        # CONDITIONAL transformer. The separate distilled unconditional transformer has
+        # different weights, so a LoRA trained against the conditional corrupts it; the
+        # corrupted negative is then amplified by the guidance factor in
+        # v = g*pos + (1-g)*neg, saturating the output into a patch mosaic. (Verified: a
+        # known-good LoRA renders garbage at guidance > 1 through the unconditional path but
+        # clean at guidance = 1; clean at full guidance with this routing.)
+        uncond_transformer = self.conditional_transformer if self.lora_paths else self.unconditional_transformer
+        predict_unconditional = self._predict_unconditional(uncond_transformer)
         time_steps = config.time_steps
         for step_index in time_steps:
             try:


### PR DESCRIPTION
## Problem
Every LoRA applied to Ideogram 4 renders as a saturated patch-mosaic at any guidance > 1, regardless of how the LoRA was trained. A reference character LoRA that produces the trained subject through its own trainer's sampler renders unrecognizable garbage through mflux.

## Root cause
Ideogram 4 ships a separate **distilled unconditional transformer** for CFG. `_apply_lora` applied the LoRA to **both** transformers — but a LoRA is trained against the *conditional* transformer's weights. Applied to the unconditional model (different weights), it pushes that model off-distribution, and CFG then amplifies the corrupted negative by the guidance factor:

`v = g*pos + (1-g)*neg`

so the corruption scales with `g` (4–7x with the shipped presets).

## Fix
- Apply the LoRA to the conditional transformer only.
- When a LoRA is active, route the CFG negative through the (LoRA'd) conditional transformer with the existing negative inputs. The LoRA's unconditional shift then largely cancels in `(pos - neg)` instead of being amplified.
- Without a LoRA, behavior is unchanged (the distilled unconditional transformer is used exactly as before).

## Validation
- Known-good character LoRA, guidance 4.0, previously mosaic → now clean and matches the reference sampler's output (same subject, same quality).
- Control: the same LoRA at guidance 1.0 (CFG disabled) was already clean before the fix, isolating CFG as the corruption path.
- Full fast test suite passes (516 passed).