### PR TITLE
Fix Ideogram 4 stepwise preview VAE decode crash

### DIFF
--- a/src/mflux/models/flux2/model/flux2_vae/vae.py
+++ b/src/mflux/models/flux2/model/flux2_vae/vae.py
@@ -45,6 +45,12 @@ class Flux2VAE(nn.Module):
     def decode_packed_latents(self, packed_latents: mx.array, tiling_config: TilingConfig | None = None) -> mx.array:
         if packed_latents.ndim == 5:
             packed_latents = packed_latents[:, :, 0, :, :]
+        # Latents already fully unpacked (channel count != the patchified bn dim) come from a latent
+        # creator that denorms + unpatchifies itself — e.g. Ideogram 4, which shares this VAE but calls
+        # vae.decode() directly. The bn-denorm + unpatchify below is only for the flux2 packed form, so
+        # decode such latents as-is instead of crashing on the shape mismatch.
+        if packed_latents.shape[1] != self.bn.running_mean.shape[0]:
+            return self.decode(packed_latents)
         bn_mean = self.bn.running_mean.reshape(1, -1, 1, 1)
         bn_std = mx.sqrt(self.bn.running_var.reshape(1, -1, 1, 1) + self.bn.eps)
         latents = packed_latents * bn_std + bn_mean


### PR DESCRIPTION
Every Ideogram 4 generation with a stepwise output dir crashes at step 0.

**Repro:** `mflux-generate-ideogram4 --model ideogram4 --prompt "..." --stepwise-image-output-dir /tmp/sw ...`

```
ValueError: [broadcast_shapes] Shapes (1,32,128,128) and (1,128,1,1) cannot be broadcast.
```

(in flux2_vae `decode_packed_latents`, at `packed_latents * bn_std + bn_mean`).

**Cause:** Ideogram 4 shares the Flux2 VAE, but `Ideogram4LatentCreator.unpack_latents` denorms and unpatchifies to a 32-channel spatial latent itself, and the final image is decoded with `vae.decode(unpacked)`, not `decode_packed_latents`. The stepwise handler sees `decode_packed_latents` on the VAE and routes Ideogram's already-unpacked 32-channel latents through the Flux2 packed path, where the 128-channel batch-norm denorm cannot broadcast against 32 channels.

**Fix:** `decode_packed_latents` now detects latents whose channel count does not match the batch-norm dim (already unpacked) and decodes them directly via `self.decode()`, which is Ideogram 4's own decode path. Flux2's packed latents (channels == bn dim) are unaffected.

Verified: a full Ideogram 4 generation with `--stepwise-image-output-dir` now completes and writes both the final image and the step previews.
