### PR TITLE
Propagate VAE tiling config for FLUX.2 edits

### DIFF
--- a/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
+++ b/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
@@ -181,7 +181,7 @@ class Flux2KleinEdit(nn.Module):
 
         # 6. Decode latents
         packed_latents = latents.reshape(latents.shape[0], latent_height, latent_width, latents.shape[-1]).transpose(0, 3, 1, 2)  # fmt: off
-        decoded = self.vae.decode_packed_latents(packed_latents)
+        decoded = self.vae.decode_packed_latents(packed_latents, tiling_config=self.tiling_config)
         return ImageUtil.to_image(
             decoded_latents=decoded,
             config=config,


### PR DESCRIPTION
## Summary

- Propagate `self.tiling_config` to the final VAE decode in `Flux2KleinEdit.generate_image`.

## Root cause

Reference image conditioning already passes `self.tiling_config` to VAE encoding. In low-memory mode this can produce tiled VAE latents, while the final generated latents were decoded without the same tiling configuration. Keeping encode and decode on the same tiling path avoids the reconstruction mismatch, which is particularly visible as desaturated output for JPEG reference images.

## Validation

- `make lint` (passed)
- Attempted `MFLUX_PRESERVE_TEST_OUTPUT=1 uv run --extra dev python -m pytest -m fast`; stopped because the initial MLX/PyTorch dependency download stalled before pytest began.
