### PR TITLE
Training: add Adafactor and Lion to the optimizer enum

### DIFF
--- a/src/mflux/models/common/training/optimization/optimizer.py
+++ b/src/mflux/models/common/training/optimization/optimizer.py
@@ -15,6 +15,8 @@ from mflux.models.common.training.state.zip_util import ZipUtil
 class Optimizers(Enum):
     ADAM = ("Adam", optim.Adam)
     ADAMW = ("AdamW", optim.AdamW)
+    ADAFACTOR = ("Adafactor", optim.Adafactor)  # ~half the optimizer state of Adam (memory-light)
+    LION = ("Lion", optim.Lion)
 
     def __init__(self, alias: str, optimizer: mlx.optimizers.Optimizer):
         self.alias = alias


### PR DESCRIPTION
Exposes `mlx.optimizers.Adafactor` (about half the optimizer state of Adam — useful for memory-bound training) and `Lion` alongside the existing Adam/AdamW. Selected by name in the training config's `optimizer` section. Full fast suite: 516 passed.