### PR TITLE
Fix training optimizer hyperparameters being silently ignored

### DIFF
--- a/src/mflux/models/common/training/optimization/optimizer.py
+++ b/src/mflux/models/common/training/optimization/optimizer.py
@@ -57,8 +57,12 @@ class Optimizer:
     @staticmethod
     def from_spec(training_spec: TrainingSpec) -> "Optimizer":
         opt_cls = Optimizers.from_alias(training_spec.optimizer.name)
+        # Forward any caller-provided optimizer kwargs (weight_decay, betas, eps, ...).
+        # Previously only learning_rate was passed, so values set in the training config's
+        # "optimizer" section were silently ignored in favor of the MLX defaults.
+        extra_params = getattr(training_spec.optimizer, "optimizer_params", None) or {}
         # noinspection PyCallingNonCallable
-        opt = opt_cls(learning_rate=Optimizer._build_lr(training_spec.optimizer))
+        opt = opt_cls(learning_rate=Optimizer._build_lr(training_spec.optimizer), **extra_params)
 
         if training_spec.optimizer.state_path is not None:
             state = ZipUtil.unzip(

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -95,6 +95,10 @@ class OptimizerSpec:
     lr_schedule: str | None = None
     lr_warmup_steps: int = 0
     lr_total_steps: int | None = None
+    # Extra keyword arguments forwarded to the MLX optimizer constructor
+    # (e.g. weight_decay, betas, eps). Without this, any optimizer hyperparameter
+    # other than the learning rate silently falls back to the MLX default.
+    optimizer_params: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/training/test_optimizer_params.py
+++ b/tests/training/test_optimizer_params.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mflux.models.common.training.optimization.optimizer import Optimizer
+from mflux.models.common.training.state.training_spec import OptimizerSpec
+
+
+def _spec(**optimizer_kwargs) -> SimpleNamespace:
+    return SimpleNamespace(
+        optimizer=OptimizerSpec(name="AdamW", learning_rate=1e-4, **optimizer_kwargs),
+        checkpoint_path=None,
+    )
+
+
+@pytest.mark.fast
+def test_optimizer_params_are_forwarded():
+    optimizer = Optimizer.from_spec(_spec(optimizer_params={"weight_decay": 0.123, "eps": 1e-6})).optimizer
+    assert optimizer.weight_decay == 0.123
+    assert optimizer.eps == 1e-6
+
+
+@pytest.mark.fast
+def test_optimizer_defaults_unchanged_without_params():
+    optimizer = Optimizer.from_spec(_spec()).optimizer
+    default_adamw_weight_decay = 0.01
+    assert optimizer.weight_decay == default_adamw_weight_decay


### PR DESCRIPTION
## Problem
`Optimizer.from_spec` only forwards `learning_rate` to the MLX optimizer constructor. Any other hyperparameter set in the training config's `optimizer` section (`weight_decay`, `betas`, `eps`, ...) is silently dropped in favor of the MLX defaults — the config accepts them but they have no effect.

## Fix
`OptimizerSpec` gains an `optimizer_params` dict forwarded as keyword arguments to the optimizer constructor. Existing configs behave exactly as before.

## Validation
New unit tests: forwarded params are applied (`weight_decay`, `eps`), and the no-params path keeps the AdamW defaults. Full fast suite: 518 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional optimizer parameters during training.
  * Preserved existing learning-rate schedule behavior and defaults when no extra parameters are provided.

* **Bug Fixes**
  * Ensured configured optimizer settings are correctly applied during training.

* **Tests**
  * Added coverage for custom optimizer parameters and unchanged default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes configured optimizer-specific hyperparameters effective while preserving existing optimizer defaults.
- Adds an `optimizer_params` dictionary to `OptimizerSpec`.
- Forwards those parameters to the selected MLX optimizer constructor.
- Tests parameter forwarding and the backward-compatible default path.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or compatibility defects identified.

The optional field defaults safely for existing configurations, passes nested values through the established optimizer construction path, and remains preserved by the existing checkpoint configuration flow.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/common/training/optimization/optimizer.py | Forwards optional optimizer parameters alongside the existing computed learning rate without changing checkpoint-state restoration. |
| src/mflux/models/common/training/state/training_spec.py | Adds a default-empty optimizer parameter mapping that remains compatible with existing configurations and checkpoint manifests. |
| tests/training/test_optimizer_params.py | Verifies configured AdamW parameters are applied and omission retains the MLX default. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix training optimizer hyperparameters b..."](https://github.com/mflux-community/mflux/commit/9adfeeec9611b83635b2a9a43e829649b8255e59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896718)</sub>

<!-- /greptile_comment -->