### PR TITLE
Add CodeRabbit and Greptile configs, and the Greptile OSS badge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    # Skip binaries, generated images, and golden reference outputs.
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.webp"
+    - "!**/*.safetensors"
+    - "!src/mflux/assets/**"
+    - "!**/reference/**"
+    - "!**/references/**"
+  path_instructions:
+    - path: "src/mflux/**"
+      instructions: >
+        MLX (Apple Silicon) code. Flag mx.array shape/dtype mismatches, missing mx.eval before
+        host reads, and quantization correctness (fp8 / stored quantization). Prefer explicit,
+        minimal changes that match the surrounding style.
+chat:
+  auto_reply: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pyc
 *.safetensors
 *.json
+!greptile.json
 !src/mflux/models/common/training/_example/train.json
 !src/mflux/models/common/training/_example/train_ernie_image_turbo.json
 !src/mflux/models/common/training/_example/train_ernie_image.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![MFLUX](https://img.shields.io/pypi/v/mflux?label=MFLUX&logo=pypi&logoColor=white)](https://pypi.org/project/mflux/)
 [![MLX](https://img.shields.io/pypi/v/mlx?label=MLX&logo=pypi&logoColor=white)](https://pypi.org/project/mlx/)
 [![CI](https://github.com/filipstrand/mflux/actions/workflows/tests.yml/badge.svg)](https://github.com/filipstrand/mflux/actions/workflows/tests.yml)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 ### About
 

--- a/greptile.json
+++ b/greptile.json
@@ -1,9 +1,17 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax"],
+  "commentTypes": [
+    "logic",
+    "syntax"
+  ],
   "instructions": "MLX (Apple Silicon) codebase. Prioritize mx.array shape/dtype mismatches, quantization correctness (fp8 and group quantization), missing mx.eval before host reads, and cross-file drift between model families. Do not comment on style.",
   "ignorePatterns": "**/*.png\n**/*.jpg\n**/*.jpeg\n**/*.webp\n**/*.safetensors\n**/reference/**\n**/references/**\nsrc/mflux/assets/**",
   "triggerOnDrafts": false,
-  "excludeAuthors": ["dependabot[bot]"],
-  "statusCheck": true
+  "excludeAuthors": [
+    "dependabot[bot]"
+  ],
+  "statusCheck": true,
+  "includeBranches": [
+    "main"
+  ]
 }

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,9 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "instructions": "MLX (Apple Silicon) codebase. Prioritize mx.array shape/dtype mismatches, quantization correctness (fp8 and group quantization), missing mx.eval before host reads, and cross-file drift between model families. Do not comment on style.",
+  "ignorePatterns": "**/*.png\n**/*.jpg\n**/*.jpeg\n**/*.webp\n**/*.safetensors\n**/reference/**\n**/references/**\nsrc/mflux/assets/**",
+  "triggerOnDrafts": false,
+  "excludeAuthors": ["dependabot[bot]"],
+  "statusCheck": true
+}


### PR DESCRIPTION
Follow-up to the automated-review note in #513: both apps are now installed on the org, this wires their configs. Tuned for low noise to start: CodeRabbit on the chill profile with golden/asset paths filtered and MLX-specific review instructions, Greptile limited to logic and syntax comments with the same focus and drafts excluded. The README badge is part of Greptile's open source plan. Also adds a gitignore exception, the root `*.json` rule was swallowing `greptile.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Greptile badge to the project README.

* **Chores**
  * Added automated code review configuration and review preferences.
  * Added repository analysis settings, including file exclusions and review priorities.
  * Ensured the repository analysis configuration is tracked by version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR configures CodeRabbit and Greptile for low-noise automated reviews, ensures the Greptile configuration is tracked, and adds the Greptile OSS badge.
- Adds CodeRabbit review settings, path filters, and MLX-specific instructions.
- Adds matching Greptile review priorities and exclusions.
- Exempts `greptile.json` from the repository-wide JSON ignore rule.
- Adds the Greptile badge to the README.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .coderabbit.yaml | Adds automated CodeRabbit review configuration with draft, branch, asset, and generated-output filtering. |
| greptile.json | Adds Greptile review settings focused on logic, syntax, and MLX-specific correctness. |
| .gitignore | Ensures the new root-level Greptile configuration is tracked despite the existing JSON ignore pattern. |
| README.md | Adds the Greptile open-source program badge. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Scope Greptile reviews to PRs targeting ..."](https://github.com/mflux-community/mflux/commit/64fb77072778db8ab56115f563a69f23420b31ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51899442)</sub>

<!-- /greptile_comment -->