### PR TITLE
Training: support LoRA alpha (effective scale = alpha/rank)

### DIFF
--- a/src/mflux/models/common/training/lora/path_util.py
+++ b/src/mflux/models/common/training/lora/path_util.py
@@ -50,8 +50,8 @@ def expand_module_paths(target: LoraTargetSpec) -> list[str]:
     return [target.module_path.format(block=b) for b in blocks.get_blocks()]
 
 
-def expand_module_paths_from_targets(targets: list[LoraTargetSpec]) -> list[tuple[str, int]]:
-    expanded: list[tuple[str, int]] = []
+def expand_module_paths_from_targets(targets: list[LoraTargetSpec]) -> list[tuple[str, int, float | None]]:
+    expanded: list[tuple[str, int, float | None]] = []
     for t in targets:
-        expanded.extend((p, t.rank) for p in expand_module_paths(t))
+        expanded.extend((p, t.rank, t.alpha) for p in expand_module_paths(t))
     return expanded

--- a/src/mflux/models/common/training/lora/target_injector.py
+++ b/src/mflux/models/common/training/lora/target_injector.py
@@ -16,7 +16,8 @@ from mflux.models.common.training.state.training_spec import LoraTargetSpec
 
 def inject_lora_targets(transformer: Any, targets: list[LoraTargetSpec]) -> None:
     expanded = expand_module_paths_from_targets(targets)
-    for module_path, rank in expanded:
+    for module_path, rank, alpha in expanded:
+        scale = (alpha / rank) if alpha is not None else 1.0
         current = get_at_path(transformer, module_path)
 
         # Skip if already has a trainable LoRA on this path
@@ -28,18 +29,18 @@ def inject_lora_targets(transformer: Any, targets: list[LoraTargetSpec]) -> None
                 continue
 
         if isinstance(current, (nn.Linear, nn.QuantizedLinear)):
-            wrapped = LoRALinear.from_linear(current, r=rank)
+            wrapped = LoRALinear.from_linear(current, r=rank, scale=scale)
             wrapped._mflux_lora_role = "train"
             set_at_path(transformer, module_path, wrapped)
         elif isinstance(current, LoRALinear):
             # Fuse a new trainable LoRA on top of an existing LoRA (e.g. assistant adapter).
-            train_lora = LoRALinear.from_linear(current.linear, r=rank)
+            train_lora = LoRALinear.from_linear(current.linear, r=rank, scale=scale)
             train_lora._mflux_lora_role = "train"
             fused = FusedLoRALinear(base_linear=current.linear, loras=[current, train_lora])
             set_at_path(transformer, module_path, fused)
         elif isinstance(current, FusedLoRALinear):
             # Add a new trainable LoRA to an existing fusion (e.g. multiple preloaded LoRAs).
-            train_lora = LoRALinear.from_linear(current.base_linear, r=rank)
+            train_lora = LoRALinear.from_linear(current.base_linear, r=rank, scale=scale)
             train_lora._mflux_lora_role = "train"
             fused = FusedLoRALinear(base_linear=current.base_linear, loras=current.loras + [train_lora])
             set_at_path(transformer, module_path, fused)

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -116,6 +116,9 @@ class LoraTargetSpec:
     module_path: str
     rank: int
     blocks: BlockRange | None = None
+    # LoRA alpha; effective scale = alpha / rank (published-recipe convention).
+    # None keeps the prior behavior (scale = 1.0).
+    alpha: float | None = None
 
 
 @dataclass
@@ -373,6 +376,7 @@ class TrainingSpec:
                     module_path=t["module_path"],
                     rank=t["rank"],
                     blocks=blocks,
+                    alpha=t.get("alpha"),
                 )
             )
 


### PR DESCRIPTION
`LoraTargetSpec` gains an optional `alpha`; the injector applies `scale = alpha/rank` to each trained LoRA layer (the published-recipe convention) instead of a hardcoded 1.0. Threaded through `expand_module_paths_from_targets` and parsed from `lora_layers.targets[]`. The saver already bakes the layer scale, so exported weights carry it. `alpha=None` keeps `scale = 1.0` (unchanged default). Full fast suite: 516 passed.