### PR TITLE
fix: flux2 CLIs discard all image metadata

### DIFF
--- a/src/mflux/models/flux2/cli/flux2_edit_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_edit_generate.py
@@ -7,7 +7,6 @@ from mflux.models.flux2.latent_creator.flux2_latent_creator import Flux2LatentCr
 from mflux.models.flux2.variants import Flux2KleinEdit
 from mflux.utils.dimension_resolver import DimensionResolver
 from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationException
-from mflux.utils.image_util import ImageUtil
 from mflux.utils.prompt_util import PromptUtil
 
 
@@ -73,11 +72,7 @@ def main():
                 num_inference_steps=args.steps,
                 scheduler="flow_match_euler_discrete",
             )
-            ImageUtil.save_image(
-                image=image,
-                path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
-            )
+            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:

--- a/src/mflux/models/flux2/cli/flux2_generate.py
+++ b/src/mflux/models/flux2/cli/flux2_generate.py
@@ -5,7 +5,6 @@ from mflux.models.flux2.latent_creator.flux2_latent_creator import Flux2LatentCr
 from mflux.models.flux2.variants import Flux2Klein
 from mflux.utils.dimension_resolver import DimensionResolver
 from mflux.utils.exceptions import PromptFileReadError, StopImageGenerationException
-from mflux.utils.image_util import ImageUtil
 from mflux.utils.prompt_util import PromptUtil
 
 
@@ -65,11 +64,7 @@ def main():
                 image_strength=args.image_strength,
                 scheduler="flow_match_euler_discrete",
             )
-            ImageUtil.save_image(
-                image=image,
-                path=args.output.format(seed=seed),
-                export_json_metadata=args.metadata,
-            )
+            image.save(path=args.output.format(seed=seed), export_json_metadata=args.metadata)
     except (StopImageGenerationException, PromptFileReadError) as exc:
         print(exc)
     finally:


### PR DESCRIPTION
Both flux2 entry points call `ImageUtil.save_image(image:path:export_json_metadata:)` without passing `metadata=`. It defaults to `None`, so the `--metadata` sidecar is written as the literal `null`.

Every other CLI in the tree calls `image.save(path:export_json_metadata:)`, which routes through `GeneratedImage._get_metadata()`. flux2 is the only outlier — this just brings it in line.

Reproduce on `main`:

```
mflux-generate-flux2 --prompt "a puffin on a cliff" --steps 4 --metadata -o out.png
cat out.metadata.json      # -> null
```

After: the sidecar carries the usual model/seed/steps/guidance/dimensions/prompt.

Two files, +2/−12 (the `ImageUtil` import becomes unused in both). No behaviour change beyond the sidecar being written.

Noticed while reviewing #490 — flux2 was the one model where a `--pid-decode` run could not be recorded, but the bug predates that work and is not specific to it, so it's split out here rather than carried in a decoder PR.

---

**Correction to an earlier version of this description**, thanks to @azrahello: I originally wrote that no EXIF or XMP was embedded either. That is wrong. `save_image` is handed a `GeneratedImage` rather than a PIL image, so `image.save(file_path)` dispatches to `GeneratedImage.save`, which routes back through `_get_metadata()` and embeds correctly — the outer call then writes the `null` sidecar on top. Verified:

```
sidecar contents : null
embedded exif    : prompt, seed, steps, model, width, height, guidance, quantize, ...
```

So the sidecar is the broken half, not the whole of it. The impact is unchanged, since `--config-from-metadata` reads the sidecar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image saving for generated and edited outputs.
  - Preserved configured output paths and metadata options when saving images.
  - Removed an issue caused by reliance on an outdated image-saving method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes Flux2 metadata sidecar exports by routing generated images through `GeneratedImage.save`, which supplies the complete generated-image metadata.
- Updates the Flux2 text-to-image CLI to preserve metadata in requested JSON sidecars.
- Applies the same correction to the Flux2 edit CLI.
- Removes unused `ImageUtil` imports from both entry points.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both Flux2 entry points now following the established generated-image save contract.

The changed calls operate on `GeneratedImage` instances and preserve existing output-path and sidecar-naming behavior while supplying populated metadata instead of writing a null sidecar.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/models/flux2/cli/flux2_generate.py | Replaces the metadata-dropping utility call with the established `GeneratedImage.save` path; no actionable regression found. |
| src/mflux/models/flux2/cli/flux2_edit_generate.py | Applies the same correct save path to edited Flux2 images and removes the unused utility import. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: flux2 CLIs discarded all image meta..."](https://github.com/mflux-community/mflux/commit/6ca8808b25d170c48d4ab232bca2be7badc4b0d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896685)</sub>

<!-- /greptile_comment -->