### PR TITLE
fix: stepwise support for Ideogram 4 generation

### DIFF
--- a/src/mflux/callbacks/instances/stepwise_handler.py
+++ b/src/mflux/callbacks/instances/stepwise_handler.py
@@ -81,7 +81,12 @@ class StepwiseHandler(BeforeLoopCallback, InLoopCallback, InterruptCallback):
         time_steps: tqdm,
     ) -> None:
         unpack_latents = self.latent_creator.unpack_latents(latents=latents, height=config.height, width=config.width)
-        if hasattr(self.model.vae, "decode_packed_latents"):
+        # Flux2's unpack_latents returns 128-channel patchified latents that still need
+        # decode_packed_latents (BN denorm + unpatchify → 32ch).  Ideogram4's unpack_latents
+        # applies its own shift/scale and already returns 32-channel VAE-ready latents, so
+        # calling decode_packed_latents on them causes a channel shape mismatch.
+        vae_latent_channels = getattr(self.model.vae, "latent_channels", 32)
+        if hasattr(self.model.vae, "decode_packed_latents") and unpack_latents.shape[1] > vae_latent_channels:
             stepwise_decoded = self.model.vae.decode_packed_latents(unpack_latents)
         else:
             stepwise_decoded = self.model.vae.decode(unpack_latents)

--- a/tests/callbacks/test_stepwise_handler_vae_routing.py
+++ b/tests/callbacks/test_stepwise_handler_vae_routing.py
@@ -1,0 +1,104 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from mflux.callbacks.instances.stepwise_handler import StepwiseHandler
+from mflux.models.common.config.config import Config
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
+from mflux.models.flux2.latent_creator.flux2_latent_creator import Flux2LatentCreator
+from mflux.models.ideogram4.latent_creator.ideogram4_latent_creator import Ideogram4LatentCreator
+
+SIZE = 256
+
+
+def _decoded(height: int, width: int) -> mx.array:
+    return mx.zeros((1, 3, height, width))
+
+
+class RecordingPackedVAE:
+    """Flux2-style VAE: decode_packed_latents does BN denorm + unpatchify, so it only
+    accepts the 4x-patchified channel count and rejects VAE-ready latents."""
+
+    latent_channels = 32
+
+    def __init__(self):
+        self.calls = []
+
+    def decode(self, latents: mx.array) -> mx.array:
+        self.calls.append("decode")
+        if latents.shape[1] != self.latent_channels:
+            raise ValueError(f"decode expects {self.latent_channels} channels, got {latents.shape[1]}")
+        return _decoded(SIZE, SIZE)
+
+    def decode_packed_latents(self, latents: mx.array) -> mx.array:
+        self.calls.append("decode_packed_latents")
+        if latents.shape[1] != 4 * self.latent_channels:
+            raise ValueError(
+                f"decode_packed_latents expects {4 * self.latent_channels} channels, got {latents.shape[1]}"
+            )
+        return _decoded(SIZE, SIZE)
+
+
+class RecordingPlainVAE:
+    """Flux-style VAE with no decode_packed_latents at all."""
+
+    latent_channels = 16
+
+    def __init__(self):
+        self.calls = []
+
+    def decode(self, latents: mx.array) -> mx.array:
+        self.calls.append("decode")
+        return _decoded(SIZE, SIZE)
+
+
+def _handler(tmp_path, vae, latent_creator) -> StepwiseHandler:
+    model = SimpleNamespace(vae=vae, bits=None, lora_paths=None, lora_scales=None)
+    return StepwiseHandler(model=model, output_dir=str(tmp_path), latent_creator=latent_creator)
+
+
+def _config(model_config: ModelConfig) -> Config:
+    return Config(model_config=model_config, num_inference_steps=1, height=SIZE, width=SIZE)
+
+
+@pytest.mark.fast
+def test_stepwise_ideogram4_uses_plain_decode(tmp_path) -> None:
+    # Ideogram4's unpack_latents applies shift/scale and returns VAE-ready 32ch latents.
+    vae = RecordingPackedVAE()
+    handler = _handler(tmp_path, vae, Ideogram4LatentCreator)
+    latents = mx.zeros((1, (SIZE // 16) * (SIZE // 16), 128))
+
+    assert Ideogram4LatentCreator.unpack_latents(latents, SIZE, SIZE).shape[1] == vae.latent_channels
+
+    handler.call_before_loop(seed=1, prompt="a", latents=latents, config=_config(ModelConfig.ideogram4_fp8()))
+
+    assert vae.calls == ["decode"]
+    assert (tmp_path / "seed_1_step0of1.png").exists()
+
+
+@pytest.mark.fast
+def test_stepwise_flux2_uses_packed_decode(tmp_path) -> None:
+    # Flux2's unpack_latents returns 128ch patchified latents that still need BN denorm.
+    vae = RecordingPackedVAE()
+    handler = _handler(tmp_path, vae, Flux2LatentCreator)
+    latents = mx.zeros((1, (SIZE // 16) * (SIZE // 16), 128))
+
+    assert Flux2LatentCreator.unpack_latents(latents, SIZE, SIZE).shape[1] == 4 * vae.latent_channels
+
+    handler.call_before_loop(seed=1, prompt="a", latents=latents, config=_config(ModelConfig.flux2_klein_4b()))
+
+    assert vae.calls == ["decode_packed_latents"]
+    assert (tmp_path / "seed_1_step0of1.png").exists()
+
+
+@pytest.mark.fast
+def test_stepwise_vae_without_packed_decode_falls_back(tmp_path) -> None:
+    vae = RecordingPlainVAE()
+    handler = _handler(tmp_path, vae, FluxLatentCreator)
+    latents = mx.zeros((1, (SIZE // 16) * (SIZE // 16), 64))
+
+    handler.call_before_loop(seed=1, prompt="a", latents=latents, config=_config(ModelConfig.dev()))
+
+    assert vae.calls == ["decode"]


### PR DESCRIPTION
## Problem

Stepwise image saving (`--stepwise-image-output-dir`) crashes when used with Ideogram 4 models:

```
ValueError: [broadcast_shapes] Shapes (1,32,64,64) and (1,128,1,1) cannot be broadcast.
```

`StepwiseHandler._save_stepwise_image` calls `unpack_latents` and then checks `hasattr(self.model.vae, "decode_packed_latents")` to decide whether to call that method or fall back to `vae.decode`. Ideogram 4 uses `Flux2VAE`, which **does** have `decode_packed_latents`, so the check always succeeds.

The difference is what `unpack_latents` returns for each model:

| Model | After `unpack_latents` | Channels | Next step |
|---|---|---|---|
| FLUX.2 | Patchified latents (BN-denorm still needed) | 128 | `decode_packed_latents` (BN denorm + unpatchify → 32ch) |
| Ideogram 4 | VAE-ready latents (shift/scale already applied + reshape done) | 32 | `vae.decode` directly |

Passing 32-channel VAE-ready latents into `decode_packed_latents` causes a channel shape mismatch — that method expects 128 channels, and the BN denorm parameters broadcast against the wrong axis.

## Fix

Add a channel count guard before calling `decode_packed_latents`:

```python
vae_latent_channels = getattr(self.model.vae, "latent_channels", 32)
if hasattr(self.model.vae, "decode_packed_latents") and unpack_latents.shape[1] > vae_latent_channels:
    stepwise_decoded = self.model.vae.decode_packed_latents(unpack_latents)
else:
    stepwise_decoded = self.model.vae.decode(unpack_latents)
```

`unpack_latents.shape[1]` is 128 for FLUX.2 (still patchified, needs the extra decode step) and 32 for Ideogram 4 (already unpacked). The `> vae_latent_channels` guard routes each model to the correct path without requiring a new abstract method or Ideogram-specific isinstance check.

`latent_channels` defaults to `32` via `getattr` fallback, matching all current VAEs that don't explicitly declare it.

## Verification

Reproduced the crash and confirmed the fix end-to-end on `ideogram-ai/ideogram-4-fp8`:

```
# main's handler
ValueError: [broadcast_shapes] Shapes (1,32,64,64) and (1,128,1,1) cannot be broadcast.   exit 1

# with this fix
exit 0 → 13 stepwise PNGs + composite, clean noise → image progression
```

Also adds `tests/callbacks/test_stepwise_handler_vae_routing.py` — three `@pytest.mark.fast` tests (0.6s, no weights, no image generation) asserting which decode path the handler picks for Ideogram 4 (`vae.decode`), FLUX.2 (`decode_packed_latents`), and a VAE with no `decode_packed_latents` at all (fallback). They fake the model and VAE but use the real latent creators, so the shape contract that actually broke is exercised rather than mocked away.

Reverting the fix makes exactly the Ideogram case fail (`decode_packed_latents expects 128 channels, got 32`) while the other two stay green.

See the test-run comment below for full fast/slow suite results.
