### PR TITLE
Exclude slow tests from the default pytest run

### DIFF
--- a/.cursor/skills/mflux-testing/SKILL.md
+++ b/.cursor/skills/mflux-testing/SKILL.md
@@ -16,7 +16,8 @@ This repo uses pytest with image-producing tests. Always preserve outputs for in
 - Prefer the Makefile test targets:
   - `make test-fast` (fast tests, no image generation)
   - `make test-slow` (slow tests, image generation)
-  - `make test` (full suite)
+  - `make test` (default selection, skips slow model tests)
+  - `make test-all` (full suite, slow tests download model weights)
 - Always keep `MFLUX_PRESERVE_TEST_OUTPUT=1` on test runs (already built into the Makefile test targets).
 - If a change affects defaults, config resolution, metadata fields, or CLI behavior, add or update tests that cover the changed behavior directly instead of relying only on manual verification.
 - If tests fail:

--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,21 @@ check: ensure-ruff
 	# 🏗️ Running pre-commit linter and formatters on files...
 	@(pre-commit run --all-files)
 
-# Run tests
+# Run the default test selection (excludes slow model tests, see addopts in pyproject.toml)
 .PHONY: test
 test: ensure-pytest
 	# 🏗️ Running tests...
 	uv pip install -e '.[dev]' # Install pinned MLX version specifically for testing
 	MFLUX_PRESERVE_TEST_OUTPUT=1 uv run python -m pytest
 	# ✅ Tests completed
+
+# Run the whole suite, slow tests included (downloads model weights)
+.PHONY: test-all
+test-all: ensure-pytest
+	# 🏗️ Running all tests (slow tests download model weights)...
+	uv pip install -e '.[dev]' # Install pinned MLX version specifically for testing
+	MFLUX_PRESERVE_TEST_OUTPUT=1 uv run python -m pytest -m "not high_memory_requirement"
+	# ✅ All tests completed
 
 # Run fast tests only (no image generation)
 .PHONY: test-fast
@@ -145,7 +153,8 @@ help:
 	@echo "  make lint        - Run ruff python linter"
 	@echo "  make format      - Run ruff code formatter"
 	@echo "  make check       - Run linters auto fixes *and* style formatter via pre-commit hook"
-	@echo "  make test        - Run all tests"
+	@echo "  make test        - Run the default test selection (skips slow model tests)"
+	@echo "  make test-all    - Run the whole suite, slow tests included (downloads weights)"
 	@echo "  make test-fast   - Run fast tests only (no image generation)"
 	@echo "  make test-slow   - Run slow tests only (image generation)"
 	@echo "  make build       - Build distribution packages and check sizes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ docstring-code-line-length = "dynamic"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
-addopts = '-v --failed-first --showlocals --tb=long --full-trace -m "not high_memory_requirement"'
+addopts = '-v --failed-first --showlocals --tb=long --full-trace -m "not slow and not high_memory_requirement"'
 filterwarnings = [
     "ignore::DeprecationWarning:transformers\\.models\\.clip\\.tokenization_clip",
     "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",

--- a/tests/lora/test_lokr_integration.py
+++ b/tests/lora/test_lokr_integration.py
@@ -48,7 +48,7 @@ class _Flux1Transformer(nn.Module):
         self.single_transformer_blocks = [_Flux1Block()]
 
 
-@pytest.mark.slow
+@pytest.mark.fast
 def test_flux2_klein_lokr_safetensors_apply_layers(tmp_path):
     lora_path = tmp_path / "klein_lycoris_lokr.safetensors"
     mx.save_safetensors(
@@ -122,7 +122,7 @@ def test_flux2_klein_lokr_load_skips_bake_when_disabled(tmp_path):
     assert isinstance(transformer.single_transformer_blocks[0].attn.to_qkv_mlp_proj, LoKrLinear)
 
 
-@pytest.mark.slow
+@pytest.mark.fast
 def test_flux1_lycoris_lokr_safetensors_apply_layers(tmp_path):
     lora_path = tmp_path / "flux1_lycoris_lokr.safetensors"
     mx.save_safetensors(


### PR DESCRIPTION
Running plain `pytest` on a fresh clone starts downloading full model checkpoints. The default addopts only filters `high_memory_requirement`, and every test that instantiates a model is marked `slow`, so they all run: the ernie model_saving test alone pulls ~12GB before the suite gets anywhere. I hit this on a nearly full disk this week, and the offline failure @plz12345 ran into while reviewing #440 (test_metadata_complete trying to fetch Z-Image-Turbo) is the same root cause.

This adds `not slow` to the default marker filter. The unmarked utility tests keep running, so the default remains a superset of what CI checks (tests.yml passes `-m fast` explicitly and is unaffected). With this change a bare `pytest` completes offline: 549 passed in under 2 seconds, zero downloads. The slow and golden suites stay available as an explicit opt-in via `-m slow`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes bare pytest and `make test` skip slow model tests while preserving explicit full, fast, and slow suite targets.
- Adds `not slow` to pytest’s default marker expression.
- Adds `make test-all` to run slow tests explicitly while retaining the high-memory exclusion.
- Reclassifies two lightweight, synthetic LoKr integration tests as fast.
- Updates testing guidance and Makefile help text to document the new behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the updated targets and markers consistently implementing the documented test-selection behavior.

The default invocation excludes slow tests as intended, explicit marker arguments preserve the existing fast and slow workflows, `test-all` restores the eligible full suite, and the newly fast LoKr tests do not access models or the network.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Updates the default pytest marker selection to exclude slow and high-memory tests; explicit command-line marker selections continue to override this default. |
| Makefile | Changes `make test` documentation to describe the default subset and adds a functional `test-all` target that explicitly includes slow tests. |
| tests/lora/test_lokr_integration.py | Reclassifies two genuinely lightweight tests that use small synthetic local tensors from slow to fast. |
| .cursor/skills/mflux-testing/SKILL.md | Aligns repository testing guidance with the new default selection and explicit full-suite target. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remark the weight-free LoKr apply\_layers..."](https://github.com/mflux-community/mflux/commit/70422b3c6f85d2453b1ba3e68e25971a5eab425f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51896669)</sub>

<!-- /greptile_comment -->