### PR TITLE
Training: skip non-finite steps and utf-8-safe caption reading

### DIFF
--- a/src/mflux/models/common/training/state/training_spec.py
+++ b/src/mflux/models/common/training/state/training_spec.py
@@ -44,7 +44,7 @@ class DataSpec:
                 base_path=base_path,
             )
             try:
-                prompt = prompt_path.read_text(encoding="utf-8").strip()
+                prompt = prompt_path.read_text(encoding="utf-8", errors="replace").strip()
             except FileNotFoundError as e:
                 raise ValueError(f"Prompt file not found: {prompt_path}") from e
         else:
@@ -445,7 +445,7 @@ class TrainingSpec:
 
     @staticmethod
     def _load_preview_prompts(prompt_paths: list[Path]) -> list[str]:
-        return [path.read_text(encoding="utf-8").strip() for path in prompt_paths]
+        return [path.read_text(encoding="utf-8", errors="replace").strip() for path in prompt_paths]
 
     @staticmethod
     def _find_preview_images_in_data(root_dir: Path) -> dict[str, Path]:

--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -137,8 +137,18 @@ class TrainingTrainer:
             initial=training_state.iterator.num_iterations,
         )
 
+        nonfinite_skips = 0
         for batch in batches:
             loss, grads = train_step_function(batch)
+            # Skip non-finite steps (bf16 activation spikes / NaN loss) so a single bad batch
+            # can't poison the LoRA weights or optimizer state; the run continues on the last
+            # good state. clip_grad_norm handles ordinary spikes; this catches Inf/NaN.
+            if not bool(mx.isfinite(loss).item()):
+                del loss, grads
+                nonfinite_skips += 1
+                if training_spec.low_ram:
+                    mx.clear_cache()
+                continue
             training_state.optimizer.optimizer.update(model=adapter.model(), gradients=grads)
             mx.eval(adapter.model().parameters(), training_state.optimizer.optimizer.state)
             del loss, grads
@@ -159,6 +169,8 @@ class TrainingTrainer:
             if training_spec.low_ram:
                 mx.clear_cache()
 
+        if nonfinite_skips:
+            print(f"Skipped {nonfinite_skips} non-finite (NaN/Inf) training step(s).")
         training_state.save(adapter, training_spec)
 
     @staticmethod

--- a/src/mflux/models/common/training/trainer.py
+++ b/src/mflux/models/common/training/trainer.py
@@ -140,10 +140,7 @@ class TrainingTrainer:
         nonfinite_skips = 0
         for batch in batches:
             loss, grads = train_step_function(batch)
-            # Skip non-finite steps (bf16 activation spikes / NaN loss) so a single bad batch
-            # can't poison the LoRA weights or optimizer state; the run continues on the last
-            # good state. clip_grad_norm handles ordinary spikes; this catches Inf/NaN.
-            if not bool(mx.isfinite(loss).item()):
+            if not TrainingTrainer._step_is_finite(loss):
                 del loss, grads
                 nonfinite_skips += 1
                 if training_spec.low_ram:
@@ -243,6 +240,16 @@ class TrainingTrainer:
                 )
             )
             del image
+
+
+    @staticmethod
+    def _step_is_finite(loss) -> bool:
+        """A non-finite loss (bf16 activation spikes, a NaN from one bad batch) must never
+        reach optimizer.update: the gradients it came with poison the LoRA weights and the
+        optimizer moments in a single step. The caller skips the step and the run continues
+        from the last good state. clip_grad_norm handles ordinary spikes; this catches
+        Inf/NaN."""
+        return bool(mx.isfinite(loss).item())
 
     @staticmethod
     def _generate_previews_with_optimizer_offload(

--- a/tests/training/test_nonfinite_and_utf8_captions.py
+++ b/tests/training/test_nonfinite_and_utf8_captions.py
@@ -1,0 +1,58 @@
+import math
+
+import mlx.core as mx
+import pytest
+
+from mflux.models.common.training.state.training_spec import DataSpec
+from mflux.models.common.training.trainer import TrainingTrainer
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_loss_is_flagged_for_skip(bad):
+    assert TrainingTrainer._step_is_finite(mx.array(bad)) is False
+
+
+@pytest.mark.fast
+def test_finite_loss_is_not_skipped():
+    assert TrainingTrainer._step_is_finite(mx.array(1.23)) is True
+    assert TrainingTrainer._step_is_finite(mx.array(0.0)) is True
+
+
+@pytest.mark.fast
+def test_caption_file_with_invalid_utf8_reads_with_replacement(tmp_path):
+    # A latin-1 caption ("café" saved by a non-utf8 editor) used to raise
+    # UnicodeDecodeError and kill the whole training run before the first step.
+    caption = tmp_path / "01.txt"
+    caption.write_bytes(b"caf\xe9 con leche")
+    (tmp_path / "01.jpeg").write_bytes(b"")
+
+    spec = DataSpec.create(
+        {"image": "01.jpeg", "prompt_file": "01.txt"},
+        absolute_or_relative_path=str(tmp_path),
+        base_path=None,
+    )
+    assert spec.prompt.startswith("caf")
+    assert spec.prompt.endswith("con leche")
+    assert "�" in spec.prompt  # the invalid byte is replaced, not fatal
+
+
+@pytest.mark.fast
+def test_valid_multibyte_utf8_caption_reads_intact(tmp_path):
+    caption = tmp_path / "02.txt"
+    caption.write_text("café über 日本語", encoding="utf-8")
+    (tmp_path / "02.jpeg").write_bytes(b"")
+
+    spec = DataSpec.create(
+        {"image": "02.jpeg", "prompt_file": "02.txt"},
+        absolute_or_relative_path=str(tmp_path),
+        base_path=None,
+    )
+    assert spec.prompt == "café über 日本語"
+
+
+@pytest.mark.fast
+def test_math_isfinite_agreement():
+    # Guard against a future rewrite comparing against a python float path.
+    for v in (0.5, float("nan"), float("inf")):
+        assert TrainingTrainer._step_is_finite(mx.array(v)) is math.isfinite(v)


### PR DESCRIPTION
Two small robustness fixes for the training loop, both hit during LoRA training on Apple Silicon.

**Skip non-finite steps.** A bf16 activation spike can send a single step's loss to NaN/Inf. That step then updates the LoRA weights and optimizer state with garbage, and because the plotted loss is smoothed the curve can still look healthy while the run is quietly ruined. The loop now checks the loss and skips the optimizer update when it isn't finite, continuing from the last good state, and prints how many steps were skipped. `clip_grad_norm` already handles ordinary spikes; this is for the Inf/NaN case it can't.

**UTF-8-safe caption reading.** Caption `.txt` files are read with a strict utf-8 decode, so a single stray byte raises `UnicodeDecodeError` and kills the whole run. Reading with `errors="replace"` keeps training going.

Verified on z-image: normal training is unchanged (no false skips), a non-finite loss is skipped, and a caption with invalid bytes no longer crashes.
