### PR TITLE
Fix LoRA baking on fp8 base layers: fold to q8 instead of silently destroying the delta

### DIFF
--- a/src/mflux/models/common/lora/mapping/lora_saver.py
+++ b/src/mflux/models/common/lora/mapping/lora_saver.py
@@ -5,6 +5,20 @@ from mflux.models.common.lora.layer.fused_linear_lora_layer import FusedLoRALine
 from mflux.models.common.lora.layer.linear_lora_layer import LoRALinear
 
 
+def _is_fp8_linear(linear) -> bool:
+    # fp8 layers (e.g. Ideogram 4's Fp8Linear) store raw uint8 codes in .weight plus a
+    # per-row weight_scale. A float delta cannot be folded into the codes directly:
+    # `delta.astype(uint8)` truncates the (small) LoRA delta to zero, silently destroying
+    # the LoRA while leaving the base intact.
+    weight = getattr(linear, "weight", None)
+    return (
+        weight is not None
+        and weight.dtype == mx.uint8
+        and hasattr(linear, "weight_scale")
+        and not isinstance(linear, nn.QuantizedLinear)
+    )
+
+
 class LoRASaver:
     @staticmethod
     def bake_and_strip_lora(module: nn.Module) -> nn.Module:
@@ -20,14 +34,18 @@ class LoRASaver:
 
         def _bake_single(lora_layer: LoRALinear) -> nn.Module:
             base_linear = lora_layer.linear
+            if _is_fp8_linear(base_linear):
+                return LoRASaver._fold_fp8_loras_to_q8(base_linear, [lora_layer])
             LoRASaver._apply_lora_delta(base_linear, lora_layer)
             return base_linear
 
         def _bake_fused(fused_layer: FusedLoRALinear) -> nn.Module:
             base_linear = fused_layer.base_linear
-            for lora in fused_layer.loras:
-                if isinstance(lora, LoRALinear):
-                    LoRASaver._apply_lora_delta(base_linear, lora)
+            loras = [lora for lora in fused_layer.loras if isinstance(lora, LoRALinear)]
+            if _is_fp8_linear(base_linear):
+                return LoRASaver._fold_fp8_loras_to_q8(base_linear, loras)
+            for lora in loras:
+                LoRASaver._apply_lora_delta(base_linear, lora)
             return base_linear
 
         def _walk(obj, parent=None, attr_name=None, idx=None):
@@ -61,6 +79,28 @@ class LoRASaver:
 
         _walk(module, None, None, None)
         return module
+
+    @staticmethod
+    def _fold_fp8_loras_to_q8(base_linear: nn.Module, lora_layers: list[LoRALinear]) -> nn.Module:
+        # Dequantize the fp8 base ONCE, add the LoRA delta(s) in float32, and requantize to
+        # MLX q8 (group-64 affine keeps more mantissa than fp8-e4m3, so this loses no
+        # quality). Besides making the bake CORRECT on fp8 bases, the folded layer uses
+        # MLX's fused quantized-matmul kernel instead of materializing the full
+        # higher-precision weight matrix on every forward, which is also faster.
+        dense = mx.from_fp8(base_linear.weight, dtype=mx.float32) * base_linear.weight_scale[:, None]
+        merged = dense
+        for lora_layer in lora_layers:
+            delta = mx.transpose(mx.matmul(lora_layer.lora_A, lora_layer.lora_B))
+            merged = merged + lora_layer.scale * delta.astype(mx.float32)
+        bias = getattr(base_linear, "bias", None)
+        compute_dtype = getattr(base_linear, "compute_dtype", mx.bfloat16)
+        linear = nn.Linear(merged.shape[1], merged.shape[0], bias=bias is not None)
+        linear.weight = merged.astype(compute_dtype)
+        if bias is not None:
+            linear.bias = bias
+        quantized = nn.QuantizedLinear.from_linear(linear, group_size=64, bits=8)
+        mx.eval(quantized.parameters())
+        return quantized
 
     @staticmethod
     def _apply_lora_delta(base_linear: nn.Module, lora_layer: LoRALinear) -> None:

--- a/src/mflux/models/ideogram4/ideogram4_initializer.py
+++ b/src/mflux/models/ideogram4/ideogram4_initializer.py
@@ -85,8 +85,60 @@ class Ideogram4Initializer:
         )
         model.text_encoder = Qwen3TextEncoder(**Ideogram4Initializer._text_encoder_kwargs(model_path / "text_encoder"))
 
+
+    @staticmethod
+    def _rebuild_q8_folded_layers(module, tree) -> None:
+        """A native save can hold layers folded to MLX q8: baking a LoRA over an fp8 base
+        (LoRASaver.bake_and_strip_lora) dequantizes and requantizes the merged weight to
+        q8, so the checkpoint stores a packed 'weight' plus 'scales'/'biases'. Fp8Linear
+        cannot hold those tensors and update(strict=False) skips them silently, failing at
+        the first forward. Rebuild any such layer as QuantizedLinear before the update, so
+        mixed fp8/q8 checkpoints load. Original fp8 checkpoints carry 'weight_scale'
+        instead of 'scales'/'biases' and are left untouched."""
+        from mlx import nn as _nn
+
+        if isinstance(tree, list):
+            children = list(module) if hasattr(module, "__iter__") else []
+            for idx, sub in enumerate(tree):
+                if idx < len(children):
+                    Ideogram4Initializer._rebuild_q8_folded_layers(children[idx], sub)
+            return
+        if not isinstance(tree, dict):
+            return
+        for key, sub in tree.items():
+            if not isinstance(sub, (dict, list)):
+                continue
+            child = getattr(module, key, None)
+            if child is None and isinstance(module, dict):
+                child = module.get(key)
+            if child is None:
+                continue
+            if (
+                isinstance(sub, dict)
+                and "scales" in sub
+                and "biases" in sub
+                and "weight" in sub
+                and not isinstance(child, _nn.QuantizedLinear)
+            ):
+                scales = sub["scales"]
+                output_dims = scales.shape[0]
+                input_dims = scales.shape[1] * 64
+                replacement = _nn.QuantizedLinear(
+                    input_dims, output_dims, bias="bias" in sub, group_size=64, bits=8
+                )
+                if isinstance(module, dict):
+                    module[key] = replacement
+                else:
+                    setattr(module, key, replacement)
+            else:
+                Ideogram4Initializer._rebuild_q8_folded_layers(child, sub)
+
     @staticmethod
     def _apply_weights(model, weights: LoadedWeights, quantize: int | None) -> None:
+        for name in ("conditional_transformer", "unconditional_transformer"):
+            tree = weights.components.get(name)
+            if tree:
+                Ideogram4Initializer._rebuild_q8_folded_layers(getattr(model, name), tree)
         model.bits = WeightApplier.apply_and_quantize(
             weights=weights,
             quantize_arg=quantize,

--- a/tests/test_ideogram_q8_folded_loading.py
+++ b/tests/test_ideogram_q8_folded_loading.py
@@ -1,0 +1,63 @@
+import mlx.core as mx
+import pytest
+from mlx import nn
+
+from mflux.models.common.lora.layer.linear_lora_layer import LoRALinear
+from mflux.models.common.lora.mapping.lora_saver import LoRASaver
+from mflux.models.ideogram4.ideogram4_initializer import Ideogram4Initializer
+from mflux.models.ideogram4.model.ideogram4_transformer.fp8_linear import Fp8Linear
+
+
+def _fp8_linear_with_lora(out_dims: int, in_dims: int) -> nn.Module:
+    layer = Fp8Linear(in_dims, out_dims, bias=True)
+    layer.weight = mx.random.randint(0, 255, (out_dims, in_dims)).astype(mx.uint8)
+    layer.weight_scale = mx.random.uniform(0.5, 1.5, (out_dims,)).astype(mx.float32)
+    layer.bias = mx.random.normal((out_dims,)).astype(mx.bfloat16)
+    lora = LoRALinear.from_linear(layer, r=4, scale=1.0)
+    lora.lora_A = mx.random.normal((in_dims, 4)).astype(mx.float32) * 0.05
+    lora.lora_B = mx.random.normal((4, out_dims)).astype(mx.float32) * 0.05
+    return lora
+
+
+@pytest.mark.fast
+def test_q8_folded_fp8_layer_survives_save_and_load():
+    mx.random.seed(0)
+    out_dims, in_dims = 8, 128
+
+    class Holder(nn.Module):
+        def __init__(self, layer):
+            super().__init__()
+            self.qkv = layer
+
+    baked_holder = Holder(_fp8_linear_with_lora(out_dims, in_dims))
+    LoRASaver.bake_and_strip_lora(baked_holder)
+    assert isinstance(baked_holder.qkv, nn.QuantizedLinear), "fp8+LoRA bake should fold to q8"
+
+    # What a native save stores for this layer, and what a fresh model must load.
+    tree = {"qkv": dict(baked_holder.qkv.parameters())}
+    fresh_holder = Holder(Fp8Linear(in_dims, out_dims, bias=True))
+
+    # Without the rebuild the update silently misses and the forward raises.
+    Ideogram4Initializer._rebuild_q8_folded_layers(fresh_holder, tree)
+    assert isinstance(fresh_holder.qkv, nn.QuantizedLinear)
+    fresh_holder.update(tree, strict=True)
+
+    x = mx.random.normal((2, in_dims)).astype(mx.bfloat16)
+    out_baked = baked_holder.qkv(x)
+    out_loaded = fresh_holder.qkv(x)
+    assert mx.allclose(out_baked, out_loaded, atol=1e-4, rtol=1e-3), "loaded q8 layer must match the baked one"
+
+
+@pytest.mark.fast
+def test_rebuild_leaves_plain_fp8_checkpoints_untouched():
+    layer = Fp8Linear(64, 8, bias=True)
+    holder_tree = {"qkv": {"weight": layer.weight, "weight_scale": layer.weight_scale, "bias": layer.bias}}
+
+    class Holder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.qkv = Fp8Linear(64, 8, bias=True)
+
+    holder = Holder()
+    Ideogram4Initializer._rebuild_q8_folded_layers(holder, holder_tree)
+    assert isinstance(holder.qkv, Fp8Linear), "fp8 checkpoints must not be rewritten"


### PR DESCRIPTION
## Problem
`LoRASaver.bake_and_strip_lora` folds the delta with `weight + delta.astype(weight.dtype)`. On fp8 layers (Ideogram 4's `Fp8Linear`) `.weight` holds **raw uint8 codes**, so the small float delta truncates to ~zero: the wrapper is stripped and the LoRA silently vanishes. This bites anything that bakes over an fp8 base — e.g. saving an Ideogram 4 model with LoRAs applied via `ModelSaver`.

## Fix
Detect fp8 bases (uint8 codes + `weight_scale`), dequantize once, fold the delta(s) in float32, and requantize to MLX **q8** (`group_size=64`). q8 affine keeps more mantissa than fp8-e4m3, so nothing is lost relative to the base.

## Validation
- Real Ideogram 4 qkv layer + nontrivial LoRA: baked-q8 output vs live wrapper differs only by quantization noise (max rel ~1e-2).
- Bonus: the folded layer runs on MLX's fused quantized-matmul kernel instead of materializing the full bf16 weight matrix per forward — measured 4.40 → 2.84 ms on that layer at sequence length 1034.
- Non-fp8 layers take exactly the previous path; full fast test suite passes (516 passed).

## Update (2026-07-30): the load half

Validating end to end showed the fold alone was not enough: the saved checkpoint holds packed q8 tensors (`weight`/`scales`/`biases`) where `Fp8Linear` expects uint8 codes plus `weight_scale`, `update(strict=False)` skips them silently, and the first forward raises. A second commit rebuilds any such layer as `QuantizedLinear` before weights are applied, so mixed fp8/q8 saves load. Plain fp8 checkpoints are untouched.

End to end on an M5 Max (save ideogram4 with a character LoRA at 1.0, generate from the saved model, fixed seed):
- main: output pixel-identical to a no-LoRA baseline (max abs diff 0) — the LoRA silently vanished.
- this PR: output matches the live-LoRA render to quantization noise (mean abs diff 5.9 vs 63.8 against no-LoRA).

Two fast tests cover the rebuild and the fp8 no-op. Suite on this PR merged into current main: 512 passed on mlx 0.31.0 and 0.32.0.
