### PR TITLE
Fix QwenVAE latent constants being pinned to the importing thread (breaks ComfyUI and Krea 2)

### DIFF
--- a/src/mflux/models/qwen/model/qwen_vae/qwen_vae.py
+++ b/src/mflux/models/qwen/model/qwen_vae/qwen_vae.py
@@ -1,4 +1,5 @@
 import mlx.core as mx
+import numpy as np
 from mlx import nn
 
 from mflux.models.qwen.model.qwen_vae.qwen_image_causal_conv_3d import QwenImageCausalConv3D
@@ -7,8 +8,8 @@ from mflux.models.qwen.model.qwen_vae.qwen_image_encoder_3d import QwenImageEnco
 
 
 class QwenVAE(nn.Module):
-    LATENTS_MEAN = mx.array([-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921]).reshape(1, 16, 1, 1, 1)  # fmt: off
-    LATENTS_STD = mx.array([2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916]).reshape(1, 16, 1, 1, 1)  # fmt: off
+    LATENTS_MEAN = np.array([-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921], dtype=np.float32)  # fmt: off
+    LATENTS_STD = np.array([2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916], dtype=np.float32)  # fmt: off
     spatial_scale = 8
     latent_channels = 16
 
@@ -22,7 +23,9 @@ class QwenVAE(nn.Module):
     def decode(self, latents: mx.array) -> mx.array:
         if len(latents.shape) == 4:
             latents = latents.reshape(latents.shape[0], latents.shape[1], 1, latents.shape[2], latents.shape[3])
-        latents = latents * QwenVAE.LATENTS_STD + QwenVAE.LATENTS_MEAN
+        latents_mean = mx.array(self.LATENTS_MEAN).reshape(1, self.latent_channels, 1, 1, 1)
+        latents_std = mx.array(self.LATENTS_STD).reshape(1, self.latent_channels, 1, 1, 1)
+        latents = latents * latents_std + latents_mean
         latents = self.post_quant_conv(latents)
         decoded = self.decoder(latents)
         return decoded
@@ -33,4 +36,6 @@ class QwenVAE(nn.Module):
         latents = self.encoder(latents)
         latents = self.quant_conv(latents)
         latents = latents[:, :16, :, :, :]
-        return (latents - QwenVAE.LATENTS_MEAN) / QwenVAE.LATENTS_STD
+        latents_mean = mx.array(self.LATENTS_MEAN).reshape(1, self.latent_channels, 1, 1, 1)
+        latents_std = mx.array(self.LATENTS_STD).reshape(1, self.latent_channels, 1, 1, 1)
+        return (latents - latents_mean) / latents_std


### PR DESCRIPTION
## Summary

`QwenVAE` declares its latent constants at class level as

```python
LATENTS_MEAN = mx.array([...]).reshape(1, 16, 1, 1, 1)
```

The trailing `.reshape()` records a primitive instead of evaluating, so the constants stay **lazy**.
MLX >= 0.31 keeps a Metal command encoder **per thread** and pins an unevaluated array to the stream
of the thread that recorded it, so evaluating it from a different thread raises

```
RuntimeError: There is no Stream(gpu, N) in current thread.
```

This makes the two models unusable in any host that imports mflux on one thread and generates on
another. ComfyUI is the concrete case: it imports custom nodes on the main thread and runs every node
on a single worker thread, so the first `mx.eval` downstream of a Qwen VAE encode/decode dies.

Since #453 merged, the blast radius is **two** models, not one: `krea2_initializer` sets
`model.vae = QwenVAE()`, so Krea 2 inherits the same crash path.

## The change follows an existing precedent in this repo

`fibo/model/fibo_vae/wan_2_2_vae.py` already does the right thing: it keeps `LATENTS_MEAN`/`LATENTS_STD`
as numpy at class level and builds the mx arrays inside `encode`/`decode`. This PR makes `QwenVAE`
match that, so the arrays are created on whichever thread does the work. It is not a new opinion about
style, just applying the pattern already used by the sibling VAE.

Diff is 9 insertions / 4 deletions in one file. The constants are only consumed inside `qwen_vae.py`,
so nothing else is affected.

## Values are unchanged

Not asserted, checked: `mx.array_equal` against the previous definition returns `True` for both
constants, still `float32`.

## Verification

- Reproduced the failure and confirmed the fix with a minimal script (import on the main thread, run
  the encode/decode arithmetic from a worker thread): raises the verbatim error before, passes after.
- End to end: with the equivalent fix applied, `qwen-image-edit` and a Krea 2 depth ControlNet run
  both render inside ComfyUI (70s and 76s) where both previously failed at the first `mx.eval`.

One caveat worth stating plainly: I could not run this repo's Qwen golden tests locally. `main` pins
`Qwen/Qwen-Image-Edit-2509`, which is not in my cache, and my `Qwen/Qwen-Image` snapshot is
incomplete, so both fail on weight loading before reaching any comparison. CI should exercise them.

Upstream MLX context: `ml-explore/mlx#3529` is open, and pre-evaluating (or constructing on the using
thread, as here) is the documented workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen VAE latent normalization and denormalization across supported latent channel configurations.
  * Enhanced consistency when encoding and decoding image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves QwenVAE latent constant materialization from import time to the thread executing encode or decode, avoiding thread-pinned lazy MLX arrays while preserving their values and arithmetic shape.
- Stores latent means and standard deviations as NumPy float32 class constants.
- Constructs and reshapes MLX arrays inside each encode and decode call.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the per-call conversion preserving the constants’ values, dtype, and broadcast shape.

The changed encode and decode paths construct thread-local MLX arrays from fixed float32 NumPy values and reshape them to the same 1×16×1×1×1 operands used previously, while repository callers do not consume the class constants directly.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/qwen/model/qwen_vae/qwen_vae.py | Replaces lazy class-level MLX constants with NumPy constants materialized per operation; no actionable regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(qwen): keep the VAE latent constants..."](https://github.com/mflux-community/mflux/commit/4c8629004b7c5325a44d1d11aa04ce45dd847929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896694)</sub>

<!-- /greptile_comment -->