### PR TITLE
feat: update Qwen models to latest versions (Edit-2511, Image-2512)

### DIFF
--- a/src/mflux/models/common/config/model_config.py
+++ b/src/mflux/models/common/config/model_config.py
@@ -501,8 +501,8 @@ AVAILABLE_MODELS = {
     ),
     "qwen-image": ModelConfig(
         priority=15,
-        aliases=["qwen-image", "qwen"],
-        model_name="Qwen/Qwen-Image",
+        aliases=["qwen-image", "qwen", "qwen-image-2512", "qwen-2512"],
+        model_name="Qwen/Qwen-Image-2512",
         base_model=None,
         controlnet_model=None,
         custom_transformer_model=None,
@@ -516,8 +516,15 @@ AVAILABLE_MODELS = {
     ),
     "qwen-image-edit": ModelConfig(
         priority=16,
-        aliases=["qwen-image-edit", "qwen-edit", "qwen-edit-plus", "qwen-edit-2509"],
-        model_name="Qwen/Qwen-Image-Edit-2509",
+        aliases=[
+            "qwen-image-edit",
+            "qwen-edit",
+            "qwen-edit-plus",
+            "qwen-edit-2509",
+            "qwen-edit-2511",
+            "qwen-image-edit-2511",
+        ],
+        model_name="Qwen/Qwen-Image-Edit-2511",
         base_model=None,
         controlnet_model=None,
         custom_transformer_model=None,

--- a/src/mflux/models/qwen/README.md
+++ b/src/mflux/models/qwen/README.md
@@ -158,12 +158,12 @@ image.save("qwen_food.png")
 </details>
 
 > [!WARNING]
-> Note: The Qwen Image model requires downloading the `Qwen/Qwen-Image` model weights (~58GB for the full model, or use quantization for smaller sizes).
+> Note: The Qwen Image model requires downloading the `Qwen/Qwen-Image-2512` model weights (~58GB for the full model, or use quantization for smaller sizes).
 
 ## Qwen Image Edit (natural language image editing)
 **Qwen Image Edit** enables precise natural language image editing, allowing you to modify images using text instructions while maintaining their original structure and context. The model uses a vision-language encoder to understand both the input image and your editing instructions.
 
-Qwen Image Edit supports natural language editing with descriptive text instructions, maintains original poses and body positions when requested, supports multiple images for complex compositions, and works seamlessly with LoRA adapters for specialized transformations like camera angles and styles. The model uses `Qwen/Qwen-Image-Edit-2509`.
+Qwen Image Edit supports natural language editing with descriptive text instructions, maintains original poses and body positions when requested, supports multiple images for complex compositions, and works seamlessly with LoRA adapters for specialized transformations like camera angles and styles. The model uses `Qwen/Qwen-Image-Edit-2511`.
 
 ![Qwen Image Edit Examples](../../assets/qwen_edit_example.jpg)
 *Examples showing dog replacement with two-image input and monkey camera angle transformations with LoRAs. Source images: [Golden Retriever](https://images.unsplash.com/photo-1552053831-71594a27632d), [Grey Dog](https://images.unsplash.com/photo-1566710582818-d673dc761201), and [Monkey](https://images.unsplash.com/photo-1578948610588-ffe24448f5ed).*
@@ -252,5 +252,5 @@ image.save("qwen_edit_monkey.png")
 7. **Image Quality**: Qwen images come out quite soft compared to Flux models
 
 > [!WARNING]
-> Note: The Qwen Image Edit model requires downloading the `Qwen/Qwen-Image-Edit-2509` model weights (~58GB for the full model, or use quantization for smaller sizes).
+> Note: The Qwen Image Edit model requires downloading the `Qwen/Qwen-Image-Edit-2511` model weights (~58GB for the full model, or use quantization for smaller sizes).
 


### PR DESCRIPTION
Update default Qwen model configurations to their latest HuggingFace releases:

- Qwen Image Edit: Qwen/Qwen-Image-Edit-2509 -> Qwen/Qwen-Image-Edit-2511
- Qwen Image (txt2img): Qwen/Qwen-Image -> Qwen/Qwen-Image-2512

Add version-specific aliases (`qwen-edit-2511`, `qwen-image-edit-2511`, `qwen-image-2512`, `qwen-2512`) while preserving backward-compatible aliases (`qwen-edit-2509` still resolves to the new default).

Update README documentation to reference the new model versions. LoRA references (`dx8152/Qwen-Edit-2509-Multiple-angles`) are kept unchanged as no 2511-compatible version exists from that author.

Closes #308