### PR TITLE
Ideogram 4: optional CFG truncation (cfg_end) and skip the unconditional pass at guidance 1.0

### DIFF
--- a/src/mflux/models/ideogram4/cli/ideogram4_generate.py
+++ b/src/mflux/models/ideogram4/cli/ideogram4_generate.py
@@ -31,6 +31,13 @@ def main():
         action="store_true",
         help="Fail when an Ideogram 4 JSON caption has schema warnings.",
     )
+    parser.add_argument(
+        "--cfg-end",
+        type=float,
+        default=None,
+        help="Fraction of steps (0-1) that run CFG; the remaining steps run cond-only "
+        "(guidance 1.0, skipping the unconditional forward). Lower = faster. Default: full CFG.",
+    )
     args = parser.parse_args()
 
     model_name = args.model or "ideogram4"
@@ -74,6 +81,7 @@ def main():
                 height=height,
                 preset=args.preset,
                 strict_caption_validation=args.strict_caption_validation,
+                cfg_end=args.cfg_end,
             )
             image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
     except (StopImageGenerationException, PromptFileReadError) as exc:

--- a/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
+++ b/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
@@ -53,6 +53,7 @@ class Ideogram4(nn.Module):
         preset: str | None = None,
         strict_caption_validation: bool = False,
         warn_on_caption_issues: bool = True,
+        cfg_end: float | None = None,
     ) -> GeneratedImage:
         prompt = Ideogram4PromptEncoder.resolve_prompt(
             prompt,
@@ -112,6 +113,11 @@ class Ideogram4(nn.Module):
             std=sampler.std,
         )
 
+        # CFG truncation: guidance shapes the result in the early steps (composition); the
+        # late steps mostly refine. cfg_end = fraction of steps that run CFG; the remaining
+        # steps run cond-only (guidance 1.0, which skips the unconditional forward entirely).
+        cfg_cutoff = num_steps if cfg_end is None else max(1, int(round(float(cfg_end) * num_steps)))
+
         ctx = self.callbacks.start(seed=seed, prompt=prompt, config=config)
         ctx.before_loop(z)
         predict_conditional = self._predict_conditional(self.conditional_transformer)
@@ -124,7 +130,7 @@ class Ideogram4(nn.Module):
                     z=z,
                     t_value=float(t_values[schedule_index]),
                     s_value=float(s_values[schedule_index]),
-                    guidance_value=float(guidance_values[schedule_index]),
+                    guidance_value=float(guidance_values[schedule_index]) if step_index < cfg_cutoff else 1.0,
                     text_z_padding=text_z_padding,
                     llm_features=llm_features,
                     inputs=inputs,
@@ -232,6 +238,10 @@ class Ideogram4(nn.Module):
             llm_features=llm_features,
             inputs=inputs,
         )
+        # guidance == 1.0 makes the negative term vanish (v = pos_v exactly) — skip the
+        # whole unconditional forward, halving the cost of CFG-free steps.
+        if abs(guidance_value - 1.0) < 1e-6:
+            return z + pos_v * (s_value - t_value)
         neg_v = predict_unconditional(z=z, t=t, negative_inputs=negative_inputs)
         v = guidance_value * pos_v + (1.0 - guidance_value) * neg_v
         return z + v * (s_value - t_value)


### PR DESCRIPTION
## What
Two complementary speedups for Ideogram 4's double-transformer CFG:

1. **guidance == 1.0 skips the unconditional forward entirely.** The negative term vanishes exactly (`v = 1.0*pos + 0.0*neg = pos`), so this is a pure 2x win for CFG-free steps with bit-identical output.
2. **`generate_image(cfg_end=<fraction>)`** runs CFG only for that leading fraction of steps, cond-only for the rest. Guidance shapes composition early; the late steps mostly refine.

## Benchmark (M5 Max, 768x768)
| Config | Time |
|---|---|
| 25 steps, full CFG | 89.7s |
| 25 steps, `cfg_end=0.6` | 74.5s (output visually indistinguishable) |
| `V4_TURBO_12` | 29.8s |
| `V4_TURBO_12` + `cfg_end=0.6` | 24.7s |

Default behavior (`cfg_end=None`) is unchanged. Full fast test suite passes (516 passed).