### PR TITLE
Read lora metadata defensively in the stepwise handler

### DIFF
--- a/src/mflux/callbacks/instances/stepwise_handler.py
+++ b/src/mflux/callbacks/instances/stepwise_handler.py
@@ -97,8 +97,8 @@ class StepwiseHandler(BeforeLoopCallback, InLoopCallback, InterruptCallback):
             seed=seed,
             prompt=prompt,
             quantization=self.model.bits,
-            lora_paths=self.model.lora_paths,
-            lora_scales=self.model.lora_scales,
+            lora_paths=getattr(self.model, "lora_paths", None),
+            lora_scales=getattr(self.model, "lora_scales", None),
             generation_time=generation_time,
         )
         stepwise_img.save(

--- a/tests/callbacks/test_stepwise_handler_vae_routing.py
+++ b/tests/callbacks/test_stepwise_handler_vae_routing.py
@@ -102,3 +102,18 @@ def test_stepwise_vae_without_packed_decode_falls_back(tmp_path) -> None:
     handler.call_before_loop(seed=1, prompt="a", latents=latents, config=_config(ModelConfig.dev()))
 
     assert vae.calls == ["decode"]
+
+
+@pytest.mark.fast
+def test_stepwise_survives_models_without_lora_attributes(tmp_path) -> None:
+    # FIBO's initializer accepts lora_paths but never assigns it to the model, so the
+    # instance has no lora_paths/lora_scales attributes at all; the handler must read
+    # them defensively or the first preview step dies with AttributeError.
+    vae = RecordingPackedVAE()
+    model = SimpleNamespace(vae=vae, bits=None)
+    handler = StepwiseHandler(model=model, output_dir=str(tmp_path), latent_creator=Ideogram4LatentCreator)
+    latents = mx.zeros((1, (SIZE // 16) * (SIZE // 16), 128))
+
+    handler.call_before_loop(seed=1, prompt="a", latents=latents, config=_config(ModelConfig.ideogram4_fp8()))
+
+    assert (tmp_path / "seed_1_step0of1.png").exists()


### PR DESCRIPTION
`--stepwise-image-output-dir` dies with `AttributeError` on the first preview step for models that never gain a `lora_paths` attribute. FIBO is the reproducible case on current main: `Fibo.__init__` accepts `lora_paths` and passes it into `FiboInitializer.init`, whose `_init_config` assigns `model_config`, `callbacks` and `tiling_config` but never `lora_paths`, so the handler's unconditional `self.model.lora_paths` read raises.

The fix mirrors what we shipped in mflux-cv 0.18.28 after hitting exactly this crash: read both attributes with `getattr` and a `None` default. The new test extends the routing test file from #444 with the attribute-less model shape its existing stubs never covered; it fails on main with the `AttributeError` and passes here.

Side observation for the #498 inventory: FIBO's constructor `lora_paths` parameter is itself accepted and silently dropped, since the initializer never applies or stores it.

Test output, this branch on current main (M5 Max 40-core GPU, macOS 26.5, Python 3.12):

```
mlx 0.31.0: 514 passed, 83 deselected
mlx 0.32.0: 514 passed, 83 deselected
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents stepwise preview generation from crashing when a model does not define LoRA metadata attributes.
- Reads `lora_paths` and `lora_scales` defensively with `None` defaults.
- Adds a regression test covering an attribute-less model and successful preview output.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no blocking or non-blocking defects identified.

The defensive reads preserve existing metadata for models that define the attributes while safely supplying supported `None` values for models that do not.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mflux/callbacks/instances/stepwise_handler.py | Safely defaults absent LoRA metadata attributes to values already supported by the generated-image metadata contract. |
| tests/callbacks/test_stepwise_handler_vae_routing.py | Adds focused regression coverage proving stepwise output succeeds when both LoRA attributes are absent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Read lora metadata defensively in the st..."](https://github.com/mflux-community/mflux/commit/a533a9be0ae54e06f9d565125ca9af9a10113061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896680)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preview generation for models that do not define optional LoRA configuration settings.
  * Ensured stepwise processing continues successfully and produces the expected preview image in this scenario.

* **Tests**
  * Added regression coverage for models without LoRA path and scale settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->