### PR TITLE
Training: configurable timestep-index sampling distribution

### DIFF
--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -77,6 +77,11 @@ class TrainingLoopSpec:
     timestep_low: int = 0
     timestep_high: int | None = None
     iterator_state_path: str | None = None
+    # Timestep-index sampling distribution: None/"uniform" (flat), "sigmoid" (mid-concentrated,
+    # ai-toolkit's default — best for subject identity), "content" (cubic, favors low-noise /
+    # fine detail), "style" (favors high-noise / coarse style). Applies to adapters that sample
+    # sigma from the index grid (flux/z-image/ernie); Ideogram has its own sample_sigma override.
+    timestep_type: str | None = None
 
 
 @dataclass

--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -24,6 +24,24 @@ from mflux.models.common.training.utils import TrainingUtil
 
 class TrainingTrainer:
     @staticmethod
+    def _sample_timestep_index(timestep_type: str, low: int, high: int, rng) -> int:
+        # Map a [0,1) draw shaped by the distribution to a timestep index in [low, high).
+        import math
+
+        span = high - low
+        if span <= 0:
+            return low
+        if timestep_type == "sigmoid":  # mid-concentrated (ai-toolkit default; best for identity)
+            frac = 1.0 / (1.0 + math.exp(-rng.gauss(0.0, 1.0)))
+        elif timestep_type == "content":  # cubic, favors low noise (fine detail)
+            frac = rng.random() ** 3
+        elif timestep_type == "style":  # favors high noise (coarse style)
+            frac = 1.0 - rng.random() ** 3
+        else:
+            frac = rng.random()
+        return min(max(low + int(frac * span), low), high - 1)
+
+    @staticmethod
     def compute_loss(
         adapter: TrainingAdapter,
         training_spec: TrainingSpec,
@@ -65,14 +83,20 @@ class TrainingTrainer:
             else training_spec.training_loop.timestep_high
         )
 
-        t = int(
-            mx.random.randint(
-                low=low,
-                high=high,
-                shape=[],
-                key=mx.random.key(time_seed),
+        timestep_type = training_spec.training_loop.timestep_type
+        if timestep_type and timestep_type != "uniform":
+            # Non-uniform timestep-index sampling (sigmoid/content/style). Identity learning
+            # lives in the mid/low-noise band that flat sampling under-weights.
+            t = TrainingTrainer._sample_timestep_index(timestep_type, low, high, rng)
+        else:
+            t = int(
+                mx.random.randint(
+                    low=low,
+                    high=high,
+                    shape=[],
+                    key=mx.random.key(time_seed),
+                )
             )
-        )
 
         clean_image = item.clean_latents
         pure_noise = mx.random.normal(


### PR DESCRIPTION
`TrainingLoopSpec` gains `timestep_type`, shaping the timestep-index draw for adapters that read `sigma = scheduler.sigmas[t]` (flux / z-image / ernie): 'sigmoid' (mid-concentrated), 'content' (cubic, favors low noise / fine detail), 'style' (favors high noise / coarse). `None`/'uniform' keeps the exact prior behavior via the original `mx.random` path. Useful because subject/identity detail concentrates in the mid/low-noise band that flat sampling under-weights. Full fast suite: 516 passed.