### PR TITLE
perf(seedvr2): build inverse permutation in linear time

### DIFF
--- a/src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py
+++ b/src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py
@@ -230,6 +230,7 @@ class SeedVR2Util:
             ref = reference[i].reshape(-1).astype(np.float32)
             src_idx = np.argsort(src, kind="stable")
             ref_sorted = np.sort(ref, kind="stable")
-            inv = np.argsort(src_idx, kind="stable")
+            inv = np.empty_like(src_idx)
+            inv[src_idx] = np.arange(src_idx.size, dtype=src_idx.dtype)
             out[i] = ref_sorted[inv].reshape(source.shape[1:]).astype(np.float32)
         return out

--- a/tests/image_generation/test_seedvr2_util.py
+++ b/tests/image_generation/test_seedvr2_util.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core", exc_type=ImportError)
+
+from mflux.models.seedvr2.variants.upscale.seedvr2_util import SeedVR2Util
+
+
+@pytest.mark.fast
+def test_hist_match_matches_argsort_inverse_with_repeated_values():
+    source = np.array(
+        [
+            [[0.5, 0.1, 0.5], [0.3, 0.1, 0.9]],
+            [[0.2, 0.2, 0.8], [0.4, 0.6, 0.4]],
+        ],
+        dtype=np.float32,
+    )
+    reference = np.array(
+        [
+            [[0.9, 0.7, 0.6], [0.4, 0.3, 0.1]],
+            [[0.8, 0.7, 0.5], [0.3, 0.2, 0.1]],
+        ],
+        dtype=np.float32,
+    )
+
+    expected = np.empty_like(source, dtype=np.float32)
+    for index in range(source.shape[0]):
+        src = source[index].reshape(-1)
+        src_idx = np.argsort(src, kind="stable")
+        inverse = np.argsort(src_idx, kind="stable")
+        reference_sorted = np.sort(reference[index].reshape(-1), kind="stable")
+        expected[index] = reference_sorted[inverse].reshape(source.shape[1:])
+
+    actual = SeedVR2Util._hist_match(source, reference)
+
+    np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
## Summary

- replace the redundant inverse `argsort` in SeedVR2 histogram matching with a scatter-built inverse permutation
- add a regression test covering batched inputs with repeated source values

Fixes #470.

## Validation

- `ruff check src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py tests/image_generation/test_seedvr2_util.py`
- `ruff format --check src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py tests/image_generation/test_seedvr2_util.py`
- `python -m compileall -q src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py tests/image_generation/test_seedvr2_util.py`
- exact equivalence of the scatter inverse and the previous stable `argsort` inverse for 1, 2, 7, and 200,000 elements

The focused pytest test requires a usable MLX runtime. It is skipped in the Linux validation runner because no CUDA driver is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved histogram matching consistency for images containing repeated pixel values.
  * Ensured stable value ordering produces the expected upscale results.

* **Tests**
  * Added coverage validating histogram mapping with repeated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a redundant stable sort with a linear-time scatter operation when constructing SeedVR2's inverse histogram permutation.
- Builds the inverse permutation by assigning each sorted position its rank.
- Adds a repeated-value, batched regression test comparing the result with the previous implementation.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking limitation that its regression test does not run in the documented Linux validation environment.

The optimized scatter operation preserves the previous inverse-permutation semantics, while the only accepted concern is reduced automated coverage caused by gating a NumPy-only test on MLX availability.

**Files Needing Attention:** tests/image_generation/test_seedvr2_util.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/seedvr2/variants/upscale/seedvr2_util.py | The scatter assignment correctly constructs the inverse of the complete permutation returned by stable `argsort`. |
| tests/image_generation/test_seedvr2_util.py | The regression case checks exact equivalence, but its module-level MLX gate prevents it from running in the documented Linux validation environment. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/image_generation/test_seedvr2_util.py:4
**MLX gate suppresses regression coverage**

The module-level `mlx.core` gate skips this NumPy-only regression test in the documented Linux validation environment, so changes to the inverse-permutation behavior receive no automated coverage there.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Speed up SeedVR2 histogram matching"](https://github.com/mflux-community/mflux/commit/34b73f8d484bb01c077dafb76fdd315488fa6ecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896689)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->