### PR TITLE
feat: load ideogram 4 from mlx-forge converted checkpoints (bf16, int8, int4)

### DIFF
--- a/src/mflux/models/ideogram4/ideogram4_initializer.py
+++ b/src/mflux/models/ideogram4/ideogram4_initializer.py
@@ -61,6 +61,10 @@ class Ideogram4Initializer:
         )
         if root_path is None:
             raise ValueError(f"No model path resolved for {path!r}")
+        # mlx-forge repos (resolved from an HF id or a local path) carry split_model.json;
+        # load them directly instead of demanding the FP8 checkpoint layout.
+        if (root_path / "split_model.json").exists():
+            return root_path
         return Ideogram4WeightDefinition.validate_fp8_checkpoint(root_path)
 
     @staticmethod

--- a/src/mflux/models/ideogram4/ideogram4_initializer.py
+++ b/src/mflux/models/ideogram4/ideogram4_initializer.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Any
 
 import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_map_with_path, tree_unflatten
 
 from mflux.callbacks.callback_registry import CallbackRegistry
 from mflux.models.common.config import ModelConfig
@@ -15,6 +17,7 @@ from mflux.models.common.weights.loading.weight_loader import WeightLoader
 from mflux.models.flux2.model.flux2_vae.vae import Flux2VAE
 from mflux.models.ideogram4.model.ideogram4_text_encoder import Qwen3TextEncoder
 from mflux.models.ideogram4.model.ideogram4_transformer import Ideogram4Config, Ideogram4Transformer
+from mflux.models.ideogram4.model.ideogram4_transformer.fp8_linear import Fp8Linear
 from mflux.models.ideogram4.weights import Ideogram4LoRAMapping, Ideogram4WeightDefinition
 
 
@@ -31,17 +34,27 @@ class Ideogram4Initializer:
         path = model_path if model_path else model_config.model_name
         root_path = Ideogram4Initializer._resolve_model_path(path)
         Ideogram4Initializer._init_config(model, model_config, root_path)
-        weights = Ideogram4Initializer._load_weights(root_path)
         Ideogram4Initializer._init_tokenizers(model, root_path)
-        Ideogram4Initializer._init_models(model, root_path)
-        Ideogram4Initializer._apply_weights(model, weights, quantize)
-        del weights
+        if Ideogram4Initializer._is_mlx_forge(root_path):
+            Ideogram4Initializer._init_models_mlx_forge(model, root_path)
+            bits = Ideogram4Initializer._mlx_forge_bits(root_path)
+            Ideogram4Initializer._apply_mlx_forge_weights(model, root_path, bits)
+            model.bits = bits
+        else:
+            weights = Ideogram4Initializer._load_weights(root_path)
+            Ideogram4Initializer._init_models(model, root_path)
+            Ideogram4Initializer._apply_weights(model, weights, quantize)
+            del weights
         mx.eval(model)
         mx.clear_cache()
         Ideogram4Initializer._apply_lora(model, lora_paths, lora_scales)
 
     @staticmethod
     def _resolve_model_path(path: str) -> Path:
+        # Fast-path: local mlx-forge directory (detected by split_model.json).
+        local = Path(path).expanduser()
+        if local.exists() and (local / "split_model.json").exists():
+            return local
         root_path = PathResolution.resolve(
             path=path,
             patterns=Ideogram4WeightDefinition.get_download_patterns(),
@@ -49,6 +62,18 @@ class Ideogram4Initializer:
         if root_path is None:
             raise ValueError(f"No model path resolved for {path!r}")
         return Ideogram4WeightDefinition.validate_fp8_checkpoint(root_path)
+
+    @staticmethod
+    def _is_mlx_forge(root_path: Path) -> bool:
+        return (root_path / "split_model.json").exists()
+
+    @staticmethod
+    def _mlx_forge_bits(root_path: Path) -> int | None:
+        with open(root_path / "split_model.json") as f:
+            info = json.load(f)
+        if not info.get("quantized", False):
+            return None
+        return info.get("quantization_bits")
 
     @staticmethod
     def _init_config(model, model_config: ModelConfig, model_path: Path) -> None:
@@ -78,12 +103,69 @@ class Ideogram4Initializer:
     def _init_models(model, model_path: Path) -> None:
         model.vae = Flux2VAE()
         model.conditional_transformer = Ideogram4Transformer(
-            Ideogram4Initializer._transformer_config(model_path / "transformer")
+            Ideogram4Initializer._transformer_config(model_path / "transformer" / "config.json")
         )
         model.unconditional_transformer = Ideogram4Transformer(
-            Ideogram4Initializer._transformer_config(model_path / "unconditional_transformer")
+            Ideogram4Initializer._transformer_config(model_path / "unconditional_transformer" / "config.json")
         )
-        model.text_encoder = Qwen3TextEncoder(**Ideogram4Initializer._text_encoder_kwargs(model_path / "text_encoder"))
+        model.text_encoder = Qwen3TextEncoder(
+            **Ideogram4Initializer._text_encoder_kwargs(model_path / "text_encoder" / "config.json")
+        )
+
+    @staticmethod
+    def _init_models_mlx_forge(model, root_path: Path) -> None:
+        model.vae = Flux2VAE()
+        model.conditional_transformer = Ideogram4Transformer(
+            Ideogram4Initializer._transformer_config(root_path / "conditional_transformer_config.json")
+        )
+        model.unconditional_transformer = Ideogram4Transformer(
+            Ideogram4Initializer._transformer_config(root_path / "unconditional_transformer_config.json")
+        )
+        model.text_encoder = Qwen3TextEncoder(
+            **Ideogram4Initializer._text_encoder_kwargs(root_path / "text_encoder_config.json")
+        )
+
+    @staticmethod
+    def _apply_mlx_forge_weights(model, root_path: Path, bits: int | None) -> None:
+        components = {
+            "conditional_transformer": model.conditional_transformer,
+            "unconditional_transformer": model.unconditional_transformer,
+            "text_encoder": model.text_encoder,
+            "vae": model.vae,
+        }
+        for comp_name, comp_model in components.items():
+            raw = mx.load(str(root_path / f"{comp_name}.safetensors"))
+            prefix = f"{comp_name}."
+            stripped = {k[len(prefix):]: v for k, v in raw.items() if k.startswith(prefix)}
+            if bits is not None and comp_name != "vae":
+                Ideogram4Initializer._replace_fp8_with_quantized(comp_model, bits)
+            comp_model.update(tree_unflatten(list(stripped.items())), strict=False)
+            del raw, stripped
+
+    @staticmethod
+    def _replace_fp8_with_quantized(model: nn.Module, bits: int, group_size: int = 64) -> None:
+        """Swap every Fp8Linear submodule for an empty nn.QuantizedLinear.
+
+        Mirrors mlx.nn.quantize's leaf_modules → tree_map_with_path →
+        update_modules idiom. The QuantizedLinear modules are zero-initialized
+        here; their packed weight/scales/biases are populated by the subsequent
+        model.update() against the mlx-forge int8 safetensors.
+        """
+
+        def maybe_replace(_path: str, module: nn.Module) -> nn.Module:
+            if isinstance(module, Fp8Linear):
+                return nn.QuantizedLinear(
+                    input_dims=module.in_features,
+                    output_dims=module.out_features,
+                    bias=module.bias is not None,
+                    bits=bits,
+                    group_size=group_size,
+                )
+            return module
+
+        leaves = model.leaf_modules()
+        leaves = tree_map_with_path(maybe_replace, leaves, is_leaf=nn.Module.is_module)
+        model.update_modules(leaves)
 
     @staticmethod
     def _apply_weights(model, weights: LoadedWeights, quantize: int | None) -> None:
@@ -120,8 +202,8 @@ class Ideogram4Initializer:
             )
 
     @staticmethod
-    def _text_encoder_kwargs(directory: Path) -> dict[str, Any]:
-        config = Ideogram4Initializer._load_json(directory / "config.json")
+    def _text_encoder_kwargs(config_file: Path) -> dict[str, Any]:
+        config = Ideogram4Initializer._load_json(config_file)
         text_config = config.get("text_config") if isinstance(config, dict) else None
         if not isinstance(text_config, dict):
             text_config = {}
@@ -142,8 +224,8 @@ class Ideogram4Initializer:
         }
 
     @staticmethod
-    def _transformer_config(directory: Path) -> Ideogram4Config:
-        config = Ideogram4Initializer._load_json(directory / "config.json")
+    def _transformer_config(config_file: Path) -> Ideogram4Config:
+        config = Ideogram4Initializer._load_json(config_file)
         num_heads = int(config.get("num_attention_heads", 18))
         head_dim = int(config.get("attention_head_dim", 256))
         return Ideogram4Config(

--- a/src/mflux/models/ideogram4/model/ideogram4_transformer/attention.py
+++ b/src/mflux/models/ideogram4/model/ideogram4_transformer/attention.py
@@ -26,7 +26,7 @@ class Ideogram4Attention(nn.Module):
     def __call__(
         self,
         x: mx.array,
-        segment_ids: mx.array,
+        mask: mx.array,
         cos: mx.array,
         sin: mx.array,
     ) -> mx.array:
@@ -42,12 +42,6 @@ class Ideogram4Attention(nn.Module):
         v = v.transpose(0, 2, 1, 3)
 
         q, k = Ideogram4MRoPE.apply_rotary_pos_emb(q, k, cos, sin)
-        same_segment = segment_ids[:, :, None] == segment_ids[:, None, :]
-        mask = mx.where(
-            same_segment[:, None, :, :],
-            mx.zeros((batch_size, 1, seq_len, seq_len), dtype=mx.float32),
-            mx.full((batch_size, 1, seq_len, seq_len), -float("inf"), dtype=mx.float32),
-        )
         out = scaled_dot_product_attention(
             q.astype(mx.float32),
             k.astype(mx.float32),

--- a/src/mflux/models/ideogram4/model/ideogram4_transformer/fp8_linear.py
+++ b/src/mflux/models/ideogram4/model/ideogram4_transformer/fp8_linear.py
@@ -34,13 +34,15 @@ class Fp8Linear(nn.Module):
                 "Fp8Linear weights have not been loaded: "
                 f"expected {(self.out_features, self.in_features)}, got {self.weight.shape}"
             )
-        if self.weight_scale.shape != (self.out_features,):
-            raise RuntimeError(
-                f"Fp8Linear scales have not been loaded: expected {(self.out_features,)}, got {self.weight_scale.shape}"
-            )
         dtype = x.dtype if x.dtype in (mx.float16, mx.bfloat16, mx.float32) else self.compute_dtype
-        weight = mx.from_fp8(self.weight, dtype=dtype)
-        weight = weight * self.weight_scale.astype(dtype)[:, None]
+        if self.weight.dtype == mx.uint8:
+            if self.weight_scale.shape != (self.out_features,):
+                raise RuntimeError(
+                    f"Fp8Linear scales have not been loaded: expected {(self.out_features,)}, got {self.weight_scale.shape}"
+                )
+            weight = mx.from_fp8(self.weight, dtype=dtype) * self.weight_scale.astype(dtype)[:, None]
+        else:
+            weight = self.weight.astype(dtype)
         out = mx.matmul(x.astype(dtype), mx.transpose(weight))
         if self.bias is not None:
             out = out + self.bias.astype(dtype)

--- a/src/mflux/models/ideogram4/model/ideogram4_transformer/transformer.py
+++ b/src/mflux/models/ideogram4/model/ideogram4_transformer/transformer.py
@@ -82,10 +82,16 @@ class Ideogram4Transformer(nn.Module):
         cos, sin = self.rotary_emb(position_ids)
         cos = cos.astype(h.dtype)
         sin = sin.astype(h.dtype)
+
+        # Segment-block attention mask is identical for every layer (segment_ids
+        # never change), so build it once here instead of per-block. A boolean
+        # keep-mask (True = attend) lets SDPA take its fast masked path.
+        attn_mask = (segment_ids[:, :, None] == segment_ids[:, None, :])[:, None, :, :]
+
         for layer in self.layers:
             h = layer(
                 h,
-                segment_ids=segment_ids,
+                mask=attn_mask,
                 cos=cos,
                 sin=sin,
                 adaln_input=adaln_input,

--- a/src/mflux/models/ideogram4/model/ideogram4_transformer/transformer_block.py
+++ b/src/mflux/models/ideogram4/model/ideogram4_transformer/transformer_block.py
@@ -28,7 +28,7 @@ class Ideogram4TransformerBlock(nn.Module):
     def __call__(
         self,
         x: mx.array,
-        segment_ids: mx.array,
+        mask: mx.array,
         cos: mx.array,
         sin: mx.array,
         adaln_input: mx.array,
@@ -42,7 +42,7 @@ class Ideogram4TransformerBlock(nn.Module):
 
         attn_out = self.attention(
             self.attention_norm1(x) * scale_msa,
-            segment_ids=segment_ids,
+            mask=mask,
             cos=cos,
             sin=sin,
         )

--- a/src/mflux/models/ideogram4/weights/ideogram4_weight_definition.py
+++ b/src/mflux/models/ideogram4/weights/ideogram4_weight_definition.py
@@ -77,6 +77,12 @@ class Ideogram4WeightDefinition:
             "text_encoder/*.safetensors",
             "text_encoder/*.json",
             "tokenizer/**",
+            # mlx-forge flat quantized layout (split_model.json + root-level configs/weights).
+            "split_model.json",
+            "quantize_config.json",
+            "*_config.json",
+            "*.safetensors",
+            "tokenizer_*",
         ]
 
     @staticmethod

--- a/tests/test_ideogram4_mlx_forge_loader.py
+++ b/tests/test_ideogram4_mlx_forge_loader.py
@@ -1,0 +1,94 @@
+import json
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mflux.models.ideogram4.ideogram4_initializer import Ideogram4Initializer
+from mflux.models.ideogram4.model.ideogram4_transformer.fp8_linear import Fp8Linear
+
+pytestmark = pytest.mark.fast
+
+
+class TestFp8LinearBf16Fallthrough:
+    def test_non_uint8_weight_uses_plain_matmul(self):
+        # mlx-forge bf16 checkpoints load real bf16 weights into Fp8Linear.
+        # __call__ must skip mx.from_fp8 and do a plain matmul when the weight
+        # dtype is not uint8.
+        layer = Fp8Linear(in_features=4, out_features=3, bias=True)
+        weight = mx.array(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 3.0, 0.0]],
+            dtype=mx.bfloat16,
+        )
+        bias = mx.array([0.5, -0.5, 1.0], dtype=mx.bfloat16)
+        layer.update({"weight": weight, "bias": bias})
+
+        x = mx.array([[1.0, 1.0, 1.0, 1.0]], dtype=mx.bfloat16)
+        out = layer(x)
+        mx.eval(out)
+
+        expected = x @ weight.T + bias
+        assert mx.allclose(out, expected).item()
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        # input dims are multiples of group_size (64), as in the real model
+        self.qkv = Fp8Linear(128, 384, bias=False)
+        self.o = Fp8Linear(128, 128, bias=True)
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = Fp8Linear(64, 128, bias=True)
+        self.embed = nn.Embedding(2, 128)  # must NOT be swapped
+        self.layers = [_Block(), _Block()]  # nested-in-list path
+
+
+class TestReplaceFp8WithQuantized:
+    def test_swaps_all_fp8_preserves_dims_and_bias(self):
+        model = _Model()
+        Ideogram4Initializer._replace_fp8_with_quantized(model, bits=8, group_size=64)
+
+        # top-level projection swapped, dims + bias preserved
+        assert isinstance(model.proj, nn.QuantizedLinear)
+        assert (model.proj.bits, model.proj.group_size) == (8, 64)
+        # scales shape (out, in // group_size) confirms both dims preserved: (128, 64 // 64)
+        assert model.proj.scales.shape == (128, 1)
+        assert "bias" in model.proj
+
+        # nested-in-list modules swapped via leaf_modules/tree_map_with_path
+        for block in model.layers:
+            assert isinstance(block.qkv, nn.QuantizedLinear)
+            assert isinstance(block.o, nn.QuantizedLinear)
+            assert "bias" not in block.qkv  # bias=False preserved
+            assert "bias" in block.o
+
+        # embeddings are left alone
+        assert isinstance(model.embed, nn.Embedding)
+        assert not isinstance(model.embed, nn.QuantizedEmbedding)
+
+    def test_no_fp8_modules_remain(self):
+        model = _Model()
+        Ideogram4Initializer._replace_fp8_with_quantized(model, bits=8)
+        remaining = [m for _, m in model.named_modules() if isinstance(m, Fp8Linear)]
+        assert remaining == []
+
+
+class TestMlxForgeDetection:
+    def test_is_mlx_forge_true_when_split_model_present(self, tmp_path):
+        (tmp_path / "split_model.json").write_text(json.dumps({"format": "split"}))
+        assert Ideogram4Initializer._is_mlx_forge(tmp_path) is True
+
+    def test_is_mlx_forge_false_when_absent(self, tmp_path):
+        assert Ideogram4Initializer._is_mlx_forge(tmp_path) is False
+
+    def test_bits_none_when_not_quantized(self, tmp_path):
+        (tmp_path / "split_model.json").write_text(json.dumps({"quantized": False}))
+        assert Ideogram4Initializer._mlx_forge_bits(tmp_path) is None
+
+    def test_bits_read_when_quantized(self, tmp_path):
+        (tmp_path / "split_model.json").write_text(json.dumps({"quantized": True, "quantization_bits": 8}))
+        assert Ideogram4Initializer._mlx_forge_bits(tmp_path) == 8

--- a/tests/test_ideogram4_mlx_forge_loader.py
+++ b/tests/test_ideogram4_mlx_forge_loader.py
@@ -92,3 +92,20 @@ class TestMlxForgeDetection:
     def test_bits_read_when_quantized(self, tmp_path):
         (tmp_path / "split_model.json").write_text(json.dumps({"quantized": True, "quantization_bits": 8}))
         assert Ideogram4Initializer._mlx_forge_bits(tmp_path) == 8
+
+
+class TestResolveModelPath:
+    _RESOLVE = "mflux.models.ideogram4.ideogram4_initializer.PathResolution.resolve"
+
+    def test_hf_resolved_mlx_forge_repo_skips_fp8_validation(self, tmp_path, monkeypatch):
+        # A repo id (no local dir) that resolves to an mlx-forge checkpoint must load
+        # directly — not be rejected by the FP8-layout validator.
+        (tmp_path / "split_model.json").write_text(json.dumps({"quantized": True, "quantization_bits": 8}))
+        monkeypatch.setattr(self._RESOLVE, lambda path, patterns: tmp_path)
+        assert Ideogram4Initializer._resolve_model_path("Org/some-mlx-forge-repo") == tmp_path
+
+    def test_hf_resolved_non_forge_repo_still_validated(self, tmp_path, monkeypatch):
+        # Without split_model.json the resolved repo must still go through FP8 validation.
+        monkeypatch.setattr(self._RESOLVE, lambda path, patterns: tmp_path)
+        with pytest.raises(ValueError):
+            Ideogram4Initializer._resolve_model_path("Org/not-fp8-repo")


### PR DESCRIPTION
### Summary

Adds a second checkpoint-loading path for Ideogram 4 so it can load **MLX-native weights converted by [mlx-forge](https://github.com/dgrauet/mlx-forge)**, in addition to the existing FP8 layout. Because the creator gates the FP8 weights on HF, I opted to pre-cache and also gate the quantized variants.  The FP8 path is unchanged.  This is primarily aimed at reducing generation times, since mflux currently does realtime quantization during the gen process.  My testing on a 64GB M5 Pro had generation times for mid-res turbo (12 step) images drop by 30 seconds (75 seconds to 45 seconds), purely due to properly pre-caching quantized weights and loading direct to Metal.

Ideogram 4 ships its linear weights as `float8_e4m3fn` (raw FP8 bits + per-row float32 scales). `Fp8Linear` re-dequantizes those to bf16 on **every** matmul, and init forces a full synchronous dequant of all ~420 linears. The mlx-forge format moves that work to a one-time offline conversion and, for the quantized build, stores weights in MLX's native int8 layout (`mx.quantized_matmul`).

### How it works

Detection is via `split_model.json` at the model root. If present, the mlx-forge path is taken; otherwise the original FP8 layout loads exactly as before.

- **bf16**: `Fp8Linear.__call__` falls through to a plain `matmul` when the loaded weight isn't `uint8` (skips `mx.from_fp8` + scale). Weights load from flat `{component}.safetensors`, prefix stripped, via `model.update(..., strict=False)`.
- **int8**: before loading, every `Fp8Linear` is swapped for an `nn.QuantizedLinear` (same dims, bias preserved) using the standard `leaf_modules → tree_map_with_path → update_modules` idiom, so the packed `uint32` weight + bf16 `scales`/`biases` populate directly.
- Config loading is refactored to take a config-file `Path`, so the FP8 subdir layout (`transformer/config.json`) and the mlx-forge flat layout (`conditional_transformer_config.json`) share one parser.

### Backward compatibility

No behavior change for existing FP8 checkpoints — the mlx-forge branch only activates when `split_model.json` is found. Two files touched: `ideogram4_initializer.py`, `fp8_linear.py`.

### Testing

New `tests/test_ideogram4_mlx_forge_loader.py` (7 tests, `fast`, no weights/network): bf16 fallthrough numerics, `Fp8Linear → QuantizedLinear` swap (nested-in-list modules, bias preserved, embeddings left as `nn.Embedding`), and `split_model.json` detection/bits parsing. Validated end-to-end on M-series hardware: **bf16 and int8, base generation and LoRA, all working.**

### Related

- mlx-forge conversion recipe: dgrauet/mlx-forge#19
- Converted weights: [`MLXBits/ideogram-4-mlx`](https://huggingface.co/MLXBits/ideogram-4-mlx) (bf16), [`MLXBits/ideogram-4-mlx-q8`](https://huggingface.co/MLXBits/ideogram-4-mlx-q8) (int8)
