### PR TITLE
Training: bound MLX's buffer-cache pool via cache_limit_gb

### DIFF
--- a/src/mflux/models/common/training/runner.py
+++ b/src/mflux/models/common/training/runner.py
@@ -57,6 +57,11 @@ class TrainingRunner:
     def train(*, config_path: str | None, resume_path: str | None) -> tuple[TrainingAdapter, TrainingSpec]:
         training_spec = TrainingSpec.resolve(config_path=config_path, resume_path=resume_path)
 
+        # Bound MLX's buffer-cache pool for the whole run (encoding + train loop). Freed
+        # buffers above the cap return to the OS instead of being retained for reuse.
+        if training_spec.cache_limit_gb:
+            mx.set_cache_limit(int(training_spec.cache_limit_gb * 1e9))
+
         # Set global seed for MLX randomness
         mx_random.seed(training_spec.seed)
 

--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -229,6 +229,10 @@ class TrainingSpec:
     checkpoint_path: str | None = None
     # If true, training will use a disk-backed cache for encoded data to reduce RAM usage.
     low_ram: bool = False
+    # Cap (in GB) on MLX's buffer-cache pool (mx.set_cache_limit). The pool otherwise grows
+    # to hold the largest transient allocations seen; bounding it returns freed buffers to
+    # the OS at ~no speed cost (unlike low_ram's clear-every-step). None = MLX default.
+    cache_limit_gb: float | None = None
 
     @staticmethod
     def resolve(
@@ -286,6 +290,11 @@ class TrainingSpec:
         low_ram = bool(config.get("low_ram", False))
         if low_ram and data_root_dir is None:
             raise ValueError("'low_ram' requires a valid data path.")
+
+        cache_limit_raw = config.get("cache_limit_gb", None)
+        cache_limit_gb = None if cache_limit_raw is None else float(cache_limit_raw)
+        if cache_limit_gb is not None and cache_limit_gb <= 0:
+            raise ValueError("'cache_limit_gb' must be > 0")
 
         monitoring_conf = config.get("monitoring", None)
         preview_prompt_paths: list[Path] = []
@@ -424,6 +433,7 @@ class TrainingSpec:
             data_root=str(data_root_dir.resolve()),
             config_path=None if absolute_config_path is None else str(absolute_config_path),
             low_ram=low_ram,
+            cache_limit_gb=cache_limit_gb,
         )
 
     @staticmethod


### PR DESCRIPTION
`TrainingSpec.cache_limit_gb` calls `mx.set_cache_limit()` for the whole run. MLX's buffer-cache pool otherwise grows to hold the largest transient allocations seen and is never returned to the OS; bounding it caps resident memory at ~no speed cost (buffers below the cap are still reused, unlike `low_ram`'s clear-every-step). `None` = MLX default (unbounded). Full fast suite: 516 passed.