### PR TITLE
Training: add LR schedule (cosine) and linear warmup

### DIFF
--- a/src/mflux/models/common/training/optimization/optimizer.py
+++ b/src/mflux/models/common/training/optimization/optimizer.py
@@ -37,10 +37,26 @@ class Optimizer:
         mx.save_safetensors(str(path), dict(state))
 
     @staticmethod
+    def _build_lr(spec):
+        # Returns a float (constant) or an MLX schedule callable. A linear warmup (lr_warmup_steps)
+        # is prepended when set; "cosine" decays over the remaining steps (needs lr_total_steps).
+        lr = spec.learning_rate
+        warmup = spec.lr_warmup_steps or 0
+        if spec.lr_schedule == "cosine" and spec.lr_total_steps:
+            decay_steps = max(1, int(spec.lr_total_steps) - warmup)
+            main = optim.cosine_decay(lr, decay_steps)
+            if warmup > 0:
+                return optim.join_schedules([optim.linear_schedule(0.0, lr, warmup), main], [warmup])
+            return main
+        if warmup > 0:  # warmup then constant
+            return optim.join_schedules([optim.linear_schedule(0.0, lr, warmup), optim.cosine_decay(lr, 10**12)], [warmup])
+        return lr
+
+    @staticmethod
     def from_spec(training_spec: TrainingSpec) -> "Optimizer":
         opt_cls = Optimizers.from_alias(training_spec.optimizer.name)
         # noinspection PyCallingNonCallable
-        opt = opt_cls(learning_rate=training_spec.optimizer.learning_rate)
+        opt = opt_cls(learning_rate=Optimizer._build_lr(training_spec.optimizer))
 
         if training_spec.optimizer.state_path is not None:
             state = ZipUtil.unzip(

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -84,6 +84,12 @@ class OptimizerSpec:
     name: str
     learning_rate: float
     state_path: str | None = None
+    # LR schedule: None = constant; "cosine" = cosine decay (needs lr_total_steps). A linear
+    # warmup of lr_warmup_steps is prepended either way (0 = none). Resumes correctly: the
+    # schedule is rebuilt from these fields and applied at the optimizer's restored step.
+    lr_schedule: str | None = None
+    lr_warmup_steps: int = 0
+    lr_total_steps: int | None = None
 
 
 @dataclass


### PR DESCRIPTION
`OptimizerSpec` gains `lr_schedule` ('cosine' | None), `lr_warmup_steps` and `lr_total_steps`. `Optimizer._build_lr` returns either a constant float or an MLX schedule callable: an optional linear warmup (0 → peak over `lr_warmup_steps`) followed by cosine decay over the remaining steps (`mlx.optimizers` cosine_decay / linear_schedule / join_schedules). The schedule is a pure function of the spec, so it resumes correctly at the optimizer's restored step. Defaults (`lr_schedule=None`, warmup=0) keep the prior constant-LR behavior. Full fast suite: 516 passed.