### PR TITLE
fix: add @with_gpu_stream decorator for thread-safe GPU stream access

### DIFF
--- a/src/mflux/models/ernie_image/ernie_image_initializer.py
+++ b/src/mflux/models/ernie_image/ernie_image_initializer.py
@@ -13,10 +13,12 @@ from mflux.models.ernie_image.model.ernie_transformer.transformer import ErnieTr
 from mflux.models.ernie_image.weights.ernie_lora_mapping import ErnieLoRAMapping
 from mflux.models.ernie_image.weights.ernie_weight_definition import ErnieWeightDefinition
 from mflux.models.flux2.model.flux2_vae.vae import Flux2VAE
+from mflux.utils.gpu_stream import with_gpu_stream
 
 
 class ErnieImageInitializer:
     @staticmethod
+    @with_gpu_stream
     def init(
         model,
         model_config: ModelConfig,

--- a/src/mflux/models/ernie_image/variants/txt2img/ernie_image.py
+++ b/src/mflux/models/ernie_image/variants/txt2img/ernie_image.py
@@ -17,6 +17,7 @@ from mflux.models.ernie_image.weights.ernie_weight_definition import ErnieWeight
 from mflux.models.flux2.model.flux2_vae.vae import Flux2VAE
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class ErnieImage(nn.Module):
             lora_scales=lora_scales,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/fibo/variants/edit/fibo_edit.py
+++ b/src/mflux/models/fibo/variants/edit/fibo_edit.py
@@ -18,6 +18,7 @@ from mflux.models.fibo.variants.edit.util import FiboEditUtil
 from mflux.models.fibo.weights.fibo_weight_definition import FIBOWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -44,6 +45,7 @@ class FIBOEdit(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/fibo/variants/txt2img/fibo.py
+++ b/src/mflux/models/fibo/variants/txt2img/fibo.py
@@ -17,6 +17,7 @@ from mflux.models.fibo.model.fibo_vae.wan_2_2_vae import Wan2_2_VAE
 from mflux.models.fibo.weights.fibo_weight_definition import FIBOWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class FIBO(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/fibo_vlm/model/fibo_vlm.py
+++ b/src/mflux/models/fibo_vlm/model/fibo_vlm.py
@@ -10,6 +10,7 @@ from mflux.models.common_models.qwen3_vl.qwen3_vl_decoder import Qwen3VLDecoder
 from mflux.models.common_models.qwen3_vl.qwen3_vl_util import Qwen3VLUtil
 from mflux.models.fibo_vlm.fibo_vlm_initializer import FiboVLMInitializer
 from mflux.models.fibo_vlm.tokenizer.qwen2vl_processor import Qwen2VLProcessor
+from mflux.utils.gpu_stream import with_gpu_stream
 
 EDIT_SYSTEM_PROMPT = '''You are a highly skilled Creative Director for Visual Adaptation at a leading Generative AI company.
 
@@ -163,6 +164,7 @@ class FiboVLM:
     def processor(self) -> Qwen2VLProcessor:
         return self.tokenizers["fibo_vlm"].processor
 
+    @with_gpu_stream
     def generate(
         self,
         prompt: str,

--- a/src/mflux/models/flux/variants/concept_attention/flux_concept.py
+++ b/src/mflux/models/flux/variants/concept_attention/flux_concept.py
@@ -18,6 +18,7 @@ from mflux.models.flux.variants.concept_attention.concept_util import ConceptUti
 from mflux.models.flux.variants.concept_attention.transformer_concept import TransformerConcept
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -45,6 +46,7 @@ class Flux1Concept(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/concept_attention/flux_concept_from_image.py
+++ b/src/mflux/models/flux/variants/concept_attention/flux_concept_from_image.py
@@ -18,6 +18,7 @@ from mflux.models.flux.variants.concept_attention.concept_util import ConceptUti
 from mflux.models.flux.variants.concept_attention.transformer_concept import TransformerConcept
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -45,6 +46,7 @@ class Flux1ConceptFromImage(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/controlnet/flux_controlnet.py
+++ b/src/mflux/models/flux/variants/controlnet/flux_controlnet.py
@@ -17,6 +17,7 @@ from mflux.models.flux.variants.controlnet.transformer_controlnet import Transfo
 from mflux.models.flux.weights.flux_weight_definition import FluxControlnetWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil, StrOrBytesPath
 from mflux.utils.metadata_reader import MetadataReader
 
@@ -47,6 +48,7 @@ class Flux1Controlnet(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/depth/flux_depth.py
+++ b/src/mflux/models/flux/variants/depth/flux_depth.py
@@ -17,6 +17,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.depth.depth_util import DepthUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -45,6 +46,7 @@ class Flux1Depth(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/fill/flux_fill.py
+++ b/src/mflux/models/flux/variants/fill/flux_fill.py
@@ -16,6 +16,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.fill.mask_util import MaskUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class Flux1Fill(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/in_context/flux_in_context_dev.py
+++ b/src/mflux/models/flux/variants/in_context/flux_in_context_dev.py
@@ -16,6 +16,7 @@ from mflux.models.flux.model.flux_transformer.transformer import Transformer
 from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class Flux1InContextDev(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/in_context/flux_in_context_fill.py
+++ b/src/mflux/models/flux/variants/in_context/flux_in_context_fill.py
@@ -16,6 +16,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.in_context.utils.in_context_mask_util import InContextMaskUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class Flux1InContextFill(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/kontext/flux_kontext.py
+++ b/src/mflux/models/flux/variants/kontext/flux_kontext.py
@@ -16,6 +16,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.variants.kontext.kontext_util import KontextUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class Flux1Kontext(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/redux/flux_redux.py
+++ b/src/mflux/models/flux/variants/redux/flux_redux.py
@@ -19,6 +19,7 @@ from mflux.models.flux.model.siglip_vision_transformer.siglip_vision_transformer
 from mflux.models.flux.variants.redux.redux_util import ReduxUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -48,6 +49,7 @@ class Flux1Redux(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux/variants/txt2img/flux.py
+++ b/src/mflux/models/flux/variants/txt2img/flux.py
@@ -18,6 +18,7 @@ from mflux.models.flux.model.flux_vae.vae import VAE
 from mflux.models.flux.weights.flux_weight_definition import FluxWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -45,6 +46,7 @@ class Flux1(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
+++ b/src/mflux/models/flux2/variants/edit/flux2_klein_edit.py
@@ -14,6 +14,7 @@ from mflux.models.flux2.variants.edit.flux2_klein_edit_helpers import _Flux2Klei
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -40,6 +41,7 @@ class Flux2KleinEdit(nn.Module):
             model_config=model_config or ModelConfig.flux2_klein_4b(),
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/flux2/variants/txt2img/flux2_klein.py
+++ b/src/mflux/models/flux2/variants/txt2img/flux2_klein.py
@@ -18,6 +18,7 @@ from mflux.models.flux2.weights.flux2_weight_definition import Flux2KleinWeightD
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -44,6 +45,7 @@ class Flux2Klein(nn.Module):
             model_config=model_config or ModelConfig.flux2_klein_4b(),
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/ideogram4/ideogram4_initializer.py
+++ b/src/mflux/models/ideogram4/ideogram4_initializer.py
@@ -16,10 +16,12 @@ from mflux.models.flux2.model.flux2_vae.vae import Flux2VAE
 from mflux.models.ideogram4.model.ideogram4_text_encoder import Qwen3TextEncoder
 from mflux.models.ideogram4.model.ideogram4_transformer import Ideogram4Config, Ideogram4Transformer
 from mflux.models.ideogram4.weights import Ideogram4LoRAMapping, Ideogram4WeightDefinition
+from mflux.utils.gpu_stream import with_gpu_stream
 
 
 class Ideogram4Initializer:
     @staticmethod
+    @with_gpu_stream
     def init(
         model,
         model_config: ModelConfig,

--- a/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
+++ b/src/mflux/models/ideogram4/variants/txt2img/ideogram4.py
@@ -15,6 +15,7 @@ from mflux.models.ideogram4.weights import Ideogram4WeightDefinition
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -42,6 +43,7 @@ class Ideogram4(nn.Module):
             lora_scales=lora_scales,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/krea2/krea2_initializer.py
+++ b/src/mflux/models/krea2/krea2_initializer.py
@@ -13,10 +13,12 @@ from mflux.models.krea2.model.krea2_transformer.transformer import Krea2Transfor
 from mflux.models.krea2.weights.krea2_lora_mapping import Krea2LoRAMapping
 from mflux.models.krea2.weights.krea2_weight_definition import Krea2WeightDefinition
 from mflux.models.qwen.model.qwen_vae.qwen_vae import QwenVAE
+from mflux.utils.gpu_stream import with_gpu_stream
 
 
 class Krea2Initializer:
     @staticmethod
+    @with_gpu_stream
     def init(
         model,
         model_config: ModelConfig,

--- a/src/mflux/models/krea2/variants/txt2img/krea2.py
+++ b/src/mflux/models/krea2/variants/txt2img/krea2.py
@@ -18,6 +18,7 @@ from mflux.models.qwen.model.qwen_vae.qwen_vae import QwenVAE
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -44,6 +45,7 @@ class Krea2(nn.Module):
             lora_scales=lora_scales,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/qwen/variants/edit/qwen_image_edit.py
+++ b/src/mflux/models/qwen/variants/edit/qwen_image_edit.py
@@ -19,6 +19,7 @@ from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
 from mflux.models.qwen.weights.qwen_weight_definition import QwenWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -53,6 +54,7 @@ class QwenImageEdit(nn.Module):
             weight_definition=QwenWeightDefinition,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/qwen/variants/txt2img/qwen_image.py
+++ b/src/mflux/models/qwen/variants/txt2img/qwen_image.py
@@ -17,6 +17,7 @@ from mflux.models.qwen.qwen_initializer import QwenImageInitializer
 from mflux.models.qwen.weights.qwen_weight_definition import QwenWeightDefinition
 from mflux.utils.exceptions import StopImageGenerationException
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -43,6 +44,7 @@ class QwenImage(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/seedvr2/variants/upscale/seedvr2.py
+++ b/src/mflux/models/seedvr2/variants/upscale/seedvr2.py
@@ -13,6 +13,7 @@ from mflux.models.seedvr2.model.seedvr2_vae.vae import SeedVR2VAE
 from mflux.models.seedvr2.seedvr2_initializer import SeedVR2Initializer
 from mflux.models.seedvr2.variants.upscale.seedvr2_util import SeedVR2Util
 from mflux.utils.generated_image import GeneratedImage
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 from mflux.utils.metadata_reader import MetadataReader
 from mflux.utils.scale_factor import ScaleFactor
@@ -36,6 +37,7 @@ class SeedVR2(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/models/z_image/variants/z_image.py
+++ b/src/mflux/models/z_image/variants/z_image.py
@@ -18,6 +18,7 @@ from mflux.models.z_image.weights.z_image_weight_definition import ZImageWeightD
 from mflux.models.z_image.z_image_initializer import ZImageInitializer
 from mflux.utils.apple_silicon import AppleSiliconUtil
 from mflux.utils.exceptions import StopImageGenerationException
+from mflux.utils.gpu_stream import with_gpu_stream
 from mflux.utils.image_util import ImageUtil
 
 
@@ -44,6 +45,7 @@ class ZImage(nn.Module):
             model_config=model_config,
         )
 
+    @with_gpu_stream
     def generate_image(
         self,
         seed: int,

--- a/src/mflux/utils/gpu_stream.py
+++ b/src/mflux/utils/gpu_stream.py
@@ -1,0 +1,21 @@
+import functools
+import logging
+import threading
+
+import mlx.core as mx
+
+log = logging.getLogger(__name__)
+
+_main_thread_id = threading.main_thread().ident
+
+
+def with_gpu_stream(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if threading.current_thread().ident == _main_thread_id:
+            return fn(*args, **kwargs)
+        stream = mx.new_stream(mx.gpu)
+        with mx.stream(stream):
+            return fn(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## Summary

Fixes #502

When `generate_image()` or model initialization runs in a worker thread (e.g., from ComfyUI, web APIs, or `concurrent.futures.ThreadPoolExecutor`), MLX raises:

```
RuntimeError: There is no Stream(gpu, 4) in current thread
```

This happens because MLX GPU streams are thread-local — the default stream only exists on the main thread. mflux has 39 `mx.eval()` calls but zero thread-safety code.

## Fix

Added `@with_gpu_stream` decorator in `mflux/utils/gpu_stream.py` that:
- **On the main thread**: no-op, uses the existing default stream (zero overhead)
- **On worker threads**: creates a new GPU stream via `mx.new_stream(mx.gpu)` and wraps the function call in `mx.stream(stream)`

Applied to:
- All 21 `generate_image()` methods across model variants
- 3 initializer classes with `mx.eval(model)` (Krea2, Ideogram4, ErnieImage)
- `FiboVLM.generate()` method

## Testing

- 507 fast tests pass (no regressions)
- Functional test verified: `@with_gpu_stream` correctly creates GPU streams in `ThreadPoolExecutor` workers
- Without the decorator, complex model inference (multi-step denoising with compiled kernels) crashes in worker threads

## Reproduction (before fix)

```python
from concurrent.futures import ThreadPoolExecutor
from mflux import Flux1

model = Flux1.from_name("flux-schnell")

# This works:
model.generate_image(seed=42, prompt="a cat", num_inference_steps=4)

# This crashes with RuntimeError:
with ThreadPoolExecutor(max_workers=1) as ex:
    ex.submit(model.generate_image, seed=42, prompt="a cat", num_inference_steps=4).result()
```

After this fix, both cases work correctly.