### PR TITLE
Add mflux-paint to Related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See the [common README](src/mflux/models/common/README.md) for detailed usage an
 ### 🌱 Related projects
 
 - [MindCraft Studio](https://themindstudio.cc/mindcraft#models) — macOS app built on mflux by [@shaoju](https://github.com/shaoju)
+- [mflux-paint](https://github.com/Amo643/mflux-paint) — native macOS inpaint/edit app (pywebview), 16 models across edit/inpaint/text-to-image, mask painting, multi-seed batch, by [@Amo643](https://github.com/Amo643)
 - [Mflux-ComfyUI](https://github.com/raysers/Mflux-ComfyUI) by [@raysers](https://github.com/raysers)
 - [MFLUX-WEBUI](https://github.com/CharafChnioune/MFLUX-WEBUI) by [@CharafChnioune](https://github.com/CharafChnioune)
 - [mflux-fasthtml](https://github.com/anthonywu/mflux-fasthtml) by [@anthonywu](https://github.com/anthonywu)


### PR DESCRIPTION
mflux-paint is a single-screen inpaint/edit desktop app built on mflux (native window via pywebview, no Chrome/Electron). Adding it to the Related projects list alongside the other community UIs.

- 16 models across Edit / Inpaint / Text-to-image
- Brush/eraser/box-select mask painting with undo/redo/invert
- Multi-seed batch generation
- Native macOS window, no browser needed

https://github.com/Amo643/mflux-paint